### PR TITLE
Fix investigator ClusterRole: add 8 missing RBAC resources (#21)

### DIFF
--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -382,12 +382,14 @@ func kubernautAgentClientClusterRole(kn *kubernautv1alpha1.Kubernaut, labels map
 
 func kubernautAgentInvestigatorClusterRole(kn *kubernautv1alpha1.Kubernaut, labels map[string]string) *rbacv1.ClusterRole {
 	rules := []rbacv1.PolicyRule{
-		{APIGroups: []string{""}, Resources: []string{"pods", "pods/log", "events", "services", "endpoints", "configmaps", "secrets", "nodes", "namespaces", "replicationcontrollers", "persistentvolumeclaims", "resourcequotas"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{""}, Resources: []string{"pods", "pods/log", "events", "services", "endpoints", "configmaps", "secrets", "nodes", "namespaces", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes", "resourcequotas", "serviceaccounts"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"apps"}, Resources: []string{"deployments", "replicasets", "statefulsets", "daemonsets"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"storage.k8s.io"}, Resources: []string{"storageclasses", "csidrivers", "volumeattachments", "csinodes"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"batch"}, Resources: []string{"jobs", "cronjobs"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"events.k8s.io"}, Resources: []string{"events"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"discovery.k8s.io"}, Resources: []string{"endpointslices"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"policy"}, Resources: []string{"poddisruptionbudgets"}, Verbs: []string{"get", "list", "watch"}},
-		{APIGroups: []string{"networking.k8s.io"}, Resources: []string{"networkpolicies"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"networking.k8s.io"}, Resources: []string{"networkpolicies", "ingresses"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"autoscaling"}, Resources: []string{"horizontalpodautoscalers"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"cert-manager.io"}, Resources: []string{"certificates", "clusterissuers", "certificaterequests"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "watch"}},


### PR DESCRIPTION
## Summary

Expands the `kubernaut-agent-investigator` ClusterRole to cover all 8 missing resources identified in the comprehensive code-level audit ([kubernaut#872](https://github.com/jordigilh/kubernaut/issues/872)).

The original PR covered 3 resources; the Kubernaut team's audit found 5 additional gaps by tracing both typed and dynamic client API usage in `pkg/kubernautagent/`.

### Resources added

| apiGroup | Resource | Rationale |
|----------|----------|-----------|
| `""` | `persistentvolumes` | Cluster-scoped PV investigation |
| `""` | `serviceaccounts` | Auth/RBAC troubleshooting ("why can't this pod pull images?") |
| `storage.k8s.io` | `storageclasses` | Storage investigation |
| `storage.k8s.io` | `csidrivers` | CSI driver investigation |
| `storage.k8s.io` | `volumeattachments` | Multi-attach / stuck detach troubleshooting |
| `storage.k8s.io` | `csinodes` | CSI driver availability per node |
| `networking.k8s.io` | `ingresses` | Core networking (alongside existing `networkpolicies`) |
| `discovery.k8s.io` | `endpointslices` | Modern replacement for `endpoints` (K8s 1.21+) |

All use **read-only verbs** (`get`, `list`, `watch`), matching the existing pattern.

## Related

- Fixes #21
- Mirrors [kubernaut#872](https://github.com/jordigilh/kubernaut/issues/872) (Helm chart)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/resources/...` passes
- [ ] CI image build
- [ ] Deploy to OCP, verify KA can query all 8 resource types without RBAC errors