### PR TITLE
fix: address audit follow-ups from PR #53 (issues #54-#61)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Check coverage threshold
         run: |
+          # cover.out is produced by `make test` (Makefile: -coverprofile cover.out)
           grep 'internal/' cover.out > cover-internal.out || true
           echo "mode: set" | cat - cover-internal.out > cover-internal-final.out
           COVERAGE=$(go tool cover -func=cover-internal-final.out | grep '^total:' | awk '{print $3}' | tr -d '%')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,15 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - name: Check coverage threshold
+        run: |
+          grep 'internal/' cover.out > cover-internal.out || true
+          echo "mode: set" | cat - cover-internal.out > cover-internal-final.out
+          COVERAGE=$(go tool cover -func=cover-internal-final.out | grep '^total:' | awk '{print $3}' | tr -d '%')
+          echo "Internal package coverage: ${COVERAGE}%"
+          THRESHOLD=80
+          if [ "$(echo "${COVERAGE} < ${THRESHOLD}" | bc -l)" -eq 1 ]; then
+            echo "::error::Internal coverage ${COVERAGE}% is below the ${THRESHOLD}% threshold"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to the Kubernaut Operator will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.0] - Unreleased
+
+### Added
+- **RBAC**: Expanded `kubernaut-agent-investigator` ClusterRole with read-only
+  access to OCP and core K8s resources for incident investigation:
+  - OLM: CSVs, Subscriptions, InstallPlans, OperatorGroups, CatalogSources
+  - OCP platform: Routes, DeploymentConfigs, SCCs, ImageStreams, Builds
+  - OCP machine management: Machines, MachineSets, MachineConfigs, MCPs
+  - Core K8s: RBAC objects, admission webhooks, CRDs, PriorityClasses
+- **RBAC**: Added egress rules to `kubernaut-agent` NetworkPolicy for
+  API server and data-storage access when NetworkPolicies are enabled
+- **Security**: Agent deployment now uses projected service account tokens
+  with 1-hour TTL and audience binding instead of long-lived automounted tokens
+- **UX**: `RBACProvisioned` condition now set to `False` with descriptive
+  message when RBAC provisioning fails, plus Warning Event emitted
+- **UX**: `AdditionalRBACBound` condition now uses `Status=False` when
+  referenced ClusterRoles do not exist (was incorrectly `True`)
+- **CI**: Coverage threshold enforcement (80% minimum) in test workflow
+- **Docs**: RBAC troubleshooting section in deployment guide
+- **Docs**: Agent cluster access summary in OLM CSV description
+- **Docs**: `SECURITY.md` investigator risk assessment section
+- **Docs**: `CHANGELOG.md` established for tracking security-relevant changes
+
+### Fixed
+- **Docs**: Corrected AWX ClusterRole name in `SECURITY.md`
+  (`<ns>-awx-integration` → `<ns>-workflowexecution-awx`)
+- **Docs**: Updated stale test plan entries (test counts, verb descriptions,
+  CI coverage claims)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - OCP machine management: Machines, MachineSets, MachineConfigs, MCPs
   - Core K8s: RBAC objects, admission webhooks, CRDs, PriorityClasses
 - **RBAC**: Added egress rules to `kubernaut-agent` NetworkPolicy for
-  API server and data-storage access when NetworkPolicies are enabled
+  API server, data-storage, and monitoring stack (Thanos Querier TCP 9091,
+  AlertManager TCP 9094) access when NetworkPolicies are enabled
 - **Security**: Agent deployment now uses projected service account tokens
   with 1-hour TTL and audience binding instead of long-lived automounted tokens
 - **UX**: `RBACProvisioned` condition now set to `False` with descriptive

--- a/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
@@ -119,6 +119,21 @@ spec:
     - LLM API credentials (e.g., OpenAI API key) in a Secret
     - Rego policy ConfigMaps for AI analysis and signal processing
 
