### PR TITLE
fix: update to kubernaut v1.4.0-rc6 and address remaining v1.4 issues

### DIFF
--- a/api/v1alpha1/kubernaut_types.go
+++ b/api/v1alpha1/kubernaut_types.go
@@ -637,7 +637,7 @@ type AnomalySpec struct {
 	// +optional
 	MaxToolCallsPerTool *int `json:"maxToolCallsPerTool,omitempty"`
 	// Max total tool calls across all tools.
-	// +kubebuilder:default=30
+	// +kubebuilder:default=40
 	// +optional
 	MaxTotalToolCalls *int `json:"maxTotalToolCalls,omitempty"`
 	// Max repeated failures before circuit-breaker.
@@ -869,6 +869,16 @@ type KubernautStatus struct {
 	// Per-service readiness.
 	// +optional
 	Services []ServiceStatus `json:"services,omitempty"`
+
+	// Hash of the last successfully completed migration Job spec.
+	// Used to skip re-running migration when the Job has been deleted
+	// (e.g. TTL cleanup, manual deletion) but nothing has changed.
+	// +optional
+	LastMigrationHash string `json:"lastMigrationHash,omitempty"`
+
+	// Timestamp of the last successfully completed migration.
+	// +optional
+	LastMigrationTime *metav1.Time `json:"lastMigrationTime,omitempty"`
 
 	// ClusterRole names for which the operator has created additional
 	// agent ClusterRoleBindings. Used for stale-pruning on spec changes

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -450,6 +450,10 @@ func (in *KubernautStatus) DeepCopyInto(out *KubernautStatus) {
 		*out = make([]ServiceStatus, len(*in))
 		copy(*out, *in)
 	}
+	if in.LastMigrationTime != nil {
+		in, out := &in.LastMigrationTime, &out.LastMigrationTime
+		*out = (*in).DeepCopy()
+	}
 	if in.BoundAdditionalClusterRoles != nil {
 		in, out := &in.BoundAdditionalClusterRoles, &out.BoundAdditionalClusterRoles
 		*out = make([]string, len(*in))

--- a/config/crd/bases/kubernaut.ai_kubernauts.yaml
+++ b/config/crd/bases/kubernaut.ai_kubernauts.yaml
@@ -833,7 +833,7 @@ spec:
                             description: Max tool calls per individual tool.
                             type: integer
                           maxTotalToolCalls:
-                            default: 30
+                            default: 40
                             description: Max total tool calls across all tools.
                             type: integer
                         type: object
@@ -1536,6 +1536,16 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              lastMigrationHash:
+                description: |-
+                  Hash of the last successfully completed migration Job spec.
+                  Used to skip re-running migration when the Job has been deleted
+                  (e.g. TTL cleanup, manual deletion) but nothing has changed.
+                type: string
+              lastMigrationTime:
+                description: Timestamp of the last successfully completed migration.
+                format: date-time
+                type: string
               phase:
                 description: Aggregate lifecycle phase.
                 enum:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kubernaut-ai/kubernaut-operator
-  newTag: 1.4.0
+  newTag: v1.4.0-rc5

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,27 +67,27 @@ spec:
         name: manager
         env:
         - name: RELATED_IMAGE_GATEWAY
-          value: quay.io/kubernaut-ai/gateway@sha256:203f8586e45407e724a4f9bb1b104fc34325be5eeedcf7f0dc7f44e53a9e2a1f
+          value: quay.io/kubernaut-ai/gateway@sha256:79610444b5ae1563dccb230971a916d352d504160ee3f61df8bb37bbecf322e6
         - name: RELATED_IMAGE_DATA_STORAGE
-          value: quay.io/kubernaut-ai/datastorage@sha256:5053bbce60cc589b8c8039afc9454ec1ed434be6cbec8833cab01ffddc3f2480
+          value: quay.io/kubernaut-ai/datastorage@sha256:0cfff45fd55ad1dcffed841520f55e4849180ad08323ead2b5e081e4233252fc
         - name: RELATED_IMAGE_AIANALYSIS
-          value: quay.io/kubernaut-ai/aianalysis@sha256:8fd5f4a4b9f8d80a51c0d82c7a5bd35fdf5f750bbfa74cc547fda532c565d3d2
+          value: quay.io/kubernaut-ai/aianalysis@sha256:71291754c4f6dd17bc859707fe1ef446f2623c7ab04bff6f849c7caab64b30cf
         - name: RELATED_IMAGE_SIGNALPROCESSING
-          value: quay.io/kubernaut-ai/signalprocessing@sha256:6d1e8f2b97bdc6b6ed0764dfc413ff394d5dda49c0eeaf8437b240a278741232
+          value: quay.io/kubernaut-ai/signalprocessing@sha256:933e75877737186f72ade5584fb35bc3635b437ba6cb3c86eba04275898f7a46
         - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:62cffbe4b68d1c8621f88e0a22d15912e7c9d3cae47cc63d68ab7ea984b74f27
+          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:90bc243379c42f982eaf70bb805df782cb233ce8fc9ef2211dcd0b614bf4c145
         - name: RELATED_IMAGE_WORKFLOWEXECUTION
-          value: quay.io/kubernaut-ai/workflowexecution@sha256:7045524c257f4364be7299a72e03bee67f69b5b30ed3484fd3d1f0e39a9ee039
+          value: quay.io/kubernaut-ai/workflowexecution@sha256:56bb04acb8f1d855f8d5b186a3e1357ca740b5cf3426b55f1f28701706701ae5
         - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:eb2703f5e52f9146ad0abb42898fa3dff312d688b50ada13fad1b76484b6c44b
+          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:916992b6d03a9cf680725ba7128112936ee0e8d41efe6872041eab6b972e2b3b
         - name: RELATED_IMAGE_NOTIFICATION
-          value: quay.io/kubernaut-ai/notification@sha256:ab5e94ce4eef291c98e6bd2056ffea537138dc0e94cdf5495098fb8a918d3aad
+          value: quay.io/kubernaut-ai/notification@sha256:9ccf615310d76a53fbdcb27260046593c77f290534d5b5bf4381aafe2a9d3458
         - name: RELATED_IMAGE_KUBERNAUT_AGENT
-          value: quay.io/kubernaut-ai/kubernautagent@sha256:25bb602d8daa4d7c6fbf84712b0c16eb75cc84e48575d4e59a70966bf8ab8050
+          value: quay.io/kubernaut-ai/kubernautagent@sha256:d08c0b0f310e9ca99ed0109d4016088aea652916dff14ad9cac3959acad8c895
         - name: RELATED_IMAGE_AUTHWEBHOOK
-          value: quay.io/kubernaut-ai/authwebhook@sha256:56a4ab10653fe6fdddb22b36cfd68050dc7e60912ecbd770983e5348fe48527c
+          value: quay.io/kubernaut-ai/authwebhook@sha256:c5b18452a983215029dd7b2d915e093cafc9d835119d171d8c069fc3ccf72f6d
         - name: RELATED_IMAGE_DB_MIGRATE
-          value: quay.io/kubernaut-ai/db-migrate@sha256:fe0cfbc7611db71f5b08b1c20b16fd68b5f9c227daa26ba30783ba1783c474af
+          value: quay.io/kubernaut-ai/db-migrate@sha256:076d92ab58da94848b2f664328bd1922ea631e82c1117d7b7e63988a4c18a8b8
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/docs/installation/01-infrastructure.md
+++ b/docs/installation/01-infrastructure.md
@@ -42,15 +42,92 @@ EOF
 
 Kubernaut requires Valkey 7+ (or Redis 7+) for deduplication and event streaming.
 
-**In-cluster example (testing only):**
+### Persistence
+
+By default Valkey enables RDB snapshots (`save` directives) and refuses writes when
+a background save fails (`stop-writes-on-bgsave-error yes`). If no writable volume is
+mounted at `/data`, the background save fails immediately and Valkey rejects all write
+commands, which prevents the DataStorage service from starting.
+
+Choose one of:
+
+| Strategy | When to use |
+|---|---|
+| **Disable RDB** (`save ""`) | Valkey is used only as a cache/stream broker; data loss on restart is acceptable (typical for Kubernaut). |
+| **Mount a PVC** on `/data` | You need persistence across pod restarts (HA / disaster recovery). |
+
+### In-cluster example (testing only)
+
+The example below disables RDB persistence so that no volume is required:
 
 ```bash
-oc new-app valkey/valkey:8 \
-  -e VALKEY_PASSWORD=changeme \
-  -n kubernaut-system
+oc apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey
+  namespace: kubernaut-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+        - name: valkey
+          image: valkey/valkey:8
+          args: ["--requirepass", "changeme", "--save", ""]
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  namespace: kubernaut-system
+spec:
+  selector:
+    app: valkey
+  ports:
+    - port: 6379
+      targetPort: 6379
+EOF
 ```
 
-Create the operator secret. The key must be `valkey-secrets.yaml` containing YAML with a `password` field:
+If you need persistence, add a PVC and mount it at `/data` instead of passing `--save ""`.
+
+### Production recommendations
+
+- **Resources**: set memory `requests` and `limits` to prevent OOM kills. Valkey is single-threaded; 1 CPU is sufficient for most workloads.
+- **High availability**: consider Valkey Sentinel or a managed Redis service (ElastiCache, Azure Cache, Memorystore) for production clusters.
+- **TLS**: Valkey supports TLS natively (`--tls-port`, `--tls-cert-file`, `--tls-key-file`). For in-cluster traffic behind NetworkPolicies, plaintext is acceptable.
+
+### Troubleshooting
+
+If the DataStorage pod logs show:
+
+```
+MISCONF Valkey is configured to save RDB snapshots, but it's currently unable to persist to disk.
+```
+
+Valkey cannot write its RDB dump file. Fix by either:
+
+1. Disabling RDB: `valkey-cli CONFIG SET save ""` and `valkey-cli CONFIG SET stop-writes-on-bgsave-error no`
+2. Mounting a writable volume at `/data`
+
+### Create the operator secret
+
+The key must be `valkey-secrets.yaml` containing YAML with a `password` field:
 
 ```bash
 oc apply -f - <<EOF

--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -276,6 +276,10 @@ func (r *KubernautReconciler) ensureMigrationJob(ctx context.Context, kn *kubern
 	desiredHash := resources.SpecHash(migrationJob)
 	setHashAnnotation(migrationJob, desiredHash)
 
+	if kn.Status.LastMigrationHash == desiredHash {
+		return ctrl.Result{}, nil
+	}
+
 	existingJob := &batchv1.Job{}
 	created, err := r.createIfNotFound(ctx, kn, migrationJob, existingJob)
 	if err != nil {
@@ -288,7 +292,11 @@ func (r *KubernautReconciler) ensureMigrationJob(ctx context.Context, kn *kubern
 	for _, cond := range existingJob.Status.Conditions {
 		if cond.Type == batchv1.JobComplete && cond.Status == corev1.ConditionTrue {
 			if existingJob.GetAnnotations()[resources.AnnotationSpecHash] == desiredHash {
-				return ctrl.Result{}, nil
+				now := metav1.Now()
+				return ctrl.Result{}, r.patchStatus(ctx, kn, func() {
+					kn.Status.LastMigrationHash = desiredHash
+					kn.Status.LastMigrationTime = &now
+				})
 			}
 			log.Info("completed migration job has stale spec-hash, deleting for re-run")
 			propagation := metav1.DeletePropagationBackground

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -127,8 +127,11 @@ const InterServiceTLSCAFile = "/etc/tls-ca/service-ca.crt"
 
 // OCP monitoring stack endpoints. These are always available on OCP clusters
 // and are hardcoded rather than discovered (OCP-only operator).
+// Thanos Querier federates both cluster Prometheus and User Workload
+// Monitoring Prometheus, providing a unified view of all metrics including
+// user-namespace ServiceMonitors (Istio, app metrics, etc.).
 const (
-	OCPPrometheusURL   = "https://prometheus-k8s.openshift-monitoring.svc:9091"
+	OCPPrometheusURL   = "https://thanos-querier.openshift-monitoring.svc:9091"
 	OCPAlertManagerURL = "https://alertmanager-main.openshift-monitoring.svc:9094"
 )
 

--- a/internal/resources/configmaps.go
+++ b/internal/resources/configmaps.go
@@ -543,7 +543,8 @@ type kaIntegrationsToolsYAML struct {
 }
 
 type kaIntegrationsPrometheusYAML struct {
-	URL string `json:"url" yaml:"url"`
+	URL       string `json:"url" yaml:"url"`
+	TLSCaFile string `json:"tlsCaFile,omitempty" yaml:"tlsCaFile,omitempty"`
 }
 
 type kubernautAgentConfigYAML struct {
@@ -1217,25 +1218,26 @@ func KubernautAgentConfigMap(kn *kubernautv1alpha1.Kubernaut, opts ...ConfigMapO
 	injEnabled := ka.Safety.Sanitization.InjectionPatternsEnabled == nil || *ka.Safety.Sanitization.InjectionPatternsEnabled
 	credEnabled := ka.Safety.Sanitization.CredentialScrubEnabled == nil || *ka.Safety.Sanitization.CredentialScrubEnabled
 	maxPerTool := intPtrDefault(ka.Safety.Anomaly.MaxToolCallsPerTool, 10)
-	maxTotal := intPtrDefault(ka.Safety.Anomaly.MaxTotalToolCalls, 30)
+	maxTotal := intPtrDefault(ka.Safety.Anomaly.MaxTotalToolCalls, 40)
 	maxFail := intPtrDefault(ka.Safety.Anomaly.MaxRepeatedFailures, 3)
-	if !injEnabled || !credEnabled || maxPerTool != 10 || maxTotal != 30 || maxFail != 3 {
-		cfg.AI.Safety = &kaSafetyYAML{
-			Sanitization: kaSanitizationYAML{
-				InjectionPatternsEnabled: injEnabled,
-				CredentialScrubEnabled:   credEnabled,
-			},
-			Anomaly: kaAnomalyYAML{
-				MaxToolCallsPerTool: maxPerTool,
-				MaxTotalToolCalls:   maxTotal,
-				MaxRepeatedFailures: maxFail,
-			},
-		}
+	cfg.AI.Safety = &kaSafetyYAML{
+		Sanitization: kaSanitizationYAML{
+			InjectionPatternsEnabled: injEnabled,
+			CredentialScrubEnabled:   credEnabled,
+		},
+		Anomaly: kaAnomalyYAML{
+			MaxToolCallsPerTool: maxPerTool,
+			MaxTotalToolCalls:   maxTotal,
+			MaxRepeatedFailures: maxFail,
+		},
 	}
 
 	if kn.Spec.Monitoring.MonitoringEnabled() {
 		cfg.Integrations.Tools = &kaIntegrationsToolsYAML{
-			Prometheus: kaIntegrationsPrometheusYAML{URL: OCPPrometheusURL},
+			Prometheus: kaIntegrationsPrometheusYAML{
+				URL:       OCPPrometheusURL,
+				TLSCaFile: "/etc/ssl/ka/service-ca.crt",
+			},
 		}
 	}
 

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -793,12 +793,12 @@ func TestKubernautAgentConfigMap_V14Structure(t *testing.T) {
 			DataStorage struct {
 				URL string `yaml:"url"`
 			} `yaml:"dataStorage"`
-		Tools *struct {
-			Prometheus struct {
-				URL       string `yaml:"url"`
-				TLSCaFile string `yaml:"tlsCaFile"`
-			} `yaml:"prometheus"`
-		} `yaml:"tools,omitempty"`
+			Tools *struct {
+				Prometheus struct {
+					URL       string `yaml:"url"`
+					TLSCaFile string `yaml:"tlsCaFile"`
+				} `yaml:"prometheus"`
+			} `yaml:"tools,omitempty"`
 		} `yaml:"integrations"`
 	}
 	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -529,6 +529,9 @@ func TestKubernautAgentConfigMap_MonitoringURL(t *testing.T) {
 	if !strings.Contains(data, OCPPrometheusURL) {
 		t.Errorf("KA config should contain Prometheus URL when monitoring enabled, got:\n%s", data)
 	}
+	if !strings.Contains(data, "tlsCaFile: /etc/ssl/ka/service-ca.crt") {
+		t.Errorf("KA config should contain Prometheus tlsCaFile for SA bearer auth, got:\n%s", data)
+	}
 	if !strings.Contains(data, "dataStorage:") {
 		t.Errorf("KA config should contain dataStorage section, got:\n%s", data)
 	}
@@ -790,11 +793,12 @@ func TestKubernautAgentConfigMap_V14Structure(t *testing.T) {
 			DataStorage struct {
 				URL string `yaml:"url"`
 			} `yaml:"dataStorage"`
-			Tools *struct {
-				Prometheus struct {
-					URL string `yaml:"url"`
-				} `yaml:"prometheus"`
-			} `yaml:"tools,omitempty"`
+		Tools *struct {
+			Prometheus struct {
+				URL       string `yaml:"url"`
+				TLSCaFile string `yaml:"tlsCaFile"`
+			} `yaml:"prometheus"`
+		} `yaml:"tools,omitempty"`
 		} `yaml:"integrations"`
 	}
 	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {
@@ -824,6 +828,9 @@ func TestKubernautAgentConfigMap_V14Structure(t *testing.T) {
 	}
 	if got := root.Integrations.Tools.Prometheus.URL; got != OCPPrometheusURL {
 		t.Errorf("integrations.tools.prometheus.url = %q, want %q", got, OCPPrometheusURL)
+	}
+	if got := root.Integrations.Tools.Prometheus.TLSCaFile; got != "/etc/ssl/ka/service-ca.crt" {
+		t.Errorf("integrations.tools.prometheus.tlsCaFile = %q, want /etc/ssl/ka/service-ca.crt", got)
 	}
 }
 

--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -517,6 +517,7 @@ func workflowExecutionControllerClusterRole(kn *kubernautv1alpha1.Kubernaut, lab
 			{APIGroups: []string{"tekton.dev"}, Resources: []string{"taskruns"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"batch"}, Resources: []string{"jobs"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
 			{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create", "patch"}},
+			{APIGroups: []string{""}, Resources: []string{"serviceaccounts/token"}, Verbs: []string{"create"}},
 			{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
 		},
 	}


### PR DESCRIPTION
## Summary

- Bumps all 11 `RELATED_IMAGE_*` digests to **kubernaut v1.4.0-rc6**
- Raises default `maxTotalToolCalls` from 30 → 40 and ensures the safety block is always emitted to override upstream KA defaults (#41)
- Adds `tlsCaFile` to the KA Prometheus config, enabling SA bearer auth for metrics (#41)
- Switches Prometheus endpoint from `prometheus-k8s` to `thanos-querier` for federated metrics including user workload (#48)
- Adds `LastMigrationHash` / `LastMigrationTime` to `KubernautStatus` to prevent migration Job re-triggers after TTL cleanup
- Adds `serviceaccounts/token create` RBAC for the WorkflowExecution controller (#50)
- Expands Valkey persistence documentation with RDB troubleshooting and production recommendations (#40)

Closes #41, #40, #48, #50

## Test plan

- [ ] CI builds the operator image successfully (linux/amd64)
- [ ] Deploy to OCP cluster using the ghcr.io image from CI
- [ ] Verify all 11 managed services roll out to rc6 images
- [ ] Confirm KA connects to thanos-querier with SA bearer auth
- [ ] Confirm migration job does not re-trigger after TTL deletion
- [ ] Confirm WE controller can create SA tokens in kubernaut-workflows


Made with [Cursor](https://cursor.com)