### PR TITLE
fix: grant kubernaut-agent read access to OCP and core K8s resources

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 1.4.x   | :white_check_mark: |
 | 1.3.x   | :white_check_mark: |
 | < 1.3   | :x:                |
 
@@ -74,11 +75,31 @@ The operator requires these elevated permissions:
 
 | ClusterRole | Purpose | Scoped Resources |
 |---|---|---|
-| `<ns>-kubernaut-agent-investigator` | Root-cause analysis across namespaces | Pods, Events, Deployments, ReplicaSets, Secrets (read-only) |
+| `<ns>-kubernaut-agent-investigator` | Cluster-wide read-only access for root-cause analysis | Core K8s (pods, deployments, secrets, events, RBAC, etc.), OCP platform (routes, SCCs, DeploymentConfigs, ImageStreams, Builds), OCP machine management (Machines, MachineSets, MachineConfigs, MCPs), OLM (CSVs, Subscriptions, InstallPlans, CatalogSources), admission webhooks, CRDs, PriorityClasses. See `internal/resources/rbac.go` for the full rule set. |
 | `<ns>-kubernaut-agent-client` | AIAnalysis service calls the KA service | Services (get/create on `kubernaut-agent-service`) |
 | `<ns>-signalprocessing-controller` | Watch Kubernetes events for signal ingestion | Events (cluster-wide, read-only) |
 | `<ns>-alertmanager-view` | EffectivenessMonitor reads Prometheus/AlertManager metrics | Created only when `monitoring.enabled=true` |
-| `<ns>-awx-integration` | WorkflowExecution talks to AWX/AAP | Created only when `ansible.enabled=true` |
+| `<ns>-workflowexecution-awx` | WorkflowExecution talks to AWX/AAP | AWX Jobs (CRUD). Created only when `ansible.enabled=true` |
+
+#### Investigator RBAC Risk Assessment
+
+The `kubernaut-agent-investigator` ClusterRole grants **read-only** access to a
+broad set of resources across 30+ API groups. Key security considerations:
+
+- **Cluster-wide secret read** (pre-existing): The agent can read all secrets
+  in all namespaces. This is required for cross-namespace root-cause analysis.
+- **RBAC topology read**: The agent can enumerate all Roles, ClusterRoles, and
+  their bindings. An attacker who compromises the agent pod could map the
+  entire cluster's principal-to-privilege chains.
+- **SCC read** (OCP): Exposes which SecurityContextConstraints exist and which
+  SAs are bound to privileged SCCs.
+- **MachineConfig read** (OCP): Exposes node-level configuration (ignition
+  snippets, kubelet config).
+
+These capabilities are equivalent to a **cluster auditor** tier — high-sensitivity
+read access with no write or escalation capability. The accepted risk boundary
+is: "compromise of the agent SA = full cluster read reconnaissance, but no
+mutation or data exfiltration beyond secret content."
 
 ## Disclosure Policy
 

--- a/docs/installation/02-configure-services.md
+++ b/docs/installation/02-configure-services.md
@@ -262,9 +262,21 @@ oc get configmap -n kubernaut-system \
 
 ## Additional RBAC for Kubernaut Agent
 
-By default, the operator creates a base `kubernaut-agent-investigator` ClusterRole
-covering well-known Kubernetes resources (pods, deployments, storage, networking,
-etc.). If your environment includes custom CRDs that the KA agent should be able
+By default, the operator creates a `kubernaut-agent-investigator` ClusterRole
+with **read-only** access to:
+
+- **Core Kubernetes**: Pods, Deployments, StatefulSets, DaemonSets, Jobs, Services,
+  Secrets, ConfigMaps, Events, RBAC (Roles/ClusterRoles/Bindings), PVCs, Ingresses,
+  NetworkPolicies, HPAs, PDBs, PriorityClasses, CRDs, admission webhooks
+- **OCP platform**: Routes, DeploymentConfigs, SecurityContextConstraints,
+  ImageStreams, Builds, ClusterOperators, ClusterVersions, Infrastructures
+- **OCP machine management**: Machines, MachineSets, MachineHealthChecks,
+  MachineConfigs, MachineConfigPools
+- **OLM**: ClusterServiceVersions, Subscriptions, InstallPlans, OperatorGroups,
+  CatalogSources, PackageManifests
+- **Ecosystem**: Istio, Linkerd, cert-manager, ArgoCD, Prometheus/monitoring
+
+If your environment includes custom CRDs that the KA agent should be able
 to investigate, use `spec.kubernautAgent.additionalClusterRoleBindings` to layer
 on pre-existing ClusterRoles:
 