+    ### Cluster Access
+
+    The operator provisions a `kubernaut-agent-investigator` ClusterRole with
+    **read-only** cluster-wide access for root-cause analysis:
+
+    - **Core Kubernetes**: pods, deployments, secrets, events, RBAC, CRDs, webhooks
+    - **OCP platform**: routes, SCCs, DeploymentConfigs, ImageStreams, Builds
+    - **OCP machine management**: Machines, MachineSets, MachineConfigs
+    - **OLM**: CSVs, Subscriptions, InstallPlans, CatalogSources
+    - **Ecosystem**: Istio, Linkerd, cert-manager, ArgoCD, Prometheus
+
+    Use `spec.kubernautAgent.additionalClusterRoleBindings` to extend the agent's
+    access to custom CRDs. See [SECURITY.md](https://github.com/jordigilh/kubernaut-operator/blob/main/SECURITY.md)
+    for full per-ClusterRole justification and risk assessment.
+
     ### Getting Started
 
     1. Create the required BYO secrets (PostgreSQL, Valkey, LLM credentials)

--- a/docs/test-plans/kubernaut-operator-test-plan.md
+++ b/docs/test-plans/kubernaut-operator-test-plan.md
@@ -276,7 +276,7 @@ Each feature maps to a business outcome the operator must deliver.
 |-------|-------|
 | Precondition | Resource builders invoked |
 | Steps | 1. Inspect ClusterRole rules |
-| Expected | data-storage-client has only get/list (no create/delete); workflow-runner has no cluster-wide secrets access |
+| Expected | data-storage-client has create/get/list/update/delete scoped to named resources; workflow-runner has no cluster-wide secrets access |
 | Tests | `TestClusterRoles_ContainsExpectedNames`, `TestDataStorageClientRoleBindings_AllRefClusterRole`, lifecycle builder edge case tests |
 
 #### TC-T3-03: Workflow Runner Scoped Access
@@ -296,6 +296,15 @@ Each feature maps to a business outcome the operator must deliver.
 | Steps | 1. Inspect names |
 | Expected | Names are `<namespace>-authwebhook-mutating` and `<namespace>-authwebhook-validating` |
 | Tests | `TestMutatingWebhookConfiguration_Basic`, `TestValidatingWebhookConfiguration_Basic` |
+
+#### TC-T3-05: Investigator OCP/Platform Rule Completeness
+
+| Field | Value |
+|-------|-------|
+| Precondition | Resource builders invoked |
+| Steps | 1. Inspect kubernaut-agent-investigator ClusterRole rules |
+| Expected | All required OCP API groups present: operators.coreos.com, packages.operators.coreos.com, route.openshift.io, apps.openshift.io, security.openshift.io, image.openshift.io, build.openshift.io, machine.openshift.io, machineconfiguration.openshift.io, quota.openshift.io, network.operator.openshift.io. All core K8s meta groups present: rbac.authorization.k8s.io, admissionregistration.k8s.io, apiextensions.k8s.io, scheduling.k8s.io |
+| Tests | `TestKAInvestigator_HasOCPAndCoreK8sRules` |
 
 ### 6.4 Tier 4: Resource Builders
 
@@ -443,8 +452,8 @@ go test ./test/e2e/... -v -count=1
 Tests are executed on every pull request via GitHub Actions. The pipeline:
 1. Runs `go build ./...`
 2. Runs unit + integration tests with coverage
-3. Fails the build if coverage drops below thresholds
-4. Runs e2e tests against a Kind cluster (when Docker is available)
+3. Enforces minimum coverage thresholds (80% combined)
+4. E2E tests run via manual `workflow_dispatch` against a real OCP cluster
 
 ---
 
@@ -544,7 +553,7 @@ Tests are executed on every pull request via GitHub Actions. The pipeline:
 
 | File | Tests | Coverage |
 |------|-------|---------|
-| `rbac_test.go` | 18 | ClusterRoles, CRBs, DataStorage bindings, Namespace roles, Workflow NS, Ansible, Monitoring, Kubernaut Agent client RB, Monitoring name enumerators |
+| `rbac_test.go` | 30 | ClusterRoles, CRBs, DataStorage bindings, Namespace roles, Workflow NS, Ansible, Monitoring, Kubernaut Agent client RB, Monitoring name enumerators, Investigator OCP/K8s rules, Additional agent CRB |
 | `deployments_test.go` | 20+ | All 10 deployment builders, image construction, volume mounts, volume source CM accuracy, security contexts |
 | `configmaps_test.go` | 19+ | All ConfigMap builders, default values, YAML formatting, default Rego policies, Slack absence |
 | `common_test.go` | 19+ | Labels, selectors, Image(), ObjectMeta, ValkeyAddr, MergeResources, SetOwnerReference, ServiceAccountName fallback, intPtrDefault |

--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -79,6 +79,7 @@ const (
 	ReasonAnsibleTokenNotFound   = "TokenSecretNotFound"
 	ReasonAnsibleTokenKeyMissing = "TokenKeyMissing"
 
+	ReasonRBACApplyFailed            = "RBACApplyFailed"
 	ReasonAdditionalRBACFullyBound   = "FullyBound"
 	ReasonAdditionalRBACPartialBound = "PartiallyBound"
 )
@@ -363,11 +364,11 @@ func (r *KubernautReconciler) phaseDeploy(ctx context.Context, kn *kubernautv1al
 		_ = r.patchStatus(ctx, kn, func() {
 			meta.SetStatusCondition(&kn.Status.Conditions, metav1.Condition{
 				Type: kubernautv1alpha1.ConditionRBACProvisioned, Status: metav1.ConditionFalse,
-				Reason: "RBACApplyFailed", Message: err.Error(),
+				Reason: ReasonRBACApplyFailed, Message: err.Error(),
 				ObservedGeneration: kn.Generation,
 			})
 		})
-		r.Recorder.Eventf(kn, nil, corev1.EventTypeWarning, "RBACApplyFailed", "Reconcile",
+		r.Recorder.Eventf(kn, nil, corev1.EventTypeWarning, ReasonRBACApplyFailed, "Reconcile",
 			"Failed to provision RBAC: %v", err)
 		return err
 	}

--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -360,6 +360,15 @@ func (r *KubernautReconciler) phaseDeploy(ctx context.Context, kn *kubernautv1al
 		return err
 	}
 	if err := r.deployRBAC(ctx, kn); err != nil {
+		_ = r.patchStatus(ctx, kn, func() {
+			meta.SetStatusCondition(&kn.Status.Conditions, metav1.Condition{
+				Type: kubernautv1alpha1.ConditionRBACProvisioned, Status: metav1.ConditionFalse,
+				Reason: "RBACApplyFailed", Message: err.Error(),
+				ObservedGeneration: kn.Generation,
+			})
+		})
+		r.Recorder.Eventf(kn, nil, corev1.EventTypeWarning, "RBACApplyFailed", "Reconcile",
+			"Failed to provision RBAC: %v", err)
 		return err
 	}
 
@@ -552,13 +561,14 @@ func (r *KubernautReconciler) deployAdditionalAgentRBAC(ctx context.Context, kn 
 
 		cond := metav1.Condition{
 			Type:               kubernautv1alpha1.ConditionAdditionalRBACBound,
-			Status:             metav1.ConditionTrue,
 			ObservedGeneration: kn.Generation,
 		}
 		if len(missingRoles) > 0 {
+			cond.Status = metav1.ConditionFalse
 			cond.Reason = ReasonAdditionalRBACPartialBound
 			cond.Message = fmt.Sprintf("CRBs created but ClusterRoles not found: %v", missingRoles)
 		} else {
+			cond.Status = metav1.ConditionTrue
 			cond.Reason = ReasonAdditionalRBACFullyBound
 			cond.Message = fmt.Sprintf("%d additional ClusterRoleBindings active", len(desiredSet))
 		}

--- a/internal/controller/kubernaut_lifecycle_test.go
+++ b/internal/controller/kubernaut_lifecycle_test.go
@@ -56,6 +56,27 @@ func (c *deleteFailingClient) Delete(ctx context.Context, obj client.Object, opt
 	return c.Client.Delete(ctx, obj, opts...)
 }
 
+// rbacCreateFailingClient wraps a real client but returns an error on
+// Create and Update calls for ClusterRole objects, simulating an RBAC
+// provisioning failure during the deploy phase.
+type rbacCreateFailingClient struct {
+	client.Client
+}
+
+func (c *rbacCreateFailingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if _, ok := obj.(*rbacv1.ClusterRole); ok {
+		return fmt.Errorf("simulated: forbidden creating ClusterRole %s", obj.GetName())
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c *rbacCreateFailingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*rbacv1.ClusterRole); ok {
+		return fmt.Errorf("simulated: forbidden updating ClusterRole %s", obj.GetName())
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
 // markMigrationJobComplete creates or patches the migration Job to have a
 // JobComplete condition, allowing the reconciler to proceed past phaseMigrate.
 func markMigrationJobComplete(ctx context.Context) {
@@ -1976,6 +1997,100 @@ var _ = Describe("Kubernaut Lifecycle", func() {
 				}
 			}
 			Expect(collected).To(ContainElement(ContainSubstring("Warning FinalizerTimeout")))
+		})
+	})
+
+	// ======================================================================
+	// RBAC Condition Accuracy
+	// ======================================================================
+
+	Context("RBAC Condition Accuracy", func() {
+		BeforeEach(func() {
+			deleteCRIfExists(ctx)
+			cleanupNamespacedResources(ctx)
+			deleteBYOSecrets(ctx)
+			cleanupClusterScoped(ctx)
+		})
+		AfterEach(func() {
+			deleteCRIfExists(ctx)
+			cleanupNamespacedResources(ctx)
+			cleanupClusterScoped(ctx)
+		})
+
+		It("should set RBACProvisioned=False when RBAC apply fails", func() {
+			createBYOSecrets(ctx)
+			Expect(k8sClient.Create(ctx, newCRWithRouteDisabled())).To(Succeed())
+
+			r := newReconciler()
+			By("reconcile 1: add finalizer")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: singletonKey()})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("reconcile 2: validate + start migration")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: singletonKey()})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("marking migration Job complete")
+			markMigrationJobComplete(ctx)
+
+			By("injecting a client that fails on ClusterRole create/update")
+			r.Client = &rbacCreateFailingClient{Client: k8sClient}
+
+			By("reconcile 3: migration complete + deploy — RBAC should fail")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: singletonKey()})
+			Expect(err).To(HaveOccurred())
+
+			By("restoring real client to read status")
+			r.Client = k8sClient
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionRBACProvisioned)
+			Expect(cond).NotTo(BeNil(), "RBACProvisioned condition should exist")
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(ReasonRBACApplyFailed))
+		})
+
+		It("should set AdditionalRBACBound=False when referenced ClusterRoles do not exist", func() {
+			createBYOSecrets(ctx)
+			cr := newCRWithRouteDisabled()
+			cr.Spec.KubernautAgent.AdditionalClusterRoleBindings = []string{"nonexistent-cluster-role"}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToDeployPhase(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAdditionalRBACBound)
+			Expect(cond).NotTo(BeNil(), "AdditionalRBACBound condition should exist")
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(ReasonAdditionalRBACPartialBound))
+			Expect(cond.Message).To(ContainSubstring("nonexistent-cluster-role"))
+		})
+
+		It("should set AdditionalRBACBound=True when referenced ClusterRoles exist", func() {
+			createBYOSecrets(ctx)
+			existingCR := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-extra-role"},
+				Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}},
+			}
+			Expect(k8sClient.Create(ctx, existingCR)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, existingCR) }()
+
+			cr := newCRWithRouteDisabled()
+			cr.Spec.KubernautAgent.AdditionalClusterRoleBindings = []string{"test-extra-role"}
+			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+			reconcileToDeployPhase(ctx)
+
+			kn := &kubernautv1alpha1.Kubernaut{}
+			Expect(k8sClient.Get(ctx, singletonKey(), kn)).To(Succeed())
+
+			cond := findCondition(kn.Status.Conditions, kubernautv1alpha1.ConditionAdditionalRBACBound)
+			Expect(cond).NotTo(BeNil(), "AdditionalRBACBound condition should exist")
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(ReasonAdditionalRBACFullyBound))
 		})
 	})
 

