### PR TITLE
fix: add config.openshift.io read access to KA investigator role

### DIFF
--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -455,6 +455,7 @@ func kubernautAgentInvestigatorClusterRole(kn *kubernautv1alpha1.Kubernaut, labe
 		{APIGroups: []string{"networking.istio.io"}, Resources: []string{"virtualservices", "destinationrules", "gateways", "serviceentries"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"monitoring.coreos.com"}, Resources: []string{"prometheusrules", "servicemonitors", "podmonitors", "probes"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"metrics.k8s.io"}, Resources: []string{"pods", "nodes"}, Verbs: []string{"get", "list"}},
+		{APIGroups: []string{"config.openshift.io"}, Resources: []string{"nodes", "clusteroperators", "clusterversions", "infrastructures"}, Verbs: []string{"get", "list", "watch"}},
 	}
 
 	return &rbacv1.ClusterRole{


### PR DESCRIPTION
## Summary

- Adds `config.openshift.io` API group to the KA investigator ClusterRole with read-only access to `nodes`, `clusteroperators`, `clusterversions`, and `infrastructures`
- Fixes RBAC forbidden error when the KA's `kubectl_describe Node` tool resolves to the OCP-specific `config.openshift.io/nodes` resource

## Context

The demo team reported:
> `kubectl_describe Node — got RBAC error (OCP config.openshift.io)`

The KA tool resolves `Node` to both core API (`nodes` — already permitted) and OCP's `config.openshift.io` group (not previously included).

## Test plan

- [x] Manually patched ClusterRole on OCP cluster, confirmed RBAC error resolved
- [x] `go build ./...` passes

Made with [Cursor](https://cursor.com)