### PR TITLE
feat(ro): add dryRun and dryRunHoldPeriod to RO spec (#24)

### DIFF
--- a/api/v1alpha1/kubernaut_types.go
+++ b/api/v1alpha1/kubernaut_types.go
@@ -279,6 +279,20 @@ type RemediationOrchestratorSpec struct {
 	// +optional
 	AsyncPropagation ROAsyncPropagationSpec `json:"asyncPropagation,omitempty"`
 
+	// DryRun enables dry-run mode: the pipeline stops after AI analysis
+	// without executing remediation workflows. Operators use this to
+	// build confidence before enabling fully autonomous remediation.
+	// +kubebuilder:default=false
+	// +optional
+	DryRun bool `json:"dryRun,omitempty"`
+
+	// DryRunHoldPeriod suppresses re-triggering of the same signal after
+	// a dry-run completion. Must be a valid Go duration string.
+	// Only effective when DryRun is true.
+	// +kubebuilder:default="1h"
+	// +optional
+	DryRunHoldPeriod string `json:"dryRunHoldPeriod,omitempty"`
+
 	// Resource requirements.
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/config/crd/bases/kubernaut.ai_kubernauts.yaml
+++ b/config/crd/bases/kubernaut.ai_kubernauts.yaml
@@ -744,6 +744,20 @@ spec:
                         default: 5m
                         type: string
                     type: object
+                  dryRun:
+                    default: false
+                    description: |-
+                      DryRun enables dry-run mode: the pipeline stops after AI analysis
+                      without executing remediation workflows. Operators use this to
+                      build confidence before enabling fully autonomous remediation.
+                    type: boolean
+                  dryRunHoldPeriod:
+                    default: 1h
+                    description: |-
+                      DryRunHoldPeriod suppresses re-triggering of the same signal after
+                      a dry-run completion. Must be a valid Go duration string.
+                      Only effective when DryRun is true.
+                    type: string
                   effectivenessAssessment:
                     description: Effectiveness assessment configuration.
                     properties:

--- a/internal/resources/configmaps.go
+++ b/internal/resources/configmaps.go
@@ -234,6 +234,8 @@ type remediationOrchestratorConfigYAML struct {
 	Routing                 roRoutingYAML          `json:"routing" yaml:"routing"`
 	EffectivenessAssessment roEffectivenessYAML    `json:"effectivenessAssessment" yaml:"effectivenessAssessment"`
 	AsyncPropagation        roAsyncPropagationYAML `json:"asyncPropagation" yaml:"asyncPropagation"`
+	DryRun                  bool                   `json:"dryRun" yaml:"dryRun"`
+	DryRunHoldPeriod        string                 `json:"dryRunHoldPeriod" yaml:"dryRunHoldPeriod"`
 }
 
 type weExecutionYAML struct {
@@ -741,6 +743,8 @@ func RemediationOrchestratorConfigMap(kn *kubernautv1alpha1.Kubernaut, opts ...C
 			OperatorReconcileDelay: withDefault(ro.AsyncPropagation.OperatorReconcileDelay, "1m"),
 			ProactiveAlertDelay:    withDefault(ro.AsyncPropagation.ProactiveAlertDelay, "5m"),
 		},
+		DryRun:           ro.DryRun,
+		DryRunHoldPeriod: withDefault(ro.DryRunHoldPeriod, "1h"),
 	}
 	data, err := marshalYAML(cfg)
 	if err != nil {

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -166,6 +166,7 @@ func TestRemediationOrchestratorConfigMap_Defaults(t *testing.T) {
 	defaults := []string{
 		"global: 1h", "processing: 5m", "analyzing: 10m", "executing: 30m", "verifying: 30m",
 		"ineffectiveChainThreshold: 3", "recurrenceCountThreshold: 5", "ineffectiveTimeWindow: 4h",
+		"dryRun: false", "dryRunHoldPeriod: 1h",
 	}
 	for _, d := range defaults {
 		if !strings.Contains(data, d) {
@@ -214,6 +215,109 @@ func TestRemediationOrchestratorConfigMap_CustomValues(t *testing.T) {
 	}
 	if !strings.Contains(data, "processing: 10m") {
 		t.Errorf("RO config should use custom processing timeout, got:\n%s", data)
+	}
+}
+
+// BAC-2: When dry-run is not explicitly configured, the RO must receive
+// dryRun: false so it operates in normal autonomous mode.
+func TestROConfig_DryRunDisabledByDefault(t *testing.T) {
+	kn := testKubernaut()
+	cm, err := RemediationOrchestratorConfigMap(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := cm.Data["remediationorchestrator.yaml"]
+	if !strings.Contains(data, "dryRun: false") {
+		t.Errorf("BAC-2: default CR must render explicit 'dryRun: false', got:\n%s", data)
+	}
+}
+
+// BAC-3: The hold period must default to 1h so that re-triggering
+// suppression works out of the box.
+func TestROConfig_DryRunHoldPeriodDefaultsTo1h(t *testing.T) {
+	kn := testKubernaut()
+	cm, err := RemediationOrchestratorConfigMap(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := cm.Data["remediationorchestrator.yaml"]
+	if !strings.Contains(data, "dryRunHoldPeriod: 1h") {
+		t.Errorf("BAC-3: default CR must render 'dryRunHoldPeriod: 1h', got:\n%s", data)
+	}
+}
+
+// BAC-1: An operator must be able to enable dry-run mode declaratively
+// via the Kubernaut CR.
+func TestROConfig_DryRunEnabled_RendersInConfigMap(t *testing.T) {
+	kn := testKubernaut()
+	kn.Spec.RemediationOrchestrator.DryRun = true
+	cm, err := RemediationOrchestratorConfigMap(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := cm.Data["remediationorchestrator.yaml"]
+	if !strings.Contains(data, "dryRun: true") {
+		t.Errorf("BAC-1: setting DryRun=true must render 'dryRun: true', got:\n%s", data)
+	}
+}
+
+// BAC-4: The operator must allow customizing the hold period and render
+// the value faithfully to the RO ConfigMap.
+func TestROConfig_CustomHoldPeriodOverride(t *testing.T) {
+	kn := testKubernaut()
+	kn.Spec.RemediationOrchestrator.DryRun = true
+	kn.Spec.RemediationOrchestrator.DryRunHoldPeriod = "30m"
+	cm, err := RemediationOrchestratorConfigMap(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := cm.Data["remediationorchestrator.yaml"]
+	if !strings.Contains(data, "dryRunHoldPeriod: 30m") {
+		t.Errorf("BAC-4: custom hold period must be rendered, got:\n%s", data)
+	}
+}
+
+// BAC-6: Changing dry-run settings must not disrupt other RO configuration.
+func TestROConfig_DryRunDoesNotAffectOtherSettings(t *testing.T) {
+	kn := testKubernaut()
+	kn.Spec.RemediationOrchestrator.DryRun = true
+	kn.Spec.RemediationOrchestrator.DryRunHoldPeriod = "2h"
+	cm, err := RemediationOrchestratorConfigMap(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := cm.Data["remediationorchestrator.yaml"]
+	unchanged := []string{
+		"global: 1h", "processing: 5m", "analyzing: 10m",
+		"consecutiveFailureThreshold: 3", "stabilizationWindow: 5m",
+		"gitOpsSyncDelay: 3m",
+	}
+	for _, want := range unchanged {
+		if !strings.Contains(data, want) {
+			t.Errorf("BAC-6: enabling dry-run must not alter %q, got:\n%s", want, data)
+		}
+	}
+}
+
+// BAC-7: An existing CR without dry-run fields must continue working
+// after operator upgrade (backward compatibility).
+func TestROConfig_EmptyCR_BackwardCompatible(t *testing.T) {
+	kn := testKubernaut()
+	cm, err := RemediationOrchestratorConfigMap(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := cm.Data["remediationorchestrator.yaml"]
+	required := []string{
+		"dryRun: false",
+		"dryRunHoldPeriod: 1h",
+		"global: 1h",
+		"consecutiveFailureThreshold: 3",
+	}
+	for _, want := range required {
+		if !strings.Contains(data, want) {
+			t.Errorf("BAC-7: upgraded CR must still render %q, got:\n%s", want, data)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `spec.remediationOrchestrator.dryRun` (bool, default `false`) and `spec.remediationOrchestrator.dryRunHoldPeriod` (string, default `"1h"`) to the Kubernaut CR
- Wires both fields into the RO ConfigMap builder so operators can enable dry-run mode declaratively without manually editing ConfigMaps
- The YAML struct renders `dryRun: false` explicitly (no `omitempty`) so the RO always sees the operator's intent

### Upstream alignment

Fields match the upstream RO config contract (`kubernaut/internal/config/remediationorchestrator/config.go`): `dryRun bool`, `dryRunHoldPeriod time.Duration`. The operator renders durations as strings, consistent with all existing timeout/duration fields.

### Cross-references

- kubernaut#712, #736: Dry-run mode implementation
- kubernaut#116: Interactive dry-run via RAR
- kubernaut#835: RO config hot-reload (fsnotify)

## Test plan

Tests provide behavioral assurance against 7 business acceptance criteria:

- [x] BAC-1: `DryRun=true` renders `dryRun: true` in ConfigMap
- [x] BAC-2: Default CR emits explicit `dryRun: false`
- [x] BAC-3: Hold period defaults to `1h`
- [x] BAC-4: Custom hold period override (`30m`) rendered faithfully
- [x] BAC-5: Spec-hash change on toggle (existing integration test)
- [x] BAC-6: Dry-run does not affect other RO settings
- [x] BAC-7: Backward compatible with empty/upgraded CR
- [x] Full envtest suite passes (73.7% controller, 87.6% resources)

Closes #24


Made with [Cursor](https://cursor.com)