--- a/internal/controller/kubernaut_lifecycle_test.go
+++ b/internal/controller/kubernaut_lifecycle_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -59,6 +60,8 @@ func (c *deleteFailingClient) Delete(ctx context.Context, obj client.Object, opt
 // rbacCreateFailingClient wraps a real client but returns an error on
 // Create and Update calls for ClusterRole objects, simulating an RBAC
 // provisioning failure during the deploy phase.
+// Note: ensureResource uses Create/Update, not Patch, for ClusterRoles.
+// If that changes, this mock must also override Patch.
 type rbacCreateFailingClient struct {
 	client.Client
 }
@@ -2049,6 +2052,27 @@ var _ = Describe("Kubernaut Lifecycle", func() {
 			Expect(cond).NotTo(BeNil(), "RBACProvisioned condition should exist")
 			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 			Expect(cond.Reason).To(Equal(ReasonRBACApplyFailed))
+
+			By("verifying Warning event was emitted")
+			recorder := r.Recorder.(*events.FakeRecorder)
+			var collected []string
+		drainRBAC:
+			for {
+				select {
+				case ev := <-recorder.Events:
+					collected = append(collected, ev)
+				default:
+					break drainRBAC
+				}
+			}
+			found := false
+			for _, ev := range collected {
+				if strings.Contains(ev, "RBACApplyFailed") && strings.Contains(ev, "Warning") {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "expected Warning RBACApplyFailed event, got: %v", collected)
 		})
 
 		It("should set AdditionalRBACBound=False when referenced ClusterRoles do not exist", func() {

--- a/internal/resources/deployments.go
+++ b/internal/resources/deployments.go
@@ -497,6 +497,9 @@ func KubernautAgentDeployment(kn *kubernautv1alpha1.Kubernaut) (*appsv1.Deployme
 		})
 	}
 
+	// Projected SA token with short TTL replaces the default automounted token.
+	// Requires AutomountServiceAccountToken=false on the kubernaut-agent-sa
+	// ServiceAccount (see serviceaccounts.go).
 	volumes = append(volumes, corev1.Volume{
 		Name: "sa-token",
 		VolumeSource: corev1.VolumeSource{

--- a/internal/resources/deployments.go
+++ b/internal/resources/deployments.go
@@ -497,6 +497,39 @@ func KubernautAgentDeployment(kn *kubernautv1alpha1.Kubernaut) (*appsv1.Deployme
 		})
 	}
 
+	volumes = append(volumes, corev1.Volume{
+		Name: "sa-token",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Path:              "token",
+							ExpirationSeconds: ptr.To[int64](3600),
+							Audience:          "https://kubernetes.default.svc",
+						},
+					},
+					{
+						ConfigMap: &corev1.ConfigMapProjection{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "kube-root-ca.crt"},
+							Items:                []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+						},
+					},
+					{
+						DownwardAPI: &corev1.DownwardAPIProjection{
+							Items: []corev1.DownwardAPIVolumeFile{
+								{Path: "namespace", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	mounts = append(mounts, corev1.VolumeMount{
+		Name: "sa-token", MountPath: "/var/run/secrets/kubernetes.io/serviceaccount", ReadOnly: true,
+	})
+
 	return buildDeployment(kn, DeploymentParams{
 		Component: ComponentKubernautAgent, ImageName: "kubernautagent",
 		Resources: res, VolumeMounts: mounts, Volumes: volumes, Env: envVars,

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -303,6 +303,9 @@ func kubernautAgentNetworkPolicy(kn *kubernautv1alpha1.Kubernaut) *networkingv1.
 		egress = append(egress, *r)
 	}
 	egress = append(egress, datastorageEgressRule())
+	if spec.MonitoringNamespace != "" {
+		egress = append(egress, monitoringStackEgressRule(spec.MonitoringNamespace))
+	}
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: ObjectMeta(kn, ComponentKubernautAgent+"-netpol", ComponentKubernautAgent),
@@ -470,6 +473,24 @@ func metricsIngressRule(monitoringNS string) *networkingv1.NetworkPolicyIngressR
 		},
 		Ports: []networkingv1.NetworkPolicyPort{
 			{Protocol: &protoTCP, Port: &p9090},
+		},
+	}
+}
+
+// monitoringStackEgressRule allows TCP 9091 (Thanos Querier) and TCP 9094
+// (AlertManager) to pods in the monitoring namespace. The agent uses these
+// for Prometheus metric queries and alert correlation.
+func monitoringStackEgressRule(monitoringNS string) networkingv1.NetworkPolicyEgressRule {
+	protoTCP := corev1.ProtocolTCP
+	p9091 := intstr.FromInt32(9091)
+	p9094 := intstr.FromInt32(9094)
+	return networkingv1.NetworkPolicyEgressRule{
+		To: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: namespaceNameSelector(monitoringNS)},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &protoTCP, Port: &p9091},
+			{Protocol: &protoTCP, Port: &p9094},
 		},
 	}
 }

--- a/internal/resources/networkpolicies.go
+++ b/internal/resources/networkpolicies.go
@@ -298,14 +298,22 @@ func kubernautAgentNetworkPolicy(kn *kubernautv1alpha1.Kubernaut) *networkingv1.
 		ingress = append(ingress, *m)
 	}
 
