### PR TITLE
fix: set SSL_CERT_FILE for WFE to work around upstream CA init order

### DIFF
--- a/internal/resources/deployments.go
+++ b/internal/resources/deployments.go
@@ -277,6 +277,7 @@ func WorkflowExecutionDeployment(kn *kubernautv1alpha1.Kubernaut) (*appsv1.Deplo
 			SecurityContext: ContainerSecurityContext(),
 		})
 		env = overrideTLSCAFile(env, "/etc/combined-ca/ca-bundle.crt")
+		env = append(env, corev1.EnvVar{Name: "SSL_CERT_FILE", Value: "/etc/combined-ca/ca-bundle.crt"})
 	}
 
 	return buildDeployment(kn, DeploymentParams{


### PR DESCRIPTION
## Summary

- Sets `SSL_CERT_FILE` env var on the WFE container pointing to the combined CA bundle (`/etc/combined-ca/ca-bundle.crt`)
- This ensures Go's `crypto/x509` system pool includes the AAP CA at process start, before the AWX HTTP client clones `http.DefaultTransport`
- Workaround for the upstream initialization order bug: jordigilh/kubernaut#902

## Context

The AWX HTTP client (`NewAWXHTTPClient`) clones `http.DefaultTransport` **before** `sharedtls.StartCAFileWatcher` loads the CA from `TLS_CA_FILE`. The existing `TLS_CA_FILE` approach only affects the transport *after* the watcher starts, which is too late for the already-cloned AWX client.

Setting `SSL_CERT_FILE` makes Go's default cert pool include the AAP CA from the start of the process.

## Test plan

- [x] Existing unit tests pass
- [x] Deploy to OCP and verify WFE can connect to AAP without x509 errors

Made with [Cursor](https://cursor.com)