### PR TITLE
feat: add preferred pod anti-affinity to all service deployments

### DIFF
--- a/internal/resources/deployments.go
+++ b/internal/resources/deployments.go
@@ -588,6 +588,7 @@ func buildDeployment(kn *kubernautv1alpha1.Kubernaut, p DeploymentParams) (*apps
 					ServiceAccountName: ServiceAccountName(p.Component),
 					SecurityContext:    PodSecurityContext(),
 					ImagePullSecrets:   kn.Spec.Image.PullSecrets,
+					Affinity:           preferredPodAntiAffinity(p.Component),
 					InitContainers:     p.InitContainers,
 					Containers: []corev1.Container{{
 						Name:            p.Component,
@@ -613,6 +614,24 @@ func buildDeployment(kn *kubernautv1alpha1.Kubernaut, p DeploymentParams) (*apps
 	}
 
 	return dep, nil
+}
+
+func preferredPodAntiAffinity(component string) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: SelectorLabels(component),
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
+	}
 }
 
 func configMapVolume(name, cmName string) corev1.Volume {

--- a/internal/resources/deployments_test.go
+++ b/internal/resources/deployments_test.go
@@ -719,6 +719,53 @@ func TestServiceAccountNaming_AllComponentsCovered(t *testing.T) {
 	}
 }
 
+func TestAllDeployments_PodAntiAffinity(t *testing.T) {
+	kn := testKubernaut()
+	deps := getAllDeployments(t, kn)
+
+	for _, dep := range deps {
+		component := dep.Spec.Template.Labels["app"]
+
+		affinity := dep.Spec.Template.Spec.Affinity
+		if affinity == nil {
+			t.Fatalf("Deployment %q: Affinity must not be nil", dep.Name)
+		}
+		paa := affinity.PodAntiAffinity
+		if paa == nil {
+			t.Fatalf("Deployment %q: PodAntiAffinity must not be nil", dep.Name)
+		}
+
+		preferred := paa.PreferredDuringSchedulingIgnoredDuringExecution
+		if len(preferred) == 0 {
+			t.Fatalf("Deployment %q: expected at least one preferred anti-affinity term", dep.Name)
+		}
+
+		term := preferred[0]
+
+		if term.Weight != 100 {
+			t.Errorf("Deployment %q: anti-affinity weight = %d, want 100", dep.Name, term.Weight)
+		}
+
+		if term.PodAffinityTerm.TopologyKey != "kubernetes.io/hostname" {
+			t.Errorf("Deployment %q: topology key = %q, want %q",
+				dep.Name, term.PodAffinityTerm.TopologyKey, "kubernetes.io/hostname")
+		}
+
+		sel := term.PodAffinityTerm.LabelSelector
+		if sel == nil {
+			t.Fatalf("Deployment %q: anti-affinity label selector must not be nil", dep.Name)
+		}
+
+		expectedLabels := SelectorLabels(component)
+		for k, v := range expectedLabels {
+			if sel.MatchLabels[k] != v {
+				t.Errorf("Deployment %q: anti-affinity selector label %q = %q, want %q",
+					dep.Name, k, sel.MatchLabels[k], v)
+			}
+		}
+	}
+}
+
 // --- helpers ---
 
 func getAllDeployments(t *testing.T, kn *kubernautv1alpha1.Kubernaut) []*appsv1.Deployment {


### PR DESCRIPTION
## Summary

- Adds a `preferredDuringSchedulingIgnoredDuringExecution` pod anti-affinity rule to the shared `buildDeployment()` helper, so all 10 Kubernaut service deployments spread across nodes by `kubernetes.io/hostname`.
- Uses weight 100 (strongest preference) with the component's own selector labels, preventing co-location of same-service pods on a single node.
- Soft preference ensures single-node dev clusters are unaffected.

Closes #14

## Test plan

- [x] `TestAllDeployments_PodAntiAffinity` asserts all 4 BACs (non-nil affinity, hostname topology key, component selector match, weight 100) across all 10 deployments
- [x] Full test suite (85 controller integration specs + all resource unit tests) passes with zero regressions
- [x] `golangci-lint` reports 0 issues

Made with [Cursor](https://cursor.com)