+	egress := []networkingv1.NetworkPolicyEgressRule{dnsEgressRule()}
+	if r := apiServerEgressRule(spec.APIServerCIDR); r != nil {
+		egress = append(egress, *r)
+	}
+	egress = append(egress, datastorageEgressRule())
+
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: ObjectMeta(kn, ComponentKubernautAgent+"-netpol", ComponentKubernautAgent),
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: SelectorLabels(ComponentKubernautAgent)},
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
 			},
 			Ingress: ingress,
+			Egress:  egress,
 		},
 	}
 }

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -126,9 +126,47 @@ func TestNetworkPolicies_KubernautAgentIngressAndEgress(t *testing.T) {
 	if len(agentNP.Spec.Ingress) < 1 {
 		t.Fatalf("kubernaut-agent ingress rule count = %d, want at least 1", len(agentNP.Spec.Ingress))
 	}
-	// Without APIServerCIDR in test fixture: DNS + data-storage egress only.
+	// Without APIServerCIDR or MonitoringNamespace: DNS + data-storage egress only.
 	if want, got := 2, len(agentNP.Spec.Egress); got != want {
 		t.Errorf("kubernaut-agent egress rule count = %d, want %d", got, want)
+	}
+}
+
+func TestNetworkPolicies_KubernautAgentMonitoringEgress(t *testing.T) {
+	kn := testKubernaut()
+	enabled := true
+	kn.Spec.NetworkPolicies.Enabled = &enabled
+	kn.Spec.NetworkPolicies.MonitoringNamespace = OCPMonitoringNamespace
+	var agentNP *networkingv1.NetworkPolicy
+	for _, np := range NetworkPolicies(kn) {
+		if np.Name == ComponentKubernautAgent+"-netpol" {
+			agentNP = np
+			break
+		}
+	}
+	if agentNP == nil {
+		t.Fatal("kubernaut-agent NetworkPolicy not found")
+	}
+	// With MonitoringNamespace: DNS + data-storage + monitoring egress.
+	if want, got := 3, len(agentNP.Spec.Egress); got != want {
+		t.Fatalf("kubernaut-agent egress rule count = %d, want %d", got, want)
+	}
+	monRule := agentNP.Spec.Egress[2]
+	if len(monRule.To) != 1 {
+		t.Fatalf("monitoring egress peer count = %d, want 1", len(monRule.To))
+	}
+	ns := monRule.To[0].NamespaceSelector
+	if ns == nil || ns.MatchLabels["kubernetes.io/metadata.name"] != OCPMonitoringNamespace {
+		t.Errorf("monitoring egress namespace selector = %v, want %s", ns, OCPMonitoringNamespace)
+	}
+	if len(monRule.Ports) != 2 {
+		t.Fatalf("monitoring egress port count = %d, want 2", len(monRule.Ports))
+	}
+	if monRule.Ports[0].Port.IntValue() != 9091 {
+		t.Errorf("monitoring egress port[0] = %d, want 9091 (Thanos)", monRule.Ports[0].Port.IntValue())
+	}
+	if monRule.Ports[1].Port.IntValue() != 9094 {
+		t.Errorf("monitoring egress port[1] = %d, want 9094 (AlertManager)", monRule.Ports[1].Port.IntValue())
 	}
 }
 
@@ -189,7 +227,7 @@ func TestNetworkPolicies_MetricsIngress(t *testing.T) {
 	kn := testKubernaut()
 	enabled := true
 	kn.Spec.NetworkPolicies.Enabled = &enabled
-	kn.Spec.NetworkPolicies.MonitoringNamespace = "openshift-monitoring"
+	kn.Spec.NetworkPolicies.MonitoringNamespace = OCPMonitoringNamespace
 	var dsNP *networkingv1.NetworkPolicy
 	for _, np := range NetworkPolicies(kn) {
 		if np.Name == ComponentDataStorage+"-netpol" {
@@ -207,7 +245,7 @@ func TestNetworkPolicies_MetricsIngress(t *testing.T) {
 		nsOK := false
 		for _, peer := range rule.From {
 			if peer.NamespaceSelector != nil && peer.NamespaceSelector.MatchLabels != nil &&
-				peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == "openshift-monitoring" {
+				peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == OCPMonitoringNamespace {
 				nsOK = true
 				break
 			}

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -102,7 +102,7 @@ func TestNetworkPolicies_GatewayIngress(t *testing.T) {
 	}
 }
 
-func TestNetworkPolicies_KubernautAgentIngressOnly(t *testing.T) {
+func TestNetworkPolicies_KubernautAgentIngressAndEgress(t *testing.T) {
 	kn := testKubernaut()
 	enabled := true
 	kn.Spec.NetworkPolicies.Enabled = &enabled
@@ -116,11 +116,19 @@ func TestNetworkPolicies_KubernautAgentIngressOnly(t *testing.T) {
 	if agentNP == nil {
 		t.Fatal("kubernaut-agent NetworkPolicy not found")
 	}
-	if !slices.Equal(agentNP.Spec.PolicyTypes, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}) {
-		t.Errorf("PolicyTypes = %v, want [Ingress] only", agentNP.Spec.PolicyTypes)
+	wantTypes := []networkingv1.PolicyType{
+		networkingv1.PolicyTypeIngress,
+		networkingv1.PolicyTypeEgress,
 	}
-	if len(agentNP.Spec.Egress) > 0 {
-		t.Errorf("kubernaut-agent NP should have no Egress rules, got %d", len(agentNP.Spec.Egress))
+	if !slices.Equal(agentNP.Spec.PolicyTypes, wantTypes) {
+		t.Errorf("PolicyTypes = %v, want %v", agentNP.Spec.PolicyTypes, wantTypes)
+	}
+	if len(agentNP.Spec.Ingress) < 1 {
+		t.Fatalf("kubernaut-agent ingress rule count = %d, want at least 1", len(agentNP.Spec.Ingress))
+	}
+	// Without APIServerCIDR in test fixture: DNS + data-storage egress only.
+	if want, got := 2, len(agentNP.Spec.Egress); got != want {
+		t.Errorf("kubernaut-agent egress rule count = %d, want %d", got, want)
 	}
 }
 

--- a/internal/resources/serviceaccounts.go
+++ b/internal/resources/serviceaccounts.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	kubernautv1alpha1 "github.com/jordigilh/kubernaut-operator/api/v1alpha1"
 )
@@ -47,9 +48,13 @@ func ServiceAccountName(component string) string {
 
 // ServiceAccount builds a ServiceAccount for the given component.
 func ServiceAccount(kn *kubernautv1alpha1.Kubernaut, component string) *corev1.ServiceAccount {
-	return &corev1.ServiceAccount{
+	sa := &corev1.ServiceAccount{
 		ObjectMeta: ObjectMeta(kn, ServiceAccountName(component), component),
 	}
+	if component == ComponentKubernautAgent {
+		sa.AutomountServiceAccountToken = ptr.To(false)
+	}
+	return sa
 }
 
 // WorkflowRunnerServiceAccount returns the SA used by workflow Jobs/PipelineRuns


### PR DESCRIPTION
## Summary

Consolidates all 8 follow-up issues from the comprehensive readiness audit on PR #53 into a single PR:

- **QE (#54, #55)**: Fix stale test plan entries (counts, verbs, CI claims) and enforce 80% coverage threshold in CI
- **Product (#56, #57)**: Add agent cluster access summary to OLM CSV description; establish `CHANGELOG.md`
- **UX (#58, #59)**: Set `RBACProvisioned=False` + Warning Event on RBAC failure; fix `AdditionalRBACBound` to use `Status=False` when ClusterRoles are missing
- **Security (#60, #61)**: Add egress rules to kubernaut-agent NetworkPolicy; use projected SA token volumes with 1h TTL

Closes #54, #55, #56, #57, #58, #59, #60, #61

## Changes

| Issue | Area | Change |
|-------|------|--------|
| #54 | QE | Test plan: fix rbac_test count (18→30), data-storage-client verbs, CI coverage claim, add TC-T3-05 |
| #55 | QE | `.github/workflows/test.yml`: add coverage threshold check step (80% minimum) |
| #56 | Product | CSV `spec.description`: add "Cluster Access" section listing agent's read-only scope |
| #57 | Product | Create `CHANGELOG.md` (Keep a Changelog format) |
| #58 | UX | Controller: set `RBACProvisioned=False` with message + emit Warning Event on `deployRBAC` failure |
| #59 | UX | Controller: `AdditionalRBACBound` uses `Status=False` when referenced ClusterRoles not found |
| #60 | Security | `kubernautAgentNetworkPolicy`: add DNS + API server + data-storage egress rules |
| #61 | Security | Agent deployment: projected SA token volume (1h TTL, audience-bound); disable automount on SA |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/resources/... -count=1` passes (all 160+ unit tests)
- [x] NetworkPolicy test updated for new egress rules
- [ ] `go test ./internal/controller/... -count=1` (integration tests)
- [ ] CI pipeline passes on PR


Made with [Cursor](https://cursor.com)