### PR TITLE
feat: ConfigMap drift detection and AnsibleReady condition (#16, #17)

### DIFF
--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -1,0 +1,67 @@
+name: PR Image Build
+
+# Builds an amd64 operator image on PR to validate the Dockerfile and
+# provide a deployable preview image for testing on OCP clusters.
+# Image is tagged as: quay.io/kubernaut-ai/kubernaut-operator:pr-<number>
+#
+# Prerequisites:
+#   - Quay.io robot account secrets: QUAY_ROBOT_USERNAME, QUAY_ROBOT_TOKEN
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+env:
+  IMAGE_REGISTRY: quay.io/kubernaut-ai
+  IMAGE_NAME: kubernaut-operator
+
+jobs:
+  build-image:
+    name: Build & Push PR Image (amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Login to Quay.io
+        run: |
+          podman login -u "${{ secrets.QUAY_ROBOT_USERNAME }}" \
+                       -p "${{ secrets.QUAY_ROBOT_TOKEN }}" \
+                       quay.io
+
+      - name: Build image
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GIT_COMMIT: ${{ github.event.pull_request.head.sha }}
+        run: |
+          IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
+          VERSION="pr-${PR_NUMBER}"
+          echo "Building ${IMAGE} (commit: ${GIT_COMMIT:0:8})..."
+          podman build \
+            --platform linux/amd64 \
+            --build-arg TARGETOS=linux \
+            --build-arg TARGETARCH=amd64 \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg GIT_COMMIT="${GIT_COMMIT}" \
+            -t "${IMAGE}" .
+
+      - name: Push image
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
+          echo "Pushing ${IMAGE}..."
+          podman push "${IMAGE}"
+          echo ""
+          echo "## Preview image ready" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${IMAGE}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Deploy with:" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "make deploy IMG=${IMAGE}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/api/v1alpha1/kubernaut_types.go
+++ b/api/v1alpha1/kubernaut_types.go
@@ -532,6 +532,7 @@ const (
 	ConditionWebhooksConfigured ConditionType = "WebhooksConfigured"
 	ConditionServicesDeployed   ConditionType = "ServicesDeployed"
 	ConditionRouteReady         ConditionType = "RouteReady"
+	ConditionAnsibleReady       ConditionType = "AnsibleReady"
 )
 
 // Finalizer used for cluster-scoped resource cleanup.

--- a/docs/test/16-17/test-plan.md
+++ b/docs/test/16-17/test-plan.md
@@ -1,0 +1,347 @@
+# ConfigMap Drift Detection & AnsibleReady Condition Test Plan
+
+**IEEE 829-2008 compliant**
+
+| Field | Value |
+|-------|-------|
+| Test Plan Identifier | KO-TP-002 |
+| Version | 1.0 |
+| Date | 2026-04-27 |
+| Author | Jordi Gil |
+| Status | Draft |
+| Related Issues | #16 (ConfigMap data corruption), #17 (AAP/Ansible validation) |
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document defines the test strategy, scope, approach, and acceptance criteria
+for verifying two related features:
+
+1. **ConfigMap drift detection** (issue #16): `ensureResource` must detect and
+   correct external modifications to operator-managed ConfigMap data, even when
+   the `kubernaut.ai/spec-hash` annotation is not modified by the external actor.
+
+2. **AnsibleReady status condition** (issue #17): The operator must validate
+   AAP/Ansible configuration (token Secret existence and key presence) and expose
+   the result via a non-blocking `AnsibleReady` status condition on the Kubernaut CR.
+
+### 1.2 Scope
+
+| In Scope | Out of Scope |
+|----------|--------------|
+| `contentDrifted` function correctness | HTTP reachability checks to AAP controller |
+| `ensureResource` dual-check (annotation + content) | AAP license validation |
+| `AnsibleReady` condition lifecycle (all states) | Dedicated Secret watch (deferred per H1) |
+| Non-blocking phase behavior (AnsibleReady does not gate Running) | OLM bundle regeneration |
+| OCP service-CA ConfigMap safety (no false positives) | E2E tests on live OCP cluster |
+| Event emission on Ansible config changes | Changes to the WFE service binary |
+
+### 1.3 References
+
+- IEEE 829-2008, Standard for Software and System Test Documentation
+- [100 Go Mistakes and How to Avoid Them](https://100go.co/) (refactor checklist)
+- Issue #16: `ensureResource` spec-hash check does not detect ConfigMap data corruption
+- Issue #17: Operator should validate AAP/Ansible reachability and expose readiness
+- KO-TP-001: Kubernaut Operator Test Plan (existing, `docs/test-plans/`)
+- controller-runtime envtest documentation
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|-----------|
+| CR | Custom Resource (instance of `Kubernaut` CRD) |
+| CM | ConfigMap |
+| WFE | Workflow Execution (service component) |
+| AAP | Ansible Automation Platform |
+| BYO | Bring Your Own (user-provided secrets) |
+| envtest | controller-runtime test harness with embedded etcd + API server |
+| spec-hash | `kubernaut.ai/spec-hash` annotation for reconcile optimization |
+| TDD | Test-Driven Development (Red-Green-Refactor cycle) |
+
+---
+
+## 2. Test Items
+
+### 2.1 Software Under Test
+
+| Component | File(s) | Version |
+|-----------|---------|---------|
+| `contentDrifted` function | `internal/controller/kubernaut_controller.go` | New |
+| `ensureResource` (modified) | `internal/controller/kubernaut_controller.go` | Modified |
+| `validateAnsibleConfig` method | `internal/controller/kubernaut_controller.go` | New |
+| `phaseRunning` (modified) | `internal/controller/kubernaut_controller.go` | Modified |
+| `ConditionAnsibleReady` constant | `api/v1alpha1/kubernaut_types.go` | New |
+| Reason constants | `internal/controller/kubernaut_controller.go` | New |
+
+### 2.2 Unchanged Dependencies (not retested)
+
+- `SpecHash`, `ConfigMapDataHash` (`internal/resources/hash.go`)
+- `WorkflowExecutionConfigMap` (`internal/resources/configmaps.go`)
+- `validateSecret` helper (existing)
+- envtest infrastructure (`internal/controller/suite_test.go`)
+
+---
+
+## 3. Features to be Tested
+
+### 3.1 Tier 1 — ConfigMap Drift Detection (Issue #16)
+
+| ID | Feature | Business Acceptance Criterion |
+|----|---------|-------------------------------|
+| D1 | Annotation-preserved data tampering | When an external actor modifies a ConfigMap's Data but preserves the spec-hash annotation, the next reconcile MUST restore the desired data. |
+| D2 | OCP service-CA ConfigMap safety | ConfigMaps with `service.beta.openshift.io/inject-cabundle` annotation and empty operator-managed Data MUST NOT trigger false positive drift detection. |
+| D3 | Key deletion detection | When an external actor deletes a desired key from a ConfigMap, the next reconcile MUST restore it. |
+| D4 | No-op when no drift | When a ConfigMap's Data matches the desired state and the annotation matches, `ensureResource` MUST NOT issue an Update (ResourceVersion unchanged). |
+| D5 | Non-ConfigMap types unaffected | `contentDrifted` MUST return `false` for Deployments, Services, and other non-ConfigMap types. |
+| D6 | Nil Data safety | `contentDrifted` MUST NOT panic when existing ConfigMap has nil Data. |
+| D7 | BinaryData comparison | `contentDrifted` MUST also compare BinaryData keys (future-proofing). |
+
+### 3.2 Tier 2 — AnsibleReady Condition (Issue #17)
+
+| ID | Feature | Business Acceptance Criterion |
+|----|---------|-------------------------------|
+| A1 | Disabled state | When `spec.ansible.enabled=false`, the `AnsibleReady` condition MUST be `True` with reason `Disabled`. |
+| A2 | Valid configuration | When `spec.ansible.enabled=true` with a valid token Secret, the condition MUST be `True` with reason `Ready`. |
+| A3 | Missing Secret | When `spec.ansible.enabled=true` and the referenced Secret does not exist, the condition MUST be `False` with reason `TokenSecretNotFound`. |
+| A4 | Missing key in Secret | When the Secret exists but lacks the expected key, the condition MUST be `False` with reason `TokenKeyMissing`. |
+| A5 | Nil tokenSecretRef | When `spec.ansible.enabled=true` but `tokenSecretRef` is nil, the condition MUST be `False` with reason `TokenSecretNotFound`. |
+| A6 | Recovery | Creating the token Secret after initial failure MUST flip the condition to `True` on the next reconcile. |
+| A7 | Non-blocking phase | The CR MUST reach `PhaseRunning` even when `AnsibleReady=False`. |
+| A8 | Event emission | Ansible config status transitions MUST emit a Kubernetes event. |
+
+---
+
+## 4. Features Not to be Tested
+
+| Feature | Rationale |
+|---------|-----------|
+| HTTP reachability to AAP controller | Deferred to follow-up issue; transient AAP downtime should not flip condition |
+| Dedicated Secret watch | Dropped per adversarial review H1 (cluster-wide blast radius); rely on 60s requeueRunning |
+| AAP license/subscription validation | Requires HTTP client; out of scope for config validation |
+| OLM bundle validation | Separate CI pipeline concern |
+
+---
+
+## 5. Approach
+
+### 5.1 Test Framework
+
+- **Unit tests**: Go standard `testing` package for `contentDrifted`, `validateAnsibleConfig`
+- **Integration tests**: Ginkgo/Gomega + envtest for full reconcile-loop behavior
+- **Event assertions**: `events.FakeRecorder` channel drain pattern (established in codebase)
+
+### 5.2 TDD Methodology
+
+Each feature tier follows strict Red-Green-Refactor cycles. Each phase is a
+single implementation commit for traceability.
+
+### 5.3 Coverage Target
+
+Minimum 80% of testable new/modified code per tier, measured by `go test -coverprofile`.
+
+### 5.4 Go Anti-Pattern Avoidance
+
+Tests MUST NOT exhibit these common Go test anti-patterns:
+- **Shared mutable state between tests** (each `It` block creates its own CR and resources)
+- **Testing implementation not behavior** (assert observable outputs: conditions, events, ResourceVersion)
+- **Flaky timing dependencies** (no `time.Sleep`; use `Eventually`/`Consistently` or direct reconcile calls)
+- **Ignoring cleanup** (use `AfterEach` with `cleanupResources`)
+- **Over-mocking** (prefer envtest real API server over hand-rolled fakes for CRUD)
+- **Missing error assertions** (every `Expect(err)` must have `.NotTo(HaveOccurred())` or `.To(HaveOccurred())`)
+
+---
+
+## 6. Item Pass/Fail Criteria
+
+### 6.1 Pass Criteria
+
+- All tests in Tier 1 and Tier 2 pass (`go test ./internal/...`)
+- `golangci-lint` reports 0 new issues
+- Coverage of new code >= 80% per tier
+- TDD Refactor phase checklist (section 10) completed with no findings
+
+### 6.2 Fail Criteria
+
+- Any Tier 1 or Tier 2 test fails
+- `contentDrifted` causes false positive drift on OCP-injected ConfigMaps (D2)
+- `AnsibleReady=False` blocks CR from reaching `PhaseRunning` (A7)
+- Regression in existing 65 tests
+
+---
+
+## 7. Suspension Criteria and Resumption Requirements
+
+| Suspension Trigger | Resumption Requirement |
+|--------------------|------------------------|
+| envtest infrastructure broken (etcd/API server won't start) | Fix suite_test.go or upgrade controller-runtime |
+| Upstream controller-runtime regression | Pin to last-known-good version |
+| CRD schema change blocks CR creation in tests | Regenerate CRD manifests |
+
+---
+
+## 8. Test Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| This test plan | `docs/test/16-17/test-plan.md` |
+| Unit tests for `contentDrifted` | `internal/controller/kubernaut_controller_test.go` |
+| Integration tests for drift detection | `internal/controller/kubernaut_lifecycle_test.go` |
+| Integration tests for AnsibleReady | `internal/controller/kubernaut_lifecycle_test.go` |
+| Coverage report | `cover.out` (generated by `make test`) |
+
+---
+
+## 9. Testing Tasks — TDD Phases
+
+### Phase 1: TDD Red — ConfigMap Drift Detection
+
+Write failing tests BEFORE any production code changes.
+
+| Test ID | Test Case | Expected Failure Reason |
+|---------|-----------|------------------------|
+| D1-R | `contentDrifted` returns true when desired key has different value in live CM | Function does not exist yet |
+| D2-R | `contentDrifted` returns false for CM with empty desired Data (OCP inject-cabundle) | Function does not exist yet |
+| D3-R | `contentDrifted` returns true when desired key is absent from live CM | Function does not exist yet |
+| D4-R | `ensureResource` skips update when annotation and content match | Passes (existing behavior) — serves as regression guard |
+| D5-R | `contentDrifted` returns false for Deployment type | Function does not exist yet |
+| D6-R | `contentDrifted` returns false when live CM Data is nil but desired Data is empty | Function does not exist yet |
+| D7-R | `contentDrifted` returns true when desired BinaryData key differs in live CM | Function does not exist yet |
+| D1-I | Integration: reconcile restores CM data after annotation-preserved tampering | `ensureResource` skips update (current bug) |
+
+**Files**: `internal/controller/kubernaut_controller_test.go`, `internal/controller/kubernaut_lifecycle_test.go`
+
+### Phase 2: TDD Green — ConfigMap Drift Detection
+
+Implement the minimum code to make all Phase 1 tests pass.
+
+| Implementation Step | File |
+|---------------------|------|
+| Add `contentDrifted` function with ConfigMap type switch | `internal/controller/kubernaut_controller.go` |
+| Use comma-ok assertion for type safety (L1 fix) | `internal/controller/kubernaut_controller.go` |
+| Add BinaryData comparison loop (L2 fix) | `internal/controller/kubernaut_controller.go` |
+| Update `ensureResource`: call `contentDrifted` when annotation matches | `internal/controller/kubernaut_controller.go` |
+
+### Phase 3: TDD Refactor — ConfigMap Drift Detection
+
+Validate production code against the 100 Go Mistakes checklist (relevant subset):
+
+| Mistake # | Check | Status |
+|-----------|-------|--------|
+| #1 | No unintended variable shadowing in `contentDrifted` | |
+| #2 | Happy path left-aligned; early returns for non-CM types | |
+| #5 | No unnecessary interface; `contentDrifted` takes concrete `client.Object` | |
+| #15 | Exported/new functions have godoc comments | |
+| #21 | Slice initialization with known capacity (BinaryData keys) | |
+| #22 | Nil vs empty slice handling in Data/BinaryData maps | |
+| #30 | Range loop values are copies — OK for map iteration (read-only) | |
+| #48 | No ignored errors from `bytes.Equal` or map lookups | |
+| #53 | No goroutines in `contentDrifted` (synchronous, no concurrency needed) | |
+| #78 | No `reflect.DeepEqual` when direct comparison suffices | |
+
+### Phase 4: TDD Red — AnsibleReady Condition
+
+Write failing tests BEFORE any production code changes.
+
+| Test ID | Test Case | Expected Failure Reason |
+|---------|-----------|------------------------|
+| A1-R | CR with `ansible.enabled=false` has `AnsibleReady=True/Disabled` after reconcile | Condition type doesn't exist |
+| A2-R | CR with valid ansible Secret has `AnsibleReady=True/Ready` after reconcile | Condition type doesn't exist |
+| A3-R | CR with missing ansible Secret has `AnsibleReady=False/TokenSecretNotFound` | Condition type doesn't exist |
+| A4-R | CR with Secret missing key has `AnsibleReady=False/TokenKeyMissing` | Condition type doesn't exist |
+| A5-R | CR with `tokenSecretRef=nil` has `AnsibleReady=False/TokenSecretNotFound` | Condition type doesn't exist |
+| A6-R | Creating Secret after failure flips condition on re-reconcile | Condition type doesn't exist |
+| A7-R | CR reaches `PhaseRunning` when `AnsibleReady=False` | Condition type doesn't exist |
+| A8-R | `AnsibleConfigInvalid` event emitted when Secret missing | No event emission logic |
+
+**Files**: `internal/controller/kubernaut_lifecycle_test.go`
+
+### Phase 5: TDD Green — AnsibleReady Condition
+
+Implement the minimum code to make all Phase 4 tests pass.
+
+| Implementation Step | File |
+|---------------------|------|
+| Add `ConditionAnsibleReady` constant | `api/v1alpha1/kubernaut_types.go` |
+| Add reason constants (`Disabled`, `Ready`, `TokenSecretNotFound`, `TokenKeyMissing`) | `internal/controller/kubernaut_controller.go` |
+| Implement `validateAnsibleConfig` returning `metav1.Condition` | `internal/controller/kubernaut_controller.go` |
+| Integrate into `phaseRunning` `patchStatus` closure (non-blocking, single writer per M3) | `internal/controller/kubernaut_controller.go` |
+| Emit events on Ansible config status transitions | `internal/controller/kubernaut_controller.go` |
+
+### Phase 6: TDD Refactor — AnsibleReady Condition
+
+Validate production code against the 100 Go Mistakes checklist (relevant subset):
+
+| Mistake # | Check | Status |
+|-----------|-------|--------|
+| #1 | No variable shadowing in `validateAnsibleConfig` | |
+| #2 | Happy path left-aligned; early return for disabled case | |
+| #5 | No unnecessary interface for validation; direct method on reconciler | |
+| #6 | No interface on producer side for condition builder | |
+| #10 | No type embedding that leaks internal fields | |
+| #15 | All exported constants and methods have godoc | |
+| #48 | `r.Get` error checked; `secret.Data[key]` nil-safe | |
+| #49 | Error wrapping uses `%w` for sentinel-compatible errors | |
+| #53 | No goroutines; validation is synchronous in reconcile loop | |
+| #54 | No race conditions; single writer for AnsibleReady (phaseRunning only) | |
+| #73 | No misuse of `time` package (no time-dependent logic in validation) | |
+| #78 | No `reflect.DeepEqual` for condition comparison; use `meta.FindStatusCondition` | |
+| #80 | HTTP client not used (deferred); no resource leak risk | |
+
+---
+
+## 10. Environmental Needs
+
+| Component | Requirement |
+|-----------|-------------|
+| Go | >= 1.25 (per go.mod) |
+| envtest binaries | Kubernetes 1.31 (ENVTEST_K8S_VERSION) |
+| golangci-lint | v2.11.4+ |
+| Ginkgo CLI | v2 (optional; `go test` with Ginkgo runner suffices) |
+| OpenShift API types | `github.com/openshift/api` (already in go.mod) |
+
+---
+
+## 11. Responsibilities
+
+| Role | Person | Responsibility |
+|------|--------|---------------|
+| Test author | Jordi Gil | Write tests, implement code, run TDD cycles |
+| Reviewer | (TBD) | Review PR for correctness and coverage |
+
+---
+
+## 12. Schedule
+
+| Phase | Description | Estimated Duration |
+|-------|-------------|--------------------|
+| Phase 1 | TDD Red: Drift detection tests | 15 min |
+| Phase 2 | TDD Green: Drift detection implementation | 20 min |
+| Phase 3 | TDD Refactor: Drift code review vs 100-go-mistakes | 10 min |
+| Phase 4 | TDD Red: AnsibleReady tests | 20 min |
+| Phase 5 | TDD Green: AnsibleReady implementation | 25 min |
+| Phase 6 | TDD Refactor: Ansible code review vs 100-go-mistakes | 10 min |
+| Total | | ~100 min |
+
+---
+
+## 13. Risks and Contingencies
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| `contentDrifted` causes reconcile loop on OCP-injected CMs | High | Low (preflight verified empty Data) | D2 test covers this; guard on inject-cabundle annotation if needed |
+| `Update` (PUT) clobbers OCP-injected data when drift detected | Medium | Low (only triggers on real tampering) | Document that inject-cabundle CMs with operator Data are unsupported |
+| `validateAnsibleConfig` accidentally blocks phase via `setConditionAndRequeue` | High | Medium (developer error) | A7 test explicitly verifies PhaseRunning when AnsibleReady=False |
+| Existing 65 tests regress | High | Low | Run full suite in each TDD Green phase |
+| envtest flakiness with Secret CRUD timing | Medium | Low | Use direct reconcile calls, not watches |
+
+---
+
+## 14. Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Author | Jordi Gil | 2026-04-27 | |
+| Reviewer | | | |

--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -71,6 +72,11 @@ const (
 	ReasonRouteCreated        = "RouteCreated"
 	ReasonRouteDisabled       = "RouteDisabled"
 	ReasonManifestsApplied    = "ManifestsApplied"
+
+	ReasonAnsibleDisabled        = "Disabled"
+	ReasonAnsibleReady           = "Ready"
+	ReasonAnsibleTokenNotFound   = "TokenSecretNotFound"
+	ReasonAnsibleTokenKeyMissing = "TokenKeyMissing"
 )
 
 // maxFinalizerAttempts is the number of consecutive reconcile attempts during
@@ -737,6 +743,8 @@ func (r *KubernautReconciler) phaseRunning(ctx context.Context, kn *kubernautv1a
 	finalStatuses := serviceStatuses
 	finalAllReady := allReady
 
+	ansibleCond := r.validateAnsibleConfig(ctx, kn)
+
 	if err := r.patchStatus(ctx, kn, func() {
 		kn.Status.Services = finalStatuses
 		if finalAllReady {
@@ -744,8 +752,14 @@ func (r *KubernautReconciler) phaseRunning(ctx context.Context, kn *kubernautv1a
 		} else {
 			r.setPhase(kn, kubernautv1alpha1.PhaseDegraded)
 		}
+		meta.SetStatusCondition(&kn.Status.Conditions, ansibleCond)
 	}); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if ansibleCond.Status == metav1.ConditionFalse {
+		r.Recorder.Eventf(kn, nil, corev1.EventTypeWarning, "AnsibleConfigInvalid", "Reconcile",
+			"%s: %s", ansibleCond.Reason, ansibleCond.Message)
 	}
 
 	log.Info("reconciliation complete", "phase", kn.Status.Phase)
@@ -958,6 +972,70 @@ func (r *KubernautReconciler) validateSecret(ctx context.Context, namespace, nam
 	return nil
 }
 
+// validateAnsibleConfig evaluates the AnsibleReady condition based on the
+// current CR spec and cluster state. It returns a condition to be set in the
+// status patch. When ansible is disabled, it returns True/Disabled. When
+// enabled, it validates the token Secret exists and contains the expected key.
+// This method is non-blocking: it never returns an error or sets PhaseError.
+func (r *KubernautReconciler) validateAnsibleConfig(ctx context.Context, kn *kubernautv1alpha1.Kubernaut) metav1.Condition {
+	if !kn.Spec.Ansible.Enabled {
+		return metav1.Condition{
+			Type:               kubernautv1alpha1.ConditionAnsibleReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonAnsibleDisabled,
+			Message:            "Ansible integration is disabled",
+			ObservedGeneration: kn.Generation,
+		}
+	}
+
+	if kn.Spec.Ansible.TokenSecretRef == nil {
+		return metav1.Condition{
+			Type:               kubernautv1alpha1.ConditionAnsibleReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             ReasonAnsibleTokenNotFound,
+			Message:            "spec.ansible.tokenSecretRef is not configured",
+			ObservedGeneration: kn.Generation,
+		}
+	}
+
+	secret := &corev1.Secret{}
+	secretKey := client.ObjectKey{
+		Namespace: kn.Namespace,
+		Name:      kn.Spec.Ansible.TokenSecretRef.Name,
+	}
+	if err := r.Get(ctx, secretKey, secret); err != nil {
+		return metav1.Condition{
+			Type:               kubernautv1alpha1.ConditionAnsibleReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             ReasonAnsibleTokenNotFound,
+			Message:            fmt.Sprintf("Secret %q not found", secretKey.Name),
+			ObservedGeneration: kn.Generation,
+		}
+	}
+
+	tokenKey := kn.Spec.Ansible.TokenSecretRef.Key
+	if tokenKey == "" {
+		tokenKey = "token"
+	}
+	if _, ok := secret.Data[tokenKey]; !ok {
+		return metav1.Condition{
+			Type:               kubernautv1alpha1.ConditionAnsibleReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             ReasonAnsibleTokenKeyMissing,
+			Message:            fmt.Sprintf("Secret %q is missing key %q", secretKey.Name, tokenKey),
+			ObservedGeneration: kn.Generation,
+		}
+	}
+
+	return metav1.Condition{
+		Type:               kubernautv1alpha1.ConditionAnsibleReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             ReasonAnsibleReady,
+		Message:            "Ansible token Secret is valid",
+		ObservedGeneration: kn.Generation,
+	}
+}
+
 func (r *KubernautReconciler) setConditionAndRequeue(
 	ctx context.Context, kn *kubernautv1alpha1.Kubernaut,
 	condType string, reason, message string,
@@ -1017,6 +1095,10 @@ func (r *KubernautReconciler) ensureUnowned(ctx context.Context, obj client.Obje
 // on the desired object and compares it with the live object to skip
 // unnecessary API server writes. AlreadyExists on Create is handled by
 // falling through to the update path.
+//
+// When the spec-hash annotation matches (no spec change), ensureResource
+// additionally checks for content drift on ConfigMaps — detecting external
+// modifications that preserved the annotation but altered the data.
 func (r *KubernautReconciler) ensureResource(ctx context.Context, obj client.Object) error {
 	desiredHash := resources.SpecHash(obj)
 	setHashAnnotation(obj, desiredHash)
@@ -1040,11 +1122,46 @@ func (r *KubernautReconciler) ensureResource(ctx context.Context, obj client.Obj
 	}
 
 	if existing.GetAnnotations()[resources.AnnotationSpecHash] == desiredHash {
-		return nil
+		if !contentDrifted(obj, existing) {
+			return nil
+		}
 	}
 
 	obj.SetResourceVersion(existing.GetResourceVersion())
 	return r.Update(ctx, obj)
+}
+
+// contentDrifted performs a targeted comparison of operator-managed content
+// for types that are susceptible to external data modification without
+// annotation changes (e.g., ConfigMaps edited by users or tooling).
+//
+// Only keys present in the desired object are compared; extra keys in the
+// live object (e.g., OCP-injected service-ca.crt) are ignored to prevent
+// false positives. Returns false for non-ConfigMap types.
+func contentDrifted(desired, existing client.Object) bool {
+	desiredCM, ok := desired.(*corev1.ConfigMap)
+	if !ok {
+		return false
+	}
+	existingCM, ok := existing.(*corev1.ConfigMap)
+	if !ok {
+		return false
+	}
+
+	for key, val := range desiredCM.Data {
+		if existingCM.Data[key] != val {
+			return true
+		}
+	}
+
+	for key, val := range desiredCM.BinaryData {
+		existingVal, exists := existingCM.BinaryData[key]
+		if !exists || !bytes.Equal(val, existingVal) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // setHashAnnotation merges the spec-hash annotation into the object's

--- a/internal/controller/kubernaut_controller_test.go
+++ b/internal/controller/kubernaut_controller_test.go
@@ -372,3 +372,116 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 	}
 	return nil
 }
+
+// ======================================================================
+// contentDrifted Unit Tests (TDD Red — Phase 1, Issue #16)
+// ======================================================================
+
+var _ = Describe("contentDrifted", func() {
+
+	It("D1: should return true when a desired key has a different value in the live ConfigMap", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			Data:       map[string]string{"config.yaml": "desired-content"},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			Data:       map[string]string{"config.yaml": "tampered-content"},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeTrue())
+	})
+
+	It("D2: should return false for a ConfigMap with empty desired Data (OCP inject-cabundle)", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "inter-service-ca",
+				Namespace:   "default",
+				Annotations: map[string]string{"service.beta.openshift.io/inject-cabundle": "true"},
+			},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "inter-service-ca", Namespace: "default"},
+			Data:       map[string]string{"service-ca.crt": "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----"},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeFalse())
+	})
+
+	It("D3: should return true when a desired key is absent from the live ConfigMap", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			Data:       map[string]string{"config.yaml": "content", "extra.yaml": "extra"},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			Data:       map[string]string{"config.yaml": "content"},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeTrue())
+	})
+
+	It("D5: should return false for non-ConfigMap types (Deployment)", func() {
+		desired := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+		}
+		existing := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeFalse())
+	})
+
+	It("D6: should return false when live ConfigMap Data is nil but desired Data is empty", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			Data:       map[string]string{},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeFalse())
+	})
+
+	It("D7: should return true when desired BinaryData key differs in the live ConfigMap", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			BinaryData: map[string][]byte{"cert.pem": []byte("desired-bytes")},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			BinaryData: map[string][]byte{"cert.pem": []byte("tampered-bytes")},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeTrue())
+	})
+
+	It("D6b: should return false when live ConfigMap has nil Data and desired has nil Data", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeFalse())
+	})
+
+	It("D3b: should return true when desired BinaryData key is absent from live ConfigMap", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			BinaryData: map[string][]byte{"cert.pem": []byte("desired")},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			BinaryData: map[string][]byte{},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeTrue())
+	})
+
+	It("D8: should not flag drift when live CM has extra keys not in desired (OCP injection safe)", func() {
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			Data:       map[string]string{"config.yaml": "content"},
+		}
+		existing := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+			Data:       map[string]string{"config.yaml": "content", "service-ca.crt": "injected-by-ocp"},
+		}
+		Expect(contentDrifted(desired, existing)).To(BeFalse())
+	})
+})

--- a/internal/controller/kubernaut_lifecycle_test.go
+++ b/internal/controller/kubernaut_lifecycle_test.go
@@ -129,6 +129,37 @@ func setAllDeploymentsReady(ctx context.Context) {
 	}
 }
 
+// newCRWithAnsibleEnabled returns a minimal CR with Ansible enabled and a
+// tokenSecretRef pointing to the given secret name.
+func newCRWithAnsibleEnabled(secretName string) *kubernautv1alpha1.Kubernaut {
+	cr := newCRWithRouteDisabled()
+	cr.Spec.Ansible.Enabled = true
+	cr.Spec.Ansible.APIURL = testAwxAPIURL
+	cr.Spec.Ansible.TokenSecretRef = &kubernautv1alpha1.SecretKeyRef{
+		Name: secretName,
+		Key:  "token",
+	}
+	return cr
+}
+
+// createAnsibleSecret creates a Secret with the given name and key/value pair.
+func createAnsibleSecret(ctx context.Context, name, key, value string) { //nolint:unparam // name varies in future tests
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Data:       map[string][]byte{key: []byte(value)},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}
+
+// deleteAnsibleSecret removes the ansible token Secret if it exists.
+func deleteAnsibleSecret(ctx context.Context, name string) {
+	secret := &corev1.Secret{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, secret)
+	if err == nil {
+		_ = k8sClient.Delete(ctx, secret)
+	}
+}
+
 // reconcileToDeployPhase drives a reconciler through finalizer, validate,
 // migration, and deploy phases, returning the reconciler for further use.
 func reconcileToDeployPhase(ctx context.Context) *KubernautReconciler {
@@ -1463,6 +1494,278 @@ var _ = Describe("Kubernaut Lifecycle", func() {
 			)).To(Succeed())
 			Expect(wfSAList.Items).To(BeEmpty(),
 				"workflow namespace SAs should be deleted")
+		})
+	})
+
+	// ======================================================================
+	// 16. ConfigMap Drift Detection (Issue #16, TDD Red — Phase 1)
+	// ======================================================================
+
+	Context("ConfigMap Drift Detection", func() {
+		BeforeEach(func() {
+			deleteCRIfExists(ctx)
+			cleanupNamespacedResources(ctx)
+			deleteBYOSecrets(ctx)
+		})
+		AfterEach(func() {
+			deleteCRIfExists(ctx)
+			cleanupNamespacedResources(ctx)
+		})
+
+		It("D1-I: should restore ConfigMap data when annotation is preserved but data is tampered", func() {
+			createBYOSecrets(ctx)
+			Expect(k8sClient.Create(ctx, newCRWithRouteDisabled())).To(Succeed())
+			r := reconcileToRunning(ctx)
+
+			cm := &corev1.ConfigMap{}
+			cmKey := types.NamespacedName{Name: "workflowexecution-config", Namespace: testNamespace}
+			Expect(k8sClient.Get(ctx, cmKey, cm)).To(Succeed())
+
+			origData := cm.Data["workflowexecution.yaml"]
+			origHash := cm.Annotations[resources.AnnotationSpecHash]
+			Expect(origData).NotTo(BeEmpty())
+			Expect(origHash).NotTo(BeEmpty())
+
+			By("simulating external actor modifying data but PRESERVING the spec-hash annotation")
+			cm.Data["workflowexecution.yaml"] = "tampered: true\n"
+			Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+			By("verifying annotation is still the original hash (simulates the issue)")
+			Expect(k8sClient.Get(ctx, cmKey, cm)).To(Succeed())
+			Expect(cm.Annotations[resources.AnnotationSpecHash]).To(Equal(origHash))
+			Expect(cm.Data["workflowexecution.yaml"]).To(Equal("tampered: true\n"))
+
+			By("reconciling — operator should detect content drift and restore")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: singletonKey()})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying data is restored to operator-desired state")
+			Expect(k8sClient.Get(ctx, cmKey, cm)).To(Succeed())
+			Expect(cm.Data["workflowexecution.yaml"]).To(Equal(origData),
+				"ConfigMap data should be restored after annotation-preserved tampering")
+		})
+
+		It("D4-I: should not update ConfigMap when annotation and content both match (regression guard)", func() {
+			createBYOSecrets(ctx)
+			Expect(k8sClient.Create(ctx, newCRWithRouteDisabled())).To(Succeed())
+			r := reconcileToRunning(ctx)
+
+			cm := &corev1.ConfigMap{}
+			cmKey := types.NamespacedName{Name: "workflowexecution-config", Namespace: testNamespace}
+			Expect(k8sClient.Get(ctx, cmKey, cm)).To(Succeed())
+			origRV := cm.ResourceVersion
+
+			By("reconciling again without any external changes")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: singletonKey()})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, cmKey, cm)).To(Succeed())
+			Expect(cm.ResourceVersion).To(Equal(origRV),
+				"ResourceVersion should not change when there is no drift")
+		})
+	})
+
+	// ======================================================================
+	// 17. AnsibleReady Condition Lifecycle (Issue #17, TDD Red — Phase 4)
+	// ======================================================================
+
+	Context("AnsibleReady Condition Lifecycle", func() {
+		const ansibleSecretName = "ansible-token"
+
+		BeforeEach(func() {
+			deleteCRIfExists(ctx)
+			cleanupNamespacedResources(ctx)
+			deleteBYOSecrets(ctx)
+			deleteAnsibleSecret(ctx, ansibleSecretName)
+		})
+		AfterEach(func() {
+			deleteCRIfExists(ctx)
+			cleanupNamespacedResources(ctx)
+			deleteAnsibleSecret(ctx, ansibleSecretName)
+		})
+
+		It("A1: should set AnsibleReady=True/Disabled when ansible is not enabled", func() {
+			createBYOSecrets(ctx)
+			cr := newCRWithRouteDisabled()
+			cr.Spec.Ansible.Enabled = false
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToRunning(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil(), "AnsibleReady condition should be present")
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("Disabled"))
+		})
+
+		It("A2: should set AnsibleReady=True/Ready when ansible is enabled with valid token Secret", func() {
+			createBYOSecrets(ctx)
+			createAnsibleSecret(ctx, ansibleSecretName, "token", "my-token-value")
+			cr := newCRWithAnsibleEnabled(ansibleSecretName)
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToRunning(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil(), "AnsibleReady condition should be present")
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("Ready"))
+		})
+
+		It("A3: should set AnsibleReady=False/TokenSecretNotFound when Secret does not exist", func() {
+			createBYOSecrets(ctx)
+			cr := newCRWithAnsibleEnabled("nonexistent-secret")
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToRunning(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil(), "AnsibleReady condition should be present")
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("TokenSecretNotFound"))
+		})
+
+		It("A4: should set AnsibleReady=False/TokenKeyMissing when Secret lacks the expected key", func() {
+			createBYOSecrets(ctx)
+			createAnsibleSecret(ctx, ansibleSecretName, "wrong-key", "value")
+			cr := newCRWithAnsibleEnabled(ansibleSecretName)
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToRunning(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil(), "AnsibleReady condition should be present")
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("TokenKeyMissing"))
+		})
+
+		It("A5: should set AnsibleReady=False/TokenSecretNotFound when tokenSecretRef is nil", func() {
+			createBYOSecrets(ctx)
+			cr := newCRWithRouteDisabled()
+			cr.Spec.Ansible.Enabled = true
+			cr.Spec.Ansible.APIURL = testAwxAPIURL
+			cr.Spec.Ansible.TokenSecretRef = nil
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToRunning(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil(), "AnsibleReady condition should be present")
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("TokenSecretNotFound"))
+		})
+
+		It("A6: should recover AnsibleReady to True when Secret is created after initial failure", func() {
+			createBYOSecrets(ctx)
+			cr := newCRWithAnsibleEnabled(ansibleSecretName)
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			r := reconcileToRunning(ctx)
+
+			By("verifying initially False")
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+
+			By("creating the Secret")
+			createAnsibleSecret(ctx, ansibleSecretName, "token", "my-token")
+
+			By("re-reconciling (simulates periodic requeue)")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: singletonKey()})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying recovery")
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+			cond = findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("Ready"))
+		})
+
+		It("A7: should reach PhaseRunning even when AnsibleReady=False (non-blocking)", func() {
+			createBYOSecrets(ctx)
+			cr := newCRWithAnsibleEnabled("nonexistent-secret")
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToRunning(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+			Expect(kn.Status.Phase).To(Equal(kubernautv1alpha1.PhaseRunning),
+				"PhaseRunning must be reached even when AnsibleReady is False")
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("A6b: should flip AnsibleReady to False when a previously valid Secret is deleted", func() {
+			createBYOSecrets(ctx)
+			createAnsibleSecret(ctx, ansibleSecretName, "token", "my-token")
+			cr := newCRWithAnsibleEnabled(ansibleSecretName)
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			r := reconcileToRunning(ctx)
+
+			By("verifying initially True/Ready")
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+
+			By("deleting the Secret")
+			deleteAnsibleSecret(ctx, ansibleSecretName)
+
+			By("re-reconciling")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: singletonKey()})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying condition flipped to False")
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+			cond = findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAnsibleReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("TokenSecretNotFound"))
+		})
+
+		It("A8: should emit AnsibleConfigInvalid event when Secret is missing", func() {
+			createBYOSecrets(ctx)
+			cr := newCRWithAnsibleEnabled("nonexistent-secret")
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			r := reconcileToRunning(ctx)
+
+			recorder := r.Recorder.(*events.FakeRecorder)
+			var collected []string
+		drain:
+			for {
+				select {
+				case ev := <-recorder.Events:
+					collected = append(collected, ev)
+				default:
+					break drain
+				}
+			}
+
+			Expect(collected).To(ContainElement(ContainSubstring("AnsibleConfigInvalid")))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- **Issue #16**: `ensureResource` now detects ConfigMap data tampering even when the `kubernaut.ai/spec-hash` annotation is preserved by an external actor. Adds `contentDrifted` function with targeted key-by-key comparison that ignores OCP-injected keys.
- **Issue #17**: Adds non-blocking `AnsibleReady` status condition that validates token Secret existence and key presence during `phaseRunning`. Emits `AnsibleConfigInvalid` warning event when config is invalid.
- Includes IEEE 829 test plan (`docs/test/16-17/test-plan.md`) and 20 new tests (9 unit + 11 integration) with 92.9% coverage on new code.

## Test plan

- [x] 85/85 controller specs pass
- [x] `golangci-lint` 0 issues
- [x] `contentDrifted` coverage: 92.9%
- [x] `validateAnsibleConfig` coverage: 92.9%
- [x] No regressions in existing tests
- [ ] CI pipeline builds multi-arch image
- [ ] Deploy to OCP cluster and verify AnsibleReady condition on CR

Closes #16
Closes #17


Made with [Cursor](https://cursor.com)