--- a/docs/installation/03-deploy.md
+++ b/docs/installation/03-deploy.md
@@ -194,6 +194,33 @@ oc logs job/kubernaut-db-migration -n kubernaut-system
 
 Common causes: PostgreSQL not accepting connections, wrong credentials, database does not exist.
 
+**Agent RBAC / Permission Errors:**
+
+If the Kubernaut Agent exhausts tool call budgets on `403 Forbidden` errors during
+investigation, the agent SA may be missing required RBAC. Diagnose with:
+
+```bash
+# Check the investigator ClusterRole exists and has rules
+oc get clusterrole <ns>-kubernaut-agent-investigator -o yaml
+
+# Test specific access (e.g., SCCs)
+oc auth can-i list securitycontextconstraints \
+  --as=system:serviceaccount:kubernaut-system:kubernaut-agent-sa
+
+# Check the RBACProvisioned condition
+oc get kubernaut kubernaut -n kubernaut-system \
+  -o jsonpath='{.status.conditions[?(@.type=="RBACProvisioned")]}'
+```
+
+Common causes: operator SA lacks `escalate`/`bind` permissions (check the
+operator's own ClusterRole), manual edits to operator-managed ClusterRoles
+(the operator will overwrite on the next reconcile), or OLM permission
+conflicts with other operators managing the same ClusterRole names.
+
+If using `additionalClusterRoleBindings`, check the `AdditionalRBACBound`
+condition for `PartiallyBound` — one or more referenced ClusterRoles may
+not exist.
+
 **CR in Degraded:**
 
 One or more services are not ready. Check which:

--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -456,6 +456,26 @@ func kubernautAgentInvestigatorClusterRole(kn *kubernautv1alpha1.Kubernaut, labe
 		{APIGroups: []string{"monitoring.coreos.com"}, Resources: []string{"prometheusrules", "servicemonitors", "podmonitors", "probes"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"metrics.k8s.io"}, Resources: []string{"pods", "nodes"}, Verbs: []string{"get", "list"}},
 		{APIGroups: []string{"config.openshift.io"}, Resources: []string{"nodes", "clusteroperators", "clusterversions", "infrastructures"}, Verbs: []string{"get", "list", "watch"}},
+		// OCP: OLM
+		{APIGroups: []string{"operators.coreos.com"}, Resources: []string{"clusterserviceversions", "subscriptions", "installplans", "operatorgroups", "catalogsources", "operatorconditions"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"packages.operators.coreos.com"}, Resources: []string{"packagemanifests"}, Verbs: []string{"get", "list", "watch"}},
+		// OCP: networking, builds, images, legacy apps, SCCs
+		{APIGroups: []string{"route.openshift.io"}, Resources: []string{"routes"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"apps.openshift.io"}, Resources: []string{"deploymentconfigs"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"security.openshift.io"}, Resources: []string{"securitycontextconstraints"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"image.openshift.io"}, Resources: []string{"imagestreams", "imagestreamtags"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"build.openshift.io"}, Resources: []string{"builds", "buildconfigs"}, Verbs: []string{"get", "list", "watch"}},
+		// OCP: machine management
+		{APIGroups: []string{"machine.openshift.io"}, Resources: []string{"machines", "machinesets", "machinehealthchecks"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"machineconfiguration.openshift.io"}, Resources: []string{"machineconfigs", "machineconfigpools"}, Verbs: []string{"get", "list", "watch"}},
+		// OCP: quotas, network operator
+		{APIGroups: []string{"quota.openshift.io"}, Resources: []string{"clusterresourcequotas", "appliedclusterresourcequotas"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"network.operator.openshift.io"}, Resources: []string{"operatorpkis", "egressrouters"}, Verbs: []string{"get", "list", "watch"}},
+		// Core K8s: RBAC, admission, CRDs, scheduling
+		{APIGroups: []string{"rbac.authorization.k8s.io"}, Resources: []string{"roles", "rolebindings", "clusterroles", "clusterrolebindings"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"admissionregistration.k8s.io"}, Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"apiextensions.k8s.io"}, Resources: []string{"customresourcedefinitions"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"scheduling.k8s.io"}, Resources: []string{"priorityclasses"}, Verbs: []string{"get", "list", "watch"}},
 	}
 
 	return &rbacv1.ClusterRole{

--- a/internal/resources/rbac_test.go
+++ b/internal/resources/rbac_test.go
@@ -445,6 +445,50 @@ func TestKAInvestigator_HasServiceMeshAndGitOpsRules(t *testing.T) {
 	}
 }
 
+func TestKAInvestigator_HasOCPAndCoreK8sRules(t *testing.T) {
+	kn := testKubernaut()
+	roles := ClusterRoles(kn)
+	var investigator *rbacv1.ClusterRole
+	for _, r := range roles {
+		if r.Name == kn.Namespace+"-kubernaut-agent-investigator" {
+			investigator = r
+			break
+		}
+	}
+	if investigator == nil {
+		t.Fatal("kubernaut-agent-investigator ClusterRole not found")
+	}
+
+	wantGroups := []string{
+		"operators.coreos.com",
+		"packages.operators.coreos.com",
+		"route.openshift.io",
+		"apps.openshift.io",
+		"security.openshift.io",
+		"image.openshift.io",
+		"build.openshift.io",
+		"machine.openshift.io",
+		"machineconfiguration.openshift.io",
+		"quota.openshift.io",
+		"network.operator.openshift.io",
+		"rbac.authorization.k8s.io",
+		"admissionregistration.k8s.io",
+		"apiextensions.k8s.io",
+		"scheduling.k8s.io",
+	}
+	foundGroups := make(map[string]bool)
+	for _, rule := range investigator.Rules {
+		for _, g := range rule.APIGroups {
+			foundGroups[g] = true
+		}
+	}
+	for _, g := range wantGroups {
+		if !foundGroups[g] {
+			t.Errorf("kubernaut-agent-investigator missing API group %q", g)
+		}
+	}
+}
+
 func TestWorkflowRunner_HasMeshAndGitOpsRules(t *testing.T) {
 	kn := testKubernaut()
 	roles := ClusterRoles(kn)


### PR DESCRIPTION
## Summary

- Adds read-only RBAC to the `kubernaut-agent-investigator` ClusterRole for OCP-specific and core K8s API groups that the agent needs during incident investigation
- **OLM**: CSVs, Subscriptions, InstallPlans, OperatorGroups, CatalogSources, OperatorConditions, PackageManifests
- **OCP platform**: Routes, DeploymentConfigs, SecurityContextConstraints, ImageStreams, Builds, Machines, MachineSets, MachineConfigs, MachineConfigPools, ClusterResourceQuotas
- **Core K8s**: RBAC objects (roles, bindings), admission webhooks, CRDs, PriorityClasses

Without these, the agent exhausts its tool call budget on RBAC 403 errors when investigating OCP-specific incidents.

Closes #52

## Test plan

- [ ] CI passes (lint + unit tests)
- [ ] Deploy to OCP and verify the ClusterRole is updated
- [ ] Run `operator-health` (OperatorCSVFailed) scenario — agent can now read CSVs
- [ ] Run SCC-related scenario — agent can read SCCs and RBAC bindings


Made with [Cursor](https://cursor.com)