### PR TITLE
test: migrate internal/resources tests to Ginkgo/Gomega

### DIFF
--- a/internal/resources/common_test.go
+++ b/internal/resources/common_test.go
@@ -18,7 +18,9 @@ package resources
 
 import (
 	"os"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,13 +32,6 @@ import (
 )
 
 const testSystemNamespace = "kubernaut-system"
-
-func TestMain(m *testing.M) {
-	cleanup := setTestRelatedImages()
-	code := m.Run()
-	cleanup()
-	os.Exit(code)
-}
 
 func testKubernaut() *kubernautv1alpha1.Kubernaut {
 	return &kubernautv1alpha1.Kubernaut{
@@ -75,315 +70,217 @@ func testKubernaut() *kubernautv1alpha1.Kubernaut {
 	}
 }
 
-// setTestRelatedImages sets RELATED_IMAGE env vars for all components
-// so that ResolveImage works in tests. Call cleanup() when done.
-func setTestRelatedImages() (cleanup func()) {
-	envs := map[string]string{
-		"RELATED_IMAGE_GATEWAY":                 "quay.io/kubernaut-ai/gateway:v1.3.0",
-		"RELATED_IMAGE_DATA_STORAGE":            "quay.io/kubernaut-ai/datastorage:v1.3.0",
-		"RELATED_IMAGE_AIANALYSIS":              "quay.io/kubernaut-ai/aianalysis:v1.3.0",
-		"RELATED_IMAGE_SIGNALPROCESSING":        "quay.io/kubernaut-ai/signalprocessing:v1.3.0",
-		"RELATED_IMAGE_REMEDIATIONORCHESTRATOR": "quay.io/kubernaut-ai/remediationorchestrator:v1.3.0",
-		"RELATED_IMAGE_WORKFLOWEXECUTION":       "quay.io/kubernaut-ai/workflowexecution:v1.3.0",
-		"RELATED_IMAGE_EFFECTIVENESSMONITOR":    "quay.io/kubernaut-ai/effectivenessmonitor:v1.3.0",
-		"RELATED_IMAGE_NOTIFICATION":            "quay.io/kubernaut-ai/notification:v1.3.0",
-		"RELATED_IMAGE_KUBERNAUT_AGENT":         "quay.io/kubernaut-ai/kubernautagent:v1.3.0",
-		"RELATED_IMAGE_AUTHWEBHOOK":             "quay.io/kubernaut-ai/authwebhook:v1.3.0",
-		"RELATED_IMAGE_DB_MIGRATE":              "quay.io/kubernaut-ai/db-migrate:v1.3.0",
-	}
-	for k, v := range envs {
-		if err := os.Setenv(k, v); err != nil {
-			panic(err)
+var _ = Describe("ResolveImage", func() {
+	It("resolves from env var", func() {
+		kn := testKubernaut()
+		got, err := ResolveImage(kn, "gateway")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal("quay.io/kubernaut-ai/gateway:v1.3.0"))
+	})
+
+	It("prefers override over env var", func() {
+		kn := testKubernaut()
+		kn.Spec.Image.Overrides = map[string]string{
+			"gateway": "myregistry.internal/custom-gateway:v2.0.0",
 		}
-	}
-	return func() {
-		for k := range envs {
-			if err := os.Unsetenv(k); err != nil {
-				panic(err)
-			}
-		}
-	}
-}
+		got, err := ResolveImage(kn, "gateway")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal("myregistry.internal/custom-gateway:v2.0.0"))
+	})
 
-func TestResolveImage_FromEnvVar(t *testing.T) {
-	kn := testKubernaut()
-	got, err := ResolveImage(kn, "gateway")
-	if err != nil {
-		t.Fatalf("ResolveImage() unexpected error: %v", err)
-	}
-	want := "quay.io/kubernaut-ai/gateway:v1.3.0"
-	if got != want {
-		t.Errorf("ResolveImage() = %q, want %q", got, want)
-	}
-}
-
-func TestResolveImage_OverrideTakesPrecedence(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Image.Overrides = map[string]string{
-		"gateway": "myregistry.internal/custom-gateway:v2.0.0",
-	}
-	got, err := ResolveImage(kn, "gateway")
-	if err != nil {
-		t.Fatalf("ResolveImage() unexpected error: %v", err)
-	}
-	want := "myregistry.internal/custom-gateway:v2.0.0"
-	if got != want {
-		t.Errorf("ResolveImage() = %q, want %q", got, want)
-	}
-}
-
-func TestResolveImage_NoEnvVar_ReturnsError(t *testing.T) {
-	t.Setenv("RELATED_IMAGE_GATEWAY", "")
-
-	kn := testKubernaut()
-	_, err := ResolveImage(kn, "gateway")
-	if err == nil {
-		t.Error("ResolveImage() should return error when no env var and no override")
-	}
-}
-
-func TestResolveImage_AllComponents(t *testing.T) {
-	kn := testKubernaut()
-	components := []string{
-		"gateway", "datastorage", "aianalysis", "signalprocessing",
-		"remediationorchestrator", "workflowexecution", "effectivenessmonitor",
-		"notification", "kubernautagent", "authwebhook",
-	}
-	for _, c := range components {
-		_, err := ResolveImage(kn, c)
-		if err != nil {
-			t.Errorf("ResolveImage(%q) unexpected error: %v", c, err)
-		}
-	}
-}
-
-func TestResolveImage_MigrationUsesDbMigrateImage(t *testing.T) {
-	kn := testKubernaut()
-	got, err := ResolveImage(kn, "db-migrate")
-	if err != nil {
-		t.Fatalf("ResolveImage(db-migrate) unexpected error: %v", err)
-	}
-	want := "quay.io/kubernaut-ai/db-migrate:v1.3.0"
-	if got != want {
-		t.Errorf("ResolveImage(db-migrate) = %q, want %q", got, want)
-	}
-}
-
-func TestCommonLabels(t *testing.T) {
-	kn := testKubernaut()
-	labels := CommonLabels(kn)
-
-	checks := map[string]string{
-		"app.kubernetes.io/managed-by": "kubernaut-operator",
-		"app.kubernetes.io/part-of":    "kubernaut",
-		"app.kubernetes.io/instance":   "kubernaut",
-	}
-	for k, want := range checks {
-		if got := labels[k]; got != want {
-			t.Errorf("CommonLabels[%q] = %q, want %q", k, got, want)
-		}
-	}
-}
-
-func TestComponentLabels_IncludesAppLabel(t *testing.T) {
-	kn := testKubernaut()
-	labels := ComponentLabels(kn, ComponentGateway)
-
-	if got := labels["app"]; got != ComponentGateway {
-		t.Errorf("ComponentLabels[app] = %q, want %q", got, ComponentGateway)
-	}
-	if got := labels["app.kubernetes.io/component"]; got != ComponentGateway {
-		t.Errorf("ComponentLabels[component] = %q, want %q", got, ComponentGateway)
-	}
-	if _, ok := labels["app.kubernetes.io/managed-by"]; !ok {
-		t.Error("ComponentLabels should include common labels")
-	}
-}
-
-func TestSelectorLabels(t *testing.T) {
-	labels := SelectorLabels(ComponentGateway)
-	if len(labels) != 1 {
-		t.Fatalf("SelectorLabels should have exactly 1 key, got %d", len(labels))
-	}
-	if got := labels["app"]; got != ComponentGateway {
-		t.Errorf("SelectorLabels[app] = %q, want %q", got, ComponentGateway)
-	}
-}
-
-func TestObjectMeta_NamespaceAndLabels(t *testing.T) {
-	kn := testKubernaut()
-	om := ObjectMeta(kn, "gateway-config", ComponentGateway)
-
-	if om.Name != "gateway-config" {
-		t.Errorf("ObjectMeta.Name = %q, want %q", om.Name, "gateway-config")
-	}
-	if om.Namespace != testSystemNamespace {
-		t.Errorf("ObjectMeta.Namespace = %q, want %q", om.Namespace, testSystemNamespace)
-	}
-	if om.Labels["app"] != ComponentGateway {
-		t.Errorf("ObjectMeta.Labels[app] = %q, want %q", om.Labels["app"], ComponentGateway)
-	}
-}
-
-func TestDataStorageURL(t *testing.T) {
-	got := DataStorageURL(testSystemNamespace)
-	want := "https://data-storage-service.kubernaut-system.svc.cluster.local:8080"
-	if got != want {
-		t.Errorf("DataStorageURL() = %q, want %q", got, want)
-	}
-}
-
-func TestGatewayURL(t *testing.T) {
-	got := GatewayURL(testSystemNamespace)
-	want := "https://gateway-service.kubernaut-system.svc.cluster.local:8080"
-	if got != want {
-		t.Errorf("GatewayURL() = %q, want %q", got, want)
-	}
-}
-
-func TestInterServiceTLSCAFile_MatchesOCPServiceCA(t *testing.T) {
-	if InterServiceTLSCAFile != "/etc/tls-ca/service-ca.crt" {
-		t.Errorf("InterServiceTLSCAFile = %q, want /etc/tls-ca/service-ca.crt (OCP service-ca key)", InterServiceTLSCAFile)
-	}
-}
-
-func TestValkeyAddr(t *testing.T) {
-	tests := []struct {
-		name string
-		spec kubernautv1alpha1.ValkeySpec
-		want string
-	}{
-		{"explicit port", kubernautv1alpha1.ValkeySpec{Host: "valkey.local", Port: 6380}, "valkey.local:6380"},
-		{"default port", kubernautv1alpha1.ValkeySpec{Host: "valkey.local"}, "valkey.local:6379"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ValkeyAddr(&tt.spec); got != tt.want {
-				t.Errorf("ValkeyAddr() = %q, want %q", got, tt.want)
-			}
+	It("returns error when env var is empty and no override", func() {
+		original := os.Getenv("RELATED_IMAGE_GATEWAY")
+		Expect(os.Setenv("RELATED_IMAGE_GATEWAY", "")).To(Succeed())
+		DeferCleanup(func() {
+			Expect(os.Setenv("RELATED_IMAGE_GATEWAY", original)).To(Succeed())
 		})
-	}
-}
 
-func TestValidateHostname_Valid(t *testing.T) {
-	for _, host := range []string{"pg.local", "192.168.1.1", "my-host.example.com", "[::1]"} {
-		if err := ValidateHostname(host); err != nil {
-			t.Errorf("ValidateHostname(%q) should be valid, got: %v", host, err)
+		kn := testKubernaut()
+		_, err := ResolveImage(kn, "gateway")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("resolves all components", func() {
+		kn := testKubernaut()
+		components := []string{
+			"gateway", "datastorage", "aianalysis", "signalprocessing",
+			"remediationorchestrator", "workflowexecution", "effectivenessmonitor",
+			"notification", "kubernautagent", "authwebhook",
 		}
-	}
-}
-
-func TestValidateHostname_Invalid(t *testing.T) {
-	for _, host := range []string{"", "host;rm -rf /", "host user=admin", "a b"} {
-		if err := ValidateHostname(host); err == nil {
-			t.Errorf("ValidateHostname(%q) should be invalid", host)
+		for _, c := range components {
+			_, err := ResolveImage(kn, c)
+			Expect(err).NotTo(HaveOccurred(), "ResolveImage(%q) unexpected error", c)
 		}
-	}
-}
+	})
 
-func TestPodSecurityContext_RestrictedProfile(t *testing.T) {
-	psc := PodSecurityContext()
-	if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
-		t.Error("PodSecurityContext must set RunAsNonRoot=true")
-	}
-	if psc.SeccompProfile == nil || psc.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
-		t.Error("PodSecurityContext must set SeccompProfile=RuntimeDefault")
-	}
-}
+	It("resolves db-migrate image", func() {
+		kn := testKubernaut()
+		got, err := ResolveImage(kn, "db-migrate")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(Equal("quay.io/kubernaut-ai/db-migrate:v1.3.0"))
+	})
+})
 
-func TestContainerSecurityContext_RestrictedProfile(t *testing.T) {
-	csc := ContainerSecurityContext()
-	if csc.AllowPrivilegeEscalation == nil || *csc.AllowPrivilegeEscalation {
-		t.Error("ContainerSecurityContext must set AllowPrivilegeEscalation=false")
-	}
-	if csc.ReadOnlyRootFilesystem == nil || !*csc.ReadOnlyRootFilesystem {
-		t.Error("ContainerSecurityContext must set ReadOnlyRootFilesystem=true")
-	}
-	if csc.Capabilities == nil || len(csc.Capabilities.Drop) == 0 || csc.Capabilities.Drop[0] != "ALL" {
-		t.Error("ContainerSecurityContext must drop ALL capabilities")
-	}
-}
+var _ = Describe("Labels", func() {
+	It("CommonLabels includes managed-by, part-of, and instance", func() {
+		kn := testKubernaut()
+		labels := CommonLabels(kn)
 
-func TestMergeResources_UsesDefaultsWhenEmpty(t *testing.T) {
-	res := MergeResources(corev1.ResourceRequirements{})
-	if res.Requests.Cpu().IsZero() {
-		t.Error("MergeResources should return default CPU request when user spec is empty")
-	}
-}
+		Expect(labels["app.kubernetes.io/managed-by"]).To(Equal("kubernaut-operator"))
+		Expect(labels["app.kubernetes.io/part-of"]).To(Equal("kubernaut"))
+		Expect(labels["app.kubernetes.io/instance"]).To(Equal("kubernaut"))
+	})
 
-func TestMergeResources_UsesUserSpecWhenProvided(t *testing.T) {
-	cpu := resource.MustParse("100m")
-	userSpec := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU: cpu,
+	It("ComponentLabels includes app and component labels plus common labels", func() {
+		kn := testKubernaut()
+		labels := ComponentLabels(kn, ComponentGateway)
+
+		Expect(labels["app"]).To(Equal(ComponentGateway))
+		Expect(labels["app.kubernetes.io/component"]).To(Equal(ComponentGateway))
+		Expect(labels).To(HaveKey("app.kubernetes.io/managed-by"))
+	})
+
+	It("SelectorLabels returns only the app label", func() {
+		labels := SelectorLabels(ComponentGateway)
+		Expect(labels).To(HaveLen(1))
+		Expect(labels["app"]).To(Equal(ComponentGateway))
+	})
+})
+
+var _ = Describe("ObjectMeta", func() {
+	It("sets name, namespace, and labels", func() {
+		kn := testKubernaut()
+		om := ObjectMeta(kn, "gateway-config", ComponentGateway)
+
+		Expect(om.Name).To(Equal("gateway-config"))
+		Expect(om.Namespace).To(Equal(testSystemNamespace))
+		Expect(om.Labels["app"]).To(Equal(ComponentGateway))
+	})
+})
+
+var _ = Describe("URL helpers", func() {
+	It("DataStorageURL returns correct HTTPS URL", func() {
+		got := DataStorageURL(testSystemNamespace)
+		Expect(got).To(Equal("https://data-storage-service.kubernaut-system.svc.cluster.local:8080"))
+	})
+
+	It("GatewayURL returns correct HTTPS URL", func() {
+		got := GatewayURL(testSystemNamespace)
+		Expect(got).To(Equal("https://gateway-service.kubernaut-system.svc.cluster.local:8080"))
+	})
+})
+
+var _ = Describe("InterServiceTLSCAFile", func() {
+	It("matches OCP service-ca path", func() {
+		Expect(InterServiceTLSCAFile).To(Equal("/etc/tls-ca/service-ca.crt"))
+	})
+})
+
+var _ = Describe("ValkeyAddr", func() {
+	DescribeTable("formats host:port",
+		func(spec kubernautv1alpha1.ValkeySpec, want string) {
+			Expect(ValkeyAddr(&spec)).To(Equal(want))
 		},
-	}
-	res := MergeResources(userSpec)
-	if res.Requests.Cpu().String() != "100m" {
-		t.Errorf("MergeResources should use user spec, got CPU=%s", res.Requests.Cpu().String())
-	}
-}
+		Entry("explicit port", kubernautv1alpha1.ValkeySpec{Host: "valkey.local", Port: 6380}, "valkey.local:6380"),
+		Entry("default port", kubernautv1alpha1.ValkeySpec{Host: "valkey.local"}, "valkey.local:6379"),
+	)
+})
 
-func TestAllComponents_Count(t *testing.T) {
-	components := AllComponents()
-	if len(components) != 10 {
-		t.Errorf("AllComponents() should return 10 components, got %d", len(components))
-	}
-}
+var _ = Describe("ValidateHostname", func() {
+	It("accepts valid hostnames", func() {
+		for _, host := range []string{"pg.local", "192.168.1.1", "my-host.example.com", "[::1]"} {
+			Expect(ValidateHostname(host)).To(Succeed(), "ValidateHostname(%q) should be valid", host)
+		}
+	})
 
-func TestSetOwnerReference_SetsControllerRef(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := kubernautv1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("AddToScheme: %v", err)
-	}
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("AddToScheme core: %v", err)
-	}
+	It("rejects invalid hostnames", func() {
+		for _, host := range []string{"", "host;rm -rf /", "host user=admin", "a b"} {
+			Expect(ValidateHostname(host)).To(HaveOccurred(), "ValidateHostname(%q) should be invalid", host)
+		}
+	})
+})
 
-	kn := testKubernaut()
-	kn.UID = types.UID("test-uid-1234")
+var _ = Describe("Security contexts", func() {
+	It("PodSecurityContext sets restricted profile", func() {
+		psc := PodSecurityContext()
+		Expect(psc.RunAsNonRoot).NotTo(BeNil())
+		Expect(*psc.RunAsNonRoot).To(BeTrue())
+		Expect(psc.SeccompProfile).NotTo(BeNil())
+		Expect(psc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+	})
 
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: kn.Namespace},
-	}
-	if err := SetOwnerReference(kn, cm, scheme); err != nil {
-		t.Fatalf("SetOwnerReference: %v", err)
-	}
+	It("ContainerSecurityContext sets restricted profile", func() {
+		csc := ContainerSecurityContext()
+		Expect(csc.AllowPrivilegeEscalation).NotTo(BeNil())
+		Expect(*csc.AllowPrivilegeEscalation).To(BeFalse())
+		Expect(csc.ReadOnlyRootFilesystem).NotTo(BeNil())
+		Expect(*csc.ReadOnlyRootFilesystem).To(BeTrue())
+		Expect(csc.Capabilities).NotTo(BeNil())
+		Expect(csc.Capabilities.Drop).NotTo(BeEmpty())
+		Expect(csc.Capabilities.Drop[0]).To(Equal(corev1.Capability("ALL")))
+	})
+})
 
-	refs := cm.GetOwnerReferences()
-	if len(refs) != 1 {
-		t.Fatalf("expected 1 owner reference, got %d", len(refs))
-	}
-	ref := refs[0]
-	if ref.Kind != "Kubernaut" {
-		t.Errorf("OwnerRef.Kind = %q, want Kubernaut", ref.Kind)
-	}
-	if ref.UID != kn.UID {
-		t.Errorf("OwnerRef.UID = %q, want %q", ref.UID, kn.UID)
-	}
-	if ref.Controller == nil || !*ref.Controller {
-		t.Error("OwnerRef.Controller should be true")
-	}
-}
+var _ = Describe("MergeResources", func() {
+	It("uses defaults when user spec is empty", func() {
+		res := MergeResources(corev1.ResourceRequirements{})
+		Expect(res.Requests.Cpu().IsZero()).To(BeFalse())
+	})
 
-func TestServiceAccountName_UnknownComponent_ReturnsSelf(t *testing.T) {
-	got := ServiceAccountName("custom-thing")
-	if got != "custom-thing" {
-		t.Errorf("ServiceAccountName(unknown) = %q, want %q", got, "custom-thing")
-	}
-}
+	It("uses user spec when provided", func() {
+		cpu := resource.MustParse("100m")
+		userSpec := corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: cpu,
+			},
+		}
+		res := MergeResources(userSpec)
+		Expect(res.Requests.Cpu().String()).To(Equal("100m"))
+	})
+})
 
-func TestIntPtrDefault_NonNil_ReturnsValue(t *testing.T) {
-	val := 0
-	got := intPtrDefault(&val, 42)
-	if got != 0 {
-		t.Errorf("intPtrDefault(ptr(0), 42) = %d, want 0", got)
-	}
-}
+var _ = Describe("AllComponents", func() {
+	It("returns 10 components", func() {
+		Expect(AllComponents()).To(HaveLen(10))
+	})
+})
 
-func TestIntPtrDefault_Nil_ReturnsDefault(t *testing.T) {
-	got := intPtrDefault(nil, 42)
-	if got != 42 {
-		t.Errorf("intPtrDefault(nil, 42) = %d, want 42", got)
-	}
-}
+var _ = Describe("SetOwnerReference", func() {
+	It("sets controller reference", func() {
+		scheme := runtime.NewScheme()
+		Expect(kubernautv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		kn := testKubernaut()
+		kn.UID = types.UID("test-uid-1234")
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: kn.Namespace},
+		}
+		Expect(SetOwnerReference(kn, cm, scheme)).To(Succeed())
+
+		refs := cm.GetOwnerReferences()
+		Expect(refs).To(HaveLen(1))
+		Expect(refs[0].Kind).To(Equal("Kubernaut"))
+		Expect(refs[0].UID).To(Equal(kn.UID))
+		Expect(refs[0].Controller).NotTo(BeNil())
+		Expect(*refs[0].Controller).To(BeTrue())
+	})
+})
+
+var _ = Describe("ServiceAccountName", func() {
+	It("returns component name for unknown component", func() {
+		Expect(ServiceAccountName("custom-thing")).To(Equal("custom-thing"))
+	})
+})
+
+var _ = Describe("intPtrDefault", func() {
+	It("returns value when pointer is non-nil", func() {
+		val := 0
+		Expect(intPtrDefault(&val, 42)).To(Equal(0))
+	})
+
+	It("returns default when pointer is nil", func() {
+		Expect(intPtrDefault(nil, 42)).To(Equal(42))
+	})
+})

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -18,8 +18,9 @@ package resources
 
 import (
 	"strings"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
@@ -28,1291 +29,976 @@ import (
 
 const injectCABundleAnnotationValue = "true"
 
-func TestGatewayConfigMap_ContainsDataStorageURL(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := GatewayConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if cm.Name != "gateway-config" {
-		t.Errorf("name = %q, want %q", cm.Name, "gateway-config")
-	}
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "https://data-storage-service.kubernaut-system.svc.cluster.local") {
-		t.Errorf("gateway config should reference DataStorage HTTPS URL, got:\n%s", data)
-	}
-	if !strings.Contains(data, "k8sRequestTimeout") {
-		t.Errorf("gateway config should contain k8sRequestTimeout, got:\n%s", data)
-	}
-	if !strings.Contains(data, "trustedProxyCIDRs") {
-		t.Errorf("gateway config should contain trustedProxyCIDRs, got:\n%s", data)
-	}
-	if !strings.Contains(data, "maxConcurrentRequests") {
-		t.Errorf("gateway config should contain maxConcurrentRequests, got:\n%s", data)
-	}
-}
-
-func TestGatewayConfigMap_CustomK8sTimeout(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Gateway.Config.K8sRequestTimeout = "30s"
-	cm, err := GatewayConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "k8sRequestTimeout: 30s") {
-		t.Errorf("gateway config should respect custom k8sRequestTimeout, got:\n%s", data)
-	}
-}
-
-func TestDataStorageConfigMap_ContainsPgAndValkey(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "host: pg.example.com") {
-		t.Errorf("datastorage config should contain PG host, got:\n%s", data)
-	}
-	if !strings.Contains(data, "addr: valkey.example.com:6379") {
-		t.Errorf("datastorage config should contain Valkey addr, got:\n%s", data)
-	}
-	if !strings.Contains(data, "secretsFile: /etc/datastorage/secrets/db-secrets.yaml") {
-		t.Errorf("datastorage config should reference db secrets file, got:\n%s", data)
-	}
-}
-
-func TestDataStorageConfigMap_DefaultPort(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.PostgreSQL.Port = 0
-	cm, err := DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "port: 5432") {
-		t.Errorf("datastorage config should default to port 5432, got:\n%s", data)
-	}
-}
-
-func TestAIAnalysisConfigMap_IncludesConfidenceThreshold(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.AIAnalysis.ConfidenceThreshold = "0.85"
-	cm, err := AIAnalysisConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "confidenceThreshold") || !strings.Contains(data, "0.85") {
-		t.Errorf("aianalysis config should contain confidence threshold, got:\n%s", data)
-	}
-}
-
-func TestAIAnalysisConfigMap_AgentKey(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := AIAnalysisConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "agent:") {
-		t.Errorf("aianalysis config should contain 'agent:' key, got:\n%s", data)
-	}
-	if strings.Contains(data, "kubernautAgent:") {
-		t.Errorf("aianalysis config should not contain old 'kubernautAgent:' key, got:\n%s", data)
-	}
-}
-
-func TestAIAnalysisConfigMap_OmitsThresholdWhenEmpty(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := AIAnalysisConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["config.yaml"]
-	if strings.Contains(data, "confidenceThreshold") {
-		t.Errorf("aianalysis config should not contain threshold when empty, got:\n%s", data)
-	}
-}
-
-func TestSignalProcessingConfigMap_ContainsDataStorageURL(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := SignalProcessingConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "data-storage-service.kubernaut-system.svc.cluster.local") {
-		t.Errorf("signalprocessing config should contain datastorage URL, got:\n%s", data)
-	}
-	if !strings.Contains(data, "classifier:") {
-		t.Errorf("signalprocessing config should contain classifier section, got:\n%s", data)
-	}
-}
-
-func TestRemediationOrchestratorConfigMap_Defaults(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["remediationorchestrator.yaml"]
-	defaults := []string{
-		"global: 1h", "processing: 5m", "analyzing: 10m", "executing: 30m", "verifying: 30m",
-		"ineffectiveChainThreshold: 3", "recurrenceCountThreshold: 5", "ineffectiveTimeWindow: 4h",
-		"dryRun: false", "dryRunHoldPeriod: 1h",
-	}
-	for _, d := range defaults {
-		if !strings.Contains(data, d) {
-			t.Errorf("RO config should contain default %q, got:\n%s", d, data)
-		}
-	}
-}
-
-func TestRemediationOrchestratorConfigMap_NestedStructure(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-
-	for _, want := range []string{
-		"controller:",
-		"leaderElectionId: remediationorchestrator.kubernaut.ai",
-		"datastorage:",
-		"url: https://data-storage-service",
-		"timeout:",
-		"buffer:",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("RO config should contain %q, got:\n%s", want, data)
-		}
-	}
-	if strings.Contains(data, "dataStorageUrl") {
-		t.Errorf("RO config should not contain flat dataStorageUrl key, got:\n%s", data)
-	}
-}
-
-func TestRemediationOrchestratorConfigMap_CustomValues(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.RemediationOrchestrator.Timeouts.Global = "2h"
-	kn.Spec.RemediationOrchestrator.Timeouts.Processing = "10m" //nolint:goconst // test value, not a meaningful constant
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["remediationorchestrator.yaml"]
-	if !strings.Contains(data, "global: 2h") {
-		t.Errorf("RO config should use custom global timeout, got:\n%s", data)
-	}
-	if !strings.Contains(data, "processing: 10m") {
-		t.Errorf("RO config should use custom processing timeout, got:\n%s", data)
-	}
-}
-
-// BAC-2: When dry-run is not explicitly configured, the RO must receive
-// dryRun: false so it operates in normal autonomous mode.
-func TestROConfig_DryRunDisabledByDefault(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-	if !strings.Contains(data, "dryRun: false") {
-		t.Errorf("BAC-2: default CR must render explicit 'dryRun: false', got:\n%s", data)
-	}
-}
-
-// BAC-3: The hold period must default to 1h so that re-triggering
-// suppression works out of the box.
-func TestROConfig_DryRunHoldPeriodDefaultsTo1h(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-	if !strings.Contains(data, "dryRunHoldPeriod: 1h") {
-		t.Errorf("BAC-3: default CR must render 'dryRunHoldPeriod: 1h', got:\n%s", data)
-	}
-}
-
-// BAC-1: An operator must be able to enable dry-run mode declaratively
-// via the Kubernaut CR.
-func TestROConfig_DryRunEnabled_RendersInConfigMap(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.RemediationOrchestrator.DryRun = true
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-	if !strings.Contains(data, "dryRun: true") {
-		t.Errorf("BAC-1: setting DryRun=true must render 'dryRun: true', got:\n%s", data)
-	}
-}
-
-// BAC-4: The operator must allow customizing the hold period and render
-// the value faithfully to the RO ConfigMap.
-func TestROConfig_CustomHoldPeriodOverride(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.RemediationOrchestrator.DryRun = true
-	kn.Spec.RemediationOrchestrator.DryRunHoldPeriod = "30m"
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-	if !strings.Contains(data, "dryRunHoldPeriod: 30m") {
-		t.Errorf("BAC-4: custom hold period must be rendered, got:\n%s", data)
-	}
-}
-
-// BAC-6: Changing dry-run settings must not disrupt other RO configuration.
-func TestROConfig_DryRunDoesNotAffectOtherSettings(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.RemediationOrchestrator.DryRun = true
-	kn.Spec.RemediationOrchestrator.DryRunHoldPeriod = "2h"
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-	unchanged := []string{
-		"global: 1h", "processing: 5m", "analyzing: 10m",
-		"consecutiveFailureThreshold: 3", "stabilizationWindow: 5m",
-		"gitOpsSyncDelay: 3m",
-	}
-	for _, want := range unchanged {
-		if !strings.Contains(data, want) {
-			t.Errorf("BAC-6: enabling dry-run must not alter %q, got:\n%s", want, data)
-		}
-	}
-}
-
-// BAC-7: An existing CR without dry-run fields must continue working
-// after operator upgrade (backward compatibility).
-func TestROConfig_EmptyCR_BackwardCompatible(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-	required := []string{
-		"dryRun: false",
-		"dryRunHoldPeriod: 1h",
-		"global: 1h",
-		"consecutiveFailureThreshold: 3",
-	}
-	for _, want := range required {
-		if !strings.Contains(data, want) {
-			t.Errorf("BAC-7: upgraded CR must still render %q, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestWorkflowExecutionConfigMap_DefaultNamespace(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := WorkflowExecutionConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["workflowexecution.yaml"]
-	if !strings.Contains(data, "kubernaut-workflows") {
-		t.Errorf("WE config should use default workflow namespace, got:\n%s", data)
-	}
-}
-
-func TestWorkflowExecutionConfigMap_CustomNamespace(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.WorkflowExecution.WorkflowNamespace = "custom-wf"
-	cm, err := WorkflowExecutionConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["workflowexecution.yaml"]
-	if !strings.Contains(data, "custom-wf") {
-		t.Errorf("WE config should use custom workflow namespace, got:\n%s", data)
-	}
-}
-
-func TestEffectivenessMonitorConfigMap_Defaults(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := EffectivenessMonitorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["effectivenessmonitor.yaml"]
-	if !strings.Contains(data, "stabilizationWindow: 30s") {
-		t.Errorf("EM config should have default stabilization window, got:\n%s", data)
-	}
-}
-
-func TestNotificationRoutingConfigMap_SlackConfigured(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Notification.Slack.SecretName = "slack-webhook"
-	kn.Spec.Notification.Slack.Channel = "#ops"
-	cm, err := NotificationRoutingConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["routing.yaml"]
-	if !strings.Contains(data, "slack") {
-		t.Errorf("routing config should reference slack receiver, got:\n%s", data)
-	}
-	if !strings.Contains(data, "#ops") {
-		t.Errorf("routing config should contain channel #ops, got:\n%s", data)
-	}
-}
-
-func TestNotificationRoutingConfigMap_NoSlack(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := NotificationRoutingConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := cm.Data["routing.yaml"]
-	if !strings.Contains(data, "console") {
-		t.Errorf("routing config without slack should use console receiver, got:\n%s", data)
-	}
-	if strings.Contains(data, "slack") {
-		t.Errorf("routing config should not contain slack when Slack is unconfigured, got:\n%s", data)
-	}
-}
-
-func TestNotificationControllerConfigMap_CredentialsInDelivery(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := NotificationControllerConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "delivery:") {
-		t.Errorf("notification config should contain delivery: block, got:\n%s", data)
-	}
-	if !strings.Contains(data, "credentials:") {
-		t.Errorf("notification config should contain credentials: block, got:\n%s", data)
-	}
-	if !strings.Contains(data, "dir: /etc/notification/credentials") {
-		t.Errorf("notification config should contain credentials dir, got:\n%s", data)
-	}
-}
-
-func TestKubernautAgentLLMRuntimeConfigMap_GeneratedWhenNoExisting(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if cm == nil {
-		t.Fatal("KubernautAgentLLMRuntimeConfigMap should not be nil when no existing CM specified")
-	}
-	data := cm.Data["llm-runtime.yaml"]
-	if !strings.Contains(data, "model: gpt-4o") {
-		t.Errorf("LLM runtime config should contain model, got:\n%s", data)
-	}
-	if !strings.Contains(data, "temperature:") {
-		t.Errorf("LLM runtime config should contain temperature, got:\n%s", data)
-	}
-}
-
-func TestKubernautAgentLLMRuntimeConfigMap_NilWhenExistingProvided(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.LLM.RuntimeConfigMapName = "my-llm-runtime-config"
-	cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cm != nil {
-		t.Error("KubernautAgentLLMRuntimeConfigMap should be nil when user provides existing CM")
-	}
-}
-
-func TestInterServiceCAConfigMap_HasInjectAnnotation(t *testing.T) {
-	kn := testKubernaut()
-	cm := InterServiceCAConfigMap(kn)
-	if cm.Name != InterServiceCAConfigMapName {
-		t.Errorf("name = %q, want %q", cm.Name, InterServiceCAConfigMapName)
-	}
-	v, ok := cm.Annotations[OCPServiceCAInjectAnnotation]
-	if !ok || v != injectCABundleAnnotationValue {
-		t.Error("inter-service-ca ConfigMap should have inject-cabundle annotation")
-	}
-}
-
-func TestServiceCAConfigMaps_HaveAnnotation(t *testing.T) {
-	kn := testKubernaut()
-	cms := []*struct {
-		name string
-		fn   func(*testing.T)
-	}{
-		{"effectivenessmonitor-service-ca", func(t *testing.T) {
-			cm := EffectivenessMonitorServiceCAConfigMap(kn)
-			if cm.Annotations["service.beta.openshift.io/inject-cabundle"] != injectCABundleAnnotationValue {
-				t.Error("EM service-ca ConfigMap should have inject-cabundle annotation")
-			}
-		}},
-		{"kubernaut-agent-service-ca", func(t *testing.T) {
-			cm := KubernautAgentServiceCAConfigMap(kn)
-			if cm.Annotations["service.beta.openshift.io/inject-cabundle"] != injectCABundleAnnotationValue {
-				t.Error("KA service-ca ConfigMap should have inject-cabundle annotation")
-			}
-		}},
-	}
-	for _, tc := range cms {
-		t.Run(tc.name, tc.fn)
-	}
-}
-
-func TestEffectivenessMonitorConfigMap_MonitoringURLs(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := EffectivenessMonitorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["effectivenessmonitor.yaml"]
-
-	if !strings.Contains(data, OCPPrometheusURL) {
-		t.Errorf("EM config should contain Prometheus URL when monitoring enabled, got:\n%s", data)
-	}
-	if !strings.Contains(data, OCPAlertManagerURL) {
-		t.Errorf("EM config should contain AlertManager URL when monitoring enabled, got:\n%s", data)
-	}
-	if !strings.Contains(data, "external:") {
-		t.Errorf("EM config should contain external section when monitoring enabled, got:\n%s", data)
-	}
-	if !strings.Contains(data, "tlsCaFile: /etc/ssl/em/service-ca.crt") {
-		t.Errorf("EM config should contain external.tlsCaFile when monitoring enabled, got:\n%s", data)
-	}
-}
-
-func TestEffectivenessMonitorConfigMap_NoMonitoringURLsWhenDisabled(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.Monitoring.Enabled = &disabled
-	cm, err := EffectivenessMonitorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["effectivenessmonitor.yaml"]
-
-	if strings.Contains(data, "external:") {
-		t.Errorf("EM config should not contain external monitoring section when disabled, got:\n%s", data)
-	}
-}
-
-func TestKubernautAgentConfigMap_MonitoringURL(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-
-	if !strings.Contains(data, OCPPrometheusURL) {
-		t.Errorf("KA config should contain Prometheus URL when monitoring enabled, got:\n%s", data)
-	}
-	if !strings.Contains(data, "tlsCaFile: /etc/ssl/ka/service-ca.crt") {
-		t.Errorf("KA config should contain Prometheus tlsCaFile for SA bearer auth, got:\n%s", data)
-	}
-	if !strings.Contains(data, "dataStorage:") {
-		t.Errorf("KA config should contain dataStorage section, got:\n%s", data)
-	}
-	if !strings.Contains(data, "url: https://data-storage-service.kubernaut-system.svc.cluster.local:8080") {
-		t.Errorf("KA config should contain HTTPS dataStorage.url, got:\n%s", data)
-	}
-	if !strings.Contains(data, "tools:") || !strings.Contains(data, "prometheus:") {
-		t.Errorf("KA config should contain upstream tools.prometheus section when monitoring enabled, got:\n%s", data)
-	}
-}
-
-func TestKubernautAgentConfigMap_NoMonitoringWhenDisabled(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.Monitoring.Enabled = &disabled
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-
-	if strings.Contains(data, "prometheusUrl") || strings.Contains(data, "tools:") {
-		t.Errorf("KA config should not contain Prometheus tools section when monitoring is disabled, got:\n%s", data)
-	}
-}
-
-func TestAuthWebhookConfigMap_UsesDefaultConfigFilename(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := AuthWebhookConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, ok := cm.Data["authwebhook.yaml"]; !ok {
-		t.Fatalf("AuthWebhookConfigMap should write authwebhook.yaml, keys: %#v", cm.Data)
-	}
-}
-
-func TestWorkflowExecutionConfigMap_AWXWiring(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.Enabled = true
-	kn.Spec.Ansible.APIURL = "https://awx.example.com"
-	kn.Spec.Ansible.OrganizationID = 42
-	kn.Spec.Ansible.TokenSecretRef = &kubernautv1alpha1.SecretKeyRef{
-		Name: "awx-token",
-		Key:  "api-token",
-	}
-	cm, err := WorkflowExecutionConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["workflowexecution.yaml"]
-
-	for _, want := range []string{
-		"ansible:",
-		"apiURL: https://awx.example.com",
-		"organizationID: 42",
-		"tokenSecretRef:",
-		"name: awx-token",
-		"key: api-token",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("WE config should contain %q when Ansible enabled, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestWorkflowExecutionConfigMap_NoAWXWhenDisabled(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := WorkflowExecutionConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["workflowexecution.yaml"]
-
-	if strings.Contains(data, "ansible:") {
-		t.Errorf("WE config should not contain ansible section when disabled, got:\n%s", data)
-	}
-}
-
-func TestWorkflowExecutionConfigMap_NestedStructure(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := WorkflowExecutionConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["workflowexecution.yaml"]
-
-	for _, want := range []string{
-		"execution:",
-		"namespace: kubernaut-workflows",
-		"cooldownPeriod:",
-		"datastorage:",
-		"url: https://data-storage-service",
-		"controller:",
-		"leaderElectionId: workflowexecution.kubernaut.ai",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("WE config should contain %q, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestConfigMaps_AllInCorrectNamespace(t *testing.T) {
-	kn := testKubernaut()
-	type builder struct {
-		name string
-		fn   func() (*corev1.ConfigMap, error)
-	}
-	builders := []builder{
-		{"gateway", func() (*corev1.ConfigMap, error) { return GatewayConfigMap(kn) }},
-		{"datastorage", func() (*corev1.ConfigMap, error) { return DataStorageConfigMap(kn, "db", "user") }},
-		{"aianalysis", func() (*corev1.ConfigMap, error) { return AIAnalysisConfigMap(kn) }},
-		{"signalprocessing", func() (*corev1.ConfigMap, error) { return SignalProcessingConfigMap(kn) }},
-		{"remediationorchestrator", func() (*corev1.ConfigMap, error) { return RemediationOrchestratorConfigMap(kn) }},
-		{"workflowexecution", func() (*corev1.ConfigMap, error) { return WorkflowExecutionConfigMap(kn) }},
-		{"effectivenessmonitor", func() (*corev1.ConfigMap, error) { return EffectivenessMonitorConfigMap(kn) }},
-		{"notification-controller", func() (*corev1.ConfigMap, error) { return NotificationControllerConfigMap(kn) }},
-		{"kubernaut-agent", func() (*corev1.ConfigMap, error) { return KubernautAgentConfigMap(kn) }},
-		{"authwebhook", func() (*corev1.ConfigMap, error) { return AuthWebhookConfigMap(kn) }},
-	}
-	for _, b := range builders {
-		cm, err := b.fn()
-		if err != nil {
-			t.Fatalf("building %s ConfigMap: %v", b.name, err)
-		}
-		if cm.Namespace != testSystemNamespace {
-			t.Errorf("ConfigMap %q namespace = %q, want %q", cm.Name, cm.Namespace, testSystemNamespace)
-		}
-	}
-}
-
-func TestAIAnalysisPoliciesConfigMap_DefaultRegoPolicy(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.AIAnalysis.Policy.ConfigMapName = ""
-
-	cm := AIAnalysisPoliciesConfigMap(kn)
-	if cm == nil {
-		t.Fatal("AIAnalysisPoliciesConfigMap should return non-nil when ConfigMapName is empty")
-	}
-	if cm.Name != "aianalysis-policies" {
-		t.Errorf("Name = %q, want %q", cm.Name, "aianalysis-policies")
-	}
-	rego, ok := cm.Data["approval.rego"]
-	if !ok {
-		t.Fatal("ConfigMap should contain approval.rego key")
-	}
-	if !strings.Contains(rego, "package kubernaut.aianalysis") {
-		t.Errorf("approval.rego should contain Rego package declaration, got:\n%s", rego)
-	}
-}
-
-func TestAIAnalysisPoliciesConfigMap_NilWhenUserProvided(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.AIAnalysis.Policy.ConfigMapName = "user-custom-policies"
-
-	cm := AIAnalysisPoliciesConfigMap(kn)
-	if cm != nil {
-		t.Error("AIAnalysisPoliciesConfigMap should return nil when user provides ConfigMapName")
-	}
-}
-
-func TestSignalProcessingPolicyConfigMap_DefaultRegoPolicy(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.SignalProcessing.Policy.ConfigMapName = ""
-
-	cm := SignalProcessingPolicyConfigMap(kn)
-	if cm == nil {
-		t.Fatal("SignalProcessingPolicyConfigMap should return non-nil when ConfigMapName is empty")
-	}
-	if cm.Name != "signalprocessing-policy" {
-		t.Errorf("Name = %q, want %q", cm.Name, "signalprocessing-policy")
-	}
-	rego, ok := cm.Data["policy.rego"]
-	if !ok {
-		t.Fatal("ConfigMap should contain policy.rego key")
-	}
-	if !strings.Contains(rego, "package kubernaut.signalprocessing") {
-		t.Errorf("policy.rego should contain Rego package declaration, got:\n%s", rego)
-	}
-}
-
-func TestSignalProcessingPolicyConfigMap_NilWhenUserProvided(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.SignalProcessing.Policy.ConfigMapName = "user-sp-policy"
-
-	cm := SignalProcessingPolicyConfigMap(kn)
-	if cm != nil {
-		t.Error("SignalProcessingPolicyConfigMap should return nil when user provides ConfigMapName")
-	}
-}
-
-func TestProactiveSignalMappingsConfigMap_DefaultMappings(t *testing.T) {
-	kn := testKubernaut()
-
-	cm := ProactiveSignalMappingsConfigMap(kn)
-	if cm == nil {
-		t.Fatal("ProactiveSignalMappingsConfigMap should return non-nil when no user override")
-	}
-	if cm.Name != "signalprocessing-proactive-signal-mappings" {
-		t.Errorf("Name = %q, want %q", cm.Name, "signalprocessing-proactive-signal-mappings")
-	}
-	data, ok := cm.Data["proactive-signal-mappings.yaml"]
-	if !ok {
-		t.Fatal("ConfigMap should contain proactive-signal-mappings.yaml key")
-	}
-	for _, mapping := range []string{
-		"PredictedOOMKill", "OOMKilled",
-		"PredictedCPUThrottling", "CPUThrottling",
-		"PredictedDiskPressure", "DiskPressure",
-		"PredictedNodeNotReady", "NodeNotReady",
-	} {
-		if !strings.Contains(data, mapping) {
-			t.Errorf("proactive-signal-mappings.yaml should contain %q, got:\n%s", mapping, data)
-		}
-	}
-}
-
-func TestProactiveSignalMappingsConfigMap_NilWhenUserProvided(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.SignalProcessing.ProactiveSignalMappings = &kubernautv1alpha1.ConfigMapRef{
-		ConfigMapName: "user-proactive-mappings",
-	}
-
-	cm := ProactiveSignalMappingsConfigMap(kn)
-	if cm != nil {
-		t.Error("ProactiveSignalMappingsConfigMap should return nil when user provides ConfigMapName")
-	}
-}
-
-func TestKubernautAgentConfigMap_V14Structure(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var root struct {
-		Runtime struct {
-			Logging struct {
-				Level string `yaml:"level"`
-			} `yaml:"logging"`
-			Server struct {
-				Address string `yaml:"address"`
-				Port    int    `yaml:"port"`
-			} `yaml:"server"`
-			Audit struct {
-				BufferSize int `yaml:"bufferSize"`
-			} `yaml:"audit"`
-		} `yaml:"runtime"`
-		AI struct {
-			LLM struct {
-				Provider string `yaml:"provider"`
-			} `yaml:"llm"`
-			Investigation struct {
-				MaxTurns int `yaml:"maxTurns"`
-			} `yaml:"investigation"`
-		} `yaml:"ai"`
-		Integrations struct {
-			DataStorage struct {
-				URL string `yaml:"url"`
-			} `yaml:"dataStorage"`
-			Tools *struct {
-				Prometheus struct {
-					URL       string `yaml:"url"`
-					TLSCaFile string `yaml:"tlsCaFile"`
-				} `yaml:"prometheus"`
-			} `yaml:"tools,omitempty"`
-		} `yaml:"integrations"`
-	}
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {
-		t.Fatalf("unmarshal KA config: %v", err)
-	}
-	if root.Runtime.Logging.Level != "info" {
-		t.Errorf("runtime.logging.level = %q, want info", root.Runtime.Logging.Level)
-	}
-	if root.Runtime.Server.Port != 8080 || root.Runtime.Server.Address != "0.0.0.0" {
-		t.Errorf("runtime.server = %#v, want address 0.0.0.0 port 8080", root.Runtime.Server)
-	}
-	if root.Runtime.Audit.BufferSize != 10000 {
-		t.Errorf("runtime.audit.bufferSize = %d, want 10000", root.Runtime.Audit.BufferSize)
-	}
-	if root.AI.LLM.Provider != "openai" {
-		t.Errorf("ai.llm.provider = %q, want openai", root.AI.LLM.Provider)
-	}
-	if root.AI.Investigation.MaxTurns != 40 {
-		t.Errorf("ai.investigation.maxTurns = %d, want 40", root.AI.Investigation.MaxTurns)
-	}
-	wantDS := DataStorageURL(kn.Namespace)
-	if root.Integrations.DataStorage.URL != wantDS {
-		t.Errorf("integrations.dataStorage.url = %q, want %q", root.Integrations.DataStorage.URL, wantDS)
-	}
-	if root.Integrations.Tools == nil {
-		t.Fatal("integrations.tools should be present when monitoring is enabled by default")
-	}
-	if got := root.Integrations.Tools.Prometheus.URL; got != OCPPrometheusURL {
-		t.Errorf("integrations.tools.prometheus.url = %q, want %q", got, OCPPrometheusURL)
-	}
-	if got := root.Integrations.Tools.Prometheus.TLSCaFile; got != "/etc/ssl/ka/service-ca.crt" {
-		t.Errorf("integrations.tools.prometheus.tlsCaFile = %q, want /etc/ssl/ka/service-ca.crt", got)
-	}
-}
-
-func TestKubernautAgentConfigMap_AlignmentCheck(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.AlignmentCheck.Enabled = true
-	kn.Spec.KubernautAgent.AlignmentCheck.Timeout = "20s"
-	kn.Spec.KubernautAgent.AlignmentCheck.MaxStepTokens = 1024
-	kn.Spec.KubernautAgent.AlignmentCheck.LLM = &kubernautv1alpha1.AlignmentCheckLLMSpec{
-		Provider: "openai",
-		Model:    "gpt-4o-mini",
-		Endpoint: "https://align.example/v1",
-	}
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	for _, want := range []string{
-		"alignmentCheck:",
-		"enabled: true",
-		"timeout: 20s",
-		"maxStepTokens: 1024",
-		"llm:",
-		"provider: openai",
-		"model: gpt-4o-mini",
-		"endpoint: https://align.example/v1",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("KA config should contain %q when alignment check enabled, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestKubernautAgentLLMRuntimeConfigMap_Defaults(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["llm-runtime.yaml"]
-	for _, want := range []string{
-		"model: gpt-4o",
-		"temperature: 0.7",
-		"maxRetries: 3",
-		"timeoutSeconds: 120",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("llm-runtime defaults should contain %q, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestKubernautAgentLLMRuntimeConfigMap_CustomValues(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.LLM.Temperature = "0.5"
-	kn.Spec.KubernautAgent.LLM.Endpoint = "https://llm-custom.example/v1"
-	maxR := 7
-	kn.Spec.KubernautAgent.LLM.MaxRetries = &maxR
-	cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["llm-runtime.yaml"]
-	for _, want := range []string{
-		"temperature: 0.5",
-		"endpoint: https://llm-custom.example/v1",
-		"maxRetries: 7",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("llm-runtime custom values should contain %q, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestKubernautAgentLLMRuntimeConfigMap_BYO(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.LLM.RuntimeConfigMapName = "user-llm-runtime"
-	cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cm != nil {
-		t.Error("KubernautAgentLLMRuntimeConfigMap should return nil when runtimeConfigMapName is set (BYO)")
-	}
-}
-
-func TestGatewayConfigMap_V14Processing(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Gateway.Logging.Level = "debug"
-	cm, err := GatewayConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	for _, want := range []string{
-		"logging:",
-		"level: debug",
-		"processing:",
-		"deduplication:",
-		"cooldownPeriod: 5m",
-		"retry:",
-		"maxAttempts: 3",
-		"initialBackoff: 100ms",
-		"maxBackoff: 5s",
-		"datastorage:",
-		"buffer:",
-		"bufferSize: 10000",
-		"batchSize: 100",
-		"flushInterval: 1s",
-		"maxRetries: 3",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("gateway v1.4 config should contain %q, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestRemediationOrchestratorConfigMap_V14Fields(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.RemediationOrchestrator.Logging.Level = "warn"
-	kn.Spec.RemediationOrchestrator.Notifications.NotifySelfResolved = true
-	kn.Spec.RemediationOrchestrator.Retention.Period = "72h"
-	kn.Spec.RemediationOrchestrator.Timeouts.AwaitingApproval = "25m"
-	kn.Spec.RemediationOrchestrator.Routing.ExponentialBackoffBase = "2m"
-	kn.Spec.RemediationOrchestrator.Routing.ExponentialBackoffMax = "20m"
-	exp := 6
-	kn.Spec.RemediationOrchestrator.Routing.ExponentialBackoffMaxExponent = &exp
-	kn.Spec.RemediationOrchestrator.Routing.ScopeBackoffBase = "10s"
-	kn.Spec.RemediationOrchestrator.Routing.ScopeBackoffMax = "10m"
-	delay := 48
-	kn.Spec.RemediationOrchestrator.Routing.NoActionRequiredDelayHours = &delay
-
-	cm, err := RemediationOrchestratorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["remediationorchestrator.yaml"]
-	for _, want := range []string{
-		"logging:",
-		"level: warn",
-		"notifications:",
-		"notifySelfResolved: true",
-		"retention:",
-		"period: 72h",
-		"routing:",
-		"exponentialBackoffBase: 2m",
-		"exponentialBackoffMax: 20m",
-		"exponentialBackoffMaxExponent: 6",
-		"scopeBackoffBase: 10s",
-		"scopeBackoffMax: 10m",
-		"noActionRequiredDelayHours: 48",
-		"timeouts:",
-		"awaitingApproval: 25m",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("RO v1.4 config should contain %q, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestWorkflowExecutionConfigMap_Logging(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.WorkflowExecution.Logging.Level = "error"
-	cm, err := WorkflowExecutionConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["workflowexecution.yaml"]
-	if !strings.Contains(data, "logging:") || !strings.Contains(data, "level: error") {
-		t.Errorf("WE config should render logging.level, got:\n%s", data)
-	}
-}
-
-func TestWorkflowExecutionConfigMap_TektonEnabled(t *testing.T) {
-	kn := testKubernaut()
-	on := true
-	kn.Spec.WorkflowExecution.Tekton.Enabled = &on
-	cm, err := WorkflowExecutionConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["workflowexecution.yaml"]
-	if !strings.Contains(data, "tekton:") || !strings.Contains(data, "enabled: true") {
-		t.Errorf("WE config should render tekton.enabled, got:\n%s", data)
-	}
-}
-
-func TestEffectivenessMonitorConfigMap_V14Buffer(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.EffectivenessMonitor.Logging.Level = "debug"
-	cm, err := EffectivenessMonitorConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["effectivenessmonitor.yaml"]
-	for _, want := range []string{
-		"logging:",
-		"level: debug",
-		"datastorage:",
-		"timeout: 10s",
-		"buffer:",
-		"bufferSize: 100",
-		"batchSize: 10",
-		"flushInterval: 1s",
-		"maxRetries: 3",
-	} {
-		if !strings.Contains(data, want) {
-			t.Errorf("EM v1.4 config should contain %q, got:\n%s", want, data)
-		}
-	}
-}
-
-func TestLoggingLevel_AllServices(t *testing.T) {
-	const lvl = "error"
-	tests := []struct {
-		name string
-		prep func(kn *kubernautv1alpha1.Kubernaut)
-		key  string
-		fn   func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error)
-	}{
-		{
-			name: "gateway",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.Gateway.Logging.Level = lvl },
-			key:  "config.yaml",
-			fn:   func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return GatewayConfigMap(kn) },
-		},
-		{
-			name: "datastorage",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.DataStorage.Logging.Level = lvl },
-			key:  "config.yaml",
-			fn: func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
-				return DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
-			},
-		},
-		{
-			name: "aianalysis",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.AIAnalysis.Logging.Level = lvl },
-			key:  "config.yaml",
-			fn:   func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return AIAnalysisConfigMap(kn) },
-		},
-		{
-			name: "signalprocessing",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.SignalProcessing.Logging.Level = lvl },
-			key:  "config.yaml",
-			fn: func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
-				return SignalProcessingConfigMap(kn)
-			},
-		},
-		{
-			name: "remediationorchestrator",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.RemediationOrchestrator.Logging.Level = lvl },
-			key:  "remediationorchestrator.yaml",
-			fn: func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
-				return RemediationOrchestratorConfigMap(kn)
-			},
-		},
-		{
-			name: "workflowexecution",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.WorkflowExecution.Logging.Level = lvl },
-			key:  "workflowexecution.yaml",
-			fn: func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
-				return WorkflowExecutionConfigMap(kn)
-			},
-		},
-		{
-			name: "effectivenessmonitor",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.EffectivenessMonitor.Logging.Level = lvl },
-			key:  "effectivenessmonitor.yaml",
-			fn: func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
-				return EffectivenessMonitorConfigMap(kn)
-			},
-		},
-		{
-			name: "notification-controller",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.Notification.Logging.Level = lvl },
-			key:  "config.yaml",
-			fn: func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
-				return NotificationControllerConfigMap(kn)
-			},
-		},
-		{
-			name: "kubernaut-agent",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.KubernautAgent.Logging.Level = lvl },
-			key:  "config.yaml",
-			fn:   func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return KubernautAgentConfigMap(kn) },
-		},
-		{
-			name: "authwebhook",
-			prep: func(kn *kubernautv1alpha1.Kubernaut) { kn.Spec.AuthWebhook.Logging.Level = lvl },
-			key:  "authwebhook.yaml",
-			fn:   func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return AuthWebhookConfigMap(kn) },
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+var _ = Describe("ConfigMaps", func() {
+	Describe("Gateway ConfigMap", func() {
+		It("contains DataStorage URL and expected keys", func() {
 			kn := testKubernaut()
-			tt.prep(kn)
-			cm, err := tt.fn(kn)
-			if err != nil {
-				t.Fatal(err)
-			}
-			data := cm.Data[tt.key]
-			if !strings.Contains(data, "level: "+lvl) {
-				t.Errorf("expected logging level %q in %s, got:\n%s", lvl, tt.key, data)
+			cm, err := GatewayConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cm.Name).To(Equal("gateway-config"))
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("https://data-storage-service.kubernaut-system.svc.cluster.local"))
+			Expect(data).To(ContainSubstring("k8sRequestTimeout"))
+			Expect(data).To(ContainSubstring("trustedProxyCIDRs"))
+			Expect(data).To(ContainSubstring("maxConcurrentRequests"))
+		})
+
+		It("respects custom K8s request timeout", func() {
+			kn := testKubernaut()
+			kn.Spec.Gateway.Config.K8sRequestTimeout = "30s"
+			cm, err := GatewayConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("k8sRequestTimeout: 30s"))
+		})
+
+		It("renders v1.4 processing and related fields", func() {
+			kn := testKubernaut()
+			kn.Spec.Gateway.Logging.Level = "debug"
+			cm, err := GatewayConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			for _, want := range []string{
+				"logging:",
+				"level: debug",
+				"processing:",
+				"deduplication:",
+				"cooldownPeriod: 5m",
+				"retry:",
+				"maxAttempts: 3",
+				"initialBackoff: 100ms",
+				"maxBackoff: 5s",
+				"datastorage:",
+				"buffer:",
+				"bufferSize: 10000",
+				"batchSize: 100",
+				"flushInterval: 1s",
+				"maxRetries: 3",
+			} {
+				Expect(data).To(ContainSubstring(want), "gateway v1.4 config should contain %q, got:\n%s", want, data)
 			}
 		})
-	}
-}
 
-func TestKubernautAgentConfigMap_LLMTLSCaFile(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.LLM.TLSCaFile = "/etc/custom-ca/llm.pem"
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var root struct {
-		AI struct {
-			LLM struct {
-				TLSCaFile string `yaml:"tlsCaFile"`
-			} `yaml:"llm"`
-		} `yaml:"ai"`
-	}
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {
-		t.Fatalf("unmarshal KA config: %v", err)
-	}
-	if root.AI.LLM.TLSCaFile != "/etc/custom-ca/llm.pem" {
-		t.Errorf("ai.llm.tlsCaFile = %q, want /etc/custom-ca/llm.pem", root.AI.LLM.TLSCaFile)
-	}
-}
+		It("renders custom trusted proxy CIDRs", func() {
+			kn := testKubernaut()
+			kn.Spec.Gateway.Config.TrustedProxyCIDRs = []string{"10.0.0.0/8"}
+			cm, err := GatewayConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			Expect(strings.Contains(data, "trustedProxyCIDRs") && strings.Contains(data, "10.0.0.0/8")).To(BeTrue(), "gateway config should contain trustedProxyCIDRs with 10.0.0.0/8, got:\n%s", data)
+		})
 
-func TestKubernautAgentConfigMap_SummarizerNonDefault(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.Summarizer.Threshold = 5000
-	kn.Spec.KubernautAgent.Summarizer.MaxToolOutputSize = 50000
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var root struct {
-		AI struct {
-			Summarizer *struct {
-				Threshold         int `yaml:"threshold"`
-				MaxToolOutputSize int `yaml:"maxToolOutputSize"`
-			} `yaml:"summarizer"`
-		} `yaml:"ai"`
-	}
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {
-		t.Fatalf("unmarshal KA config: %v", err)
-	}
-	if root.AI.Summarizer == nil {
-		t.Fatal("expected ai.summarizer block for non-default summarizer settings")
-	}
-	if root.AI.Summarizer.Threshold != 5000 {
-		t.Errorf("summarizer.threshold = %d, want 5000", root.AI.Summarizer.Threshold)
-	}
-	if root.AI.Summarizer.MaxToolOutputSize != 50000 {
-		t.Errorf("summarizer.maxToolOutputSize = %d, want 50000", root.AI.Summarizer.MaxToolOutputSize)
-	}
-}
+		It("renders custom deduplication cooldown", func() {
+			kn := testKubernaut()
+			kn.Spec.Gateway.Config.DeduplicationCooldown = "10m"
+			cm, err := GatewayConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("cooldownPeriod: 10m"), "gateway config should contain cooldownPeriod 10m, got:\n%s", data)
+		})
+	})
 
-func TestKubernautAgentConfigMap_SafetyAnomalyMaxToolCallsPerTool(t *testing.T) {
-	kn := testKubernaut()
-	maxPer := 5
-	kn.Spec.KubernautAgent.Safety.Anomaly.MaxToolCallsPerTool = &maxPer
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var root struct {
-		AI struct {
-			Safety struct {
-				Anomaly struct {
-					MaxToolCallsPerTool int `yaml:"maxToolCallsPerTool"`
-				} `yaml:"anomaly"`
-			} `yaml:"safety"`
-		} `yaml:"ai"`
-	}
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {
-		t.Fatalf("unmarshal KA config: %v", err)
-	}
-	if root.AI.Safety.Anomaly.MaxToolCallsPerTool != 5 {
-		t.Errorf("ai.safety.anomaly.maxToolCallsPerTool = %d, want 5", root.AI.Safety.Anomaly.MaxToolCallsPerTool)
-	}
-}
+	Describe("DataStorage ConfigMap", func() {
+		It("contains PostgreSQL and Valkey settings", func() {
+			kn := testKubernaut()
+			cm, err := DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
+			Expect(err).NotTo(HaveOccurred())
 
-func TestKubernautAgentConfigMap_LLMOAuth2Block(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.LLM.OAuth2.Enabled = true
-	kn.Spec.KubernautAgent.LLM.OAuth2.TokenURL = "https://idp.example/oauth/token"
-	kn.Spec.KubernautAgent.LLM.OAuth2.Scopes = []string{"openid", "api.read"}
-	cm, err := KubernautAgentConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var root struct {
-		AI struct {
-			LLM struct {
-				OAuth2 *struct {
-					Enabled  bool     `yaml:"enabled"`
-					TokenURL string   `yaml:"tokenURL"`
-					Scopes   []string `yaml:"scopes"`
-				} `yaml:"oauth2"`
-			} `yaml:"llm"`
-		} `yaml:"ai"`
-	}
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {
-		t.Fatalf("unmarshal KA config: %v", err)
-	}
-	if root.AI.LLM.OAuth2 == nil {
-		t.Fatal("expected ai.llm.oauth2 block when OAuth2 enabled")
-	}
-	if !root.AI.LLM.OAuth2.Enabled {
-		t.Error("oauth2.enabled should be true")
-	}
-	if root.AI.LLM.OAuth2.TokenURL != "https://idp.example/oauth/token" {
-		t.Errorf("oauth2.tokenURL = %q", root.AI.LLM.OAuth2.TokenURL)
-	}
-	if len(root.AI.LLM.OAuth2.Scopes) != 2 || root.AI.LLM.OAuth2.Scopes[0] != "openid" || root.AI.LLM.OAuth2.Scopes[1] != "api.read" {
-		t.Errorf("oauth2.scopes = %#v, want [openid api.read]", root.AI.LLM.OAuth2.Scopes)
-	}
-}
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("host: pg.example.com"), "datastorage config should contain PG host, got:\n%s", data)
+			Expect(data).To(ContainSubstring("addr: valkey.example.com:6379"), "datastorage config should contain Valkey addr, got:\n%s", data)
+			Expect(data).To(ContainSubstring("secretsFile: /etc/datastorage/secrets/db-secrets.yaml"), "datastorage config should reference db secrets file, got:\n%s", data)
+		})
 
-func TestGatewayConfigMap_TrustedProxyCIDRsCustom(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Gateway.Config.TrustedProxyCIDRs = []string{"10.0.0.0/8"}
-	cm, err := GatewayConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "trustedProxyCIDRs") || !strings.Contains(data, "10.0.0.0/8") {
-		t.Errorf("gateway config should contain trustedProxyCIDRs with 10.0.0.0/8, got:\n%s", data)
-	}
-}
+		It("defaults PostgreSQL port to 5432 when unset", func() {
+			kn := testKubernaut()
+			kn.Spec.PostgreSQL.Port = 0
+			cm, err := DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("port: 5432"), "datastorage config should default to port 5432, got:\n%s", data)
+		})
 
-func TestGatewayConfigMap_DeduplicationCooldownCustom(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Gateway.Config.DeduplicationCooldown = "10m"
-	cm, err := GatewayConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	data := cm.Data["config.yaml"]
-	if !strings.Contains(data, "cooldownPeriod: 10m") {
-		t.Errorf("gateway config should contain cooldownPeriod 10m, got:\n%s", data)
-	}
-}
+		It("passes through PostgreSQL SSL mode", func() {
+			kn := testKubernaut()
+			kn.Spec.PostgreSQL.SSLMode = "require"
+			cm, err := DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
+			Expect(err).NotTo(HaveOccurred())
+			var root struct {
+				Database struct {
+					SSLMode string `yaml:"sslMode"`
+				} `yaml:"database"`
+			}
+			err = yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(root.Database.SSLMode).To(Equal("require"), "database.sslMode = %q, want require", root.Database.SSLMode)
+		})
+	})
 
-func TestDataStorageConfigMap_PostgreSQLSSLModeRequire(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.PostgreSQL.SSLMode = "require"
-	cm, err := DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var root struct {
-		Database struct {
-			SSLMode string `yaml:"sslMode"`
-		} `yaml:"database"`
-	}
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root); err != nil {
-		t.Fatalf("unmarshal datastorage config: %v", err)
-	}
-	if root.Database.SSLMode != "require" {
-		t.Errorf("database.sslMode = %q, want require", root.Database.SSLMode)
-	}
-}
+	Describe("AIAnalysis ConfigMap", func() {
+		It("includes confidence threshold when set", func() {
+			kn := testKubernaut()
+			kn.Spec.AIAnalysis.ConfidenceThreshold = "0.85"
+			cm, err := AIAnalysisConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
 
-func TestNotificationRoutingConfigMap_StillBuildsWhenRoutingConfigMapNameBYO(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Notification.Routing = &kubernautv1alpha1.ConfigMapRef{ConfigMapName: "my-routing"}
-	cm, err := NotificationRoutingConfigMap(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cm.Name != "notification-routing-config" {
-		t.Errorf("NotificationRoutingConfigMap name = %q, want notification-routing-config (BYO affects deployment/controller, not this builder)", cm.Name)
-	}
-	data := cm.Data["routing.yaml"]
-	if !strings.Contains(data, "console") {
-		t.Errorf("expected default routing content when builder invoked, got:\n%s", data)
-	}
-}
+			data := cm.Data["config.yaml"]
+			Expect(strings.Contains(data, "confidenceThreshold") && strings.Contains(data, "0.85")).To(BeTrue(), "aianalysis config should contain confidence threshold, got:\n%s", data)
+		})
+
+		It("uses agent key and not legacy kubernautAgent key", func() {
+			kn := testKubernaut()
+			cm, err := AIAnalysisConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("agent:"), "aianalysis config should contain 'agent:' key, got:\n%s", data)
+			Expect(data).NotTo(ContainSubstring("kubernautAgent:"), "aianalysis config should not contain old 'kubernautAgent:' key, got:\n%s", data)
+		})
+
+		It("omits threshold when empty", func() {
+			kn := testKubernaut()
+			cm, err := AIAnalysisConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["config.yaml"]
+			Expect(data).NotTo(ContainSubstring("confidenceThreshold"), "aianalysis config should not contain threshold when empty, got:\n%s", data)
+		})
+	})
+
+	Describe("SignalProcessing ConfigMap", func() {
+		It("contains DataStorage URL and classifier section", func() {
+			kn := testKubernaut()
+			cm, err := SignalProcessingConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("data-storage-service.kubernaut-system.svc.cluster.local"), "signalprocessing config should contain datastorage URL, got:\n%s", data)
+			Expect(data).To(ContainSubstring("classifier:"), "signalprocessing config should contain classifier section, got:\n%s", data)
+		})
+	})
+
+	Describe("RemediationOrchestrator ConfigMap", func() {
+		It("includes default timeout and threshold strings", func() {
+			kn := testKubernaut()
+			cm, err := RemediationOrchestratorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["remediationorchestrator.yaml"]
+			defaults := []string{
+				"global: 1h", "processing: 5m", "analyzing: 10m", "executing: 30m", "verifying: 30m",
+				"ineffectiveChainThreshold: 3", "recurrenceCountThreshold: 5", "ineffectiveTimeWindow: 4h",
+				"dryRun: false", "dryRunHoldPeriod: 1h",
+			}
+			for _, d := range defaults {
+				Expect(data).To(ContainSubstring(d), "RO config should contain default %q, got:\n%s", d, data)
+			}
+		})
+
+		It("uses nested structure for controller, datastorage, and timeouts", func() {
+			kn := testKubernaut()
+			cm, err := RemediationOrchestratorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["remediationorchestrator.yaml"]
+
+			for _, want := range []string{
+				"controller:",
+				"leaderElectionId: remediationorchestrator.kubernaut.ai",
+				"datastorage:",
+				"url: https://data-storage-service",
+				"timeout:",
+				"buffer:",
+			} {
+				Expect(data).To(ContainSubstring(want), "RO config should contain %q, got:\n%s", want, data)
+			}
+			Expect(data).NotTo(ContainSubstring("dataStorageUrl"), "RO config should not contain flat dataStorageUrl key, got:\n%s", data)
+		})
+
+		It("applies custom timeout values from the CR", func() {
+			kn := testKubernaut()
+			kn.Spec.RemediationOrchestrator.Timeouts.Global = "2h"
+			kn.Spec.RemediationOrchestrator.Timeouts.Processing = "10m" //nolint:goconst // test value, not a meaningful constant
+			cm, err := RemediationOrchestratorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["remediationorchestrator.yaml"]
+			Expect(data).To(ContainSubstring("global: 2h"), "RO config should use custom global timeout, got:\n%s", data)
+			Expect(data).To(ContainSubstring("processing: 10m"), "RO config should use custom processing timeout, got:\n%s", data)
+		})
+
+		Context("BAC requirements", func() {
+			It("BAC-2: default CR renders explicit dryRun false", func() {
+				kn := testKubernaut()
+				cm, err := RemediationOrchestratorConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["remediationorchestrator.yaml"]
+				Expect(data).To(ContainSubstring("dryRun: false"), "BAC-2: default CR must render explicit 'dryRun: false', got:\n%s", data)
+			})
+
+			It("BAC-3: default CR renders dryRunHoldPeriod 1h", func() {
+				kn := testKubernaut()
+				cm, err := RemediationOrchestratorConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["remediationorchestrator.yaml"]
+				Expect(data).To(ContainSubstring("dryRunHoldPeriod: 1h"), "BAC-3: default CR must render 'dryRunHoldPeriod: 1h', got:\n%s", data)
+			})
+
+			It("BAC-1: DryRun true renders dryRun true in ConfigMap", func() {
+				kn := testKubernaut()
+				kn.Spec.RemediationOrchestrator.DryRun = true
+				cm, err := RemediationOrchestratorConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["remediationorchestrator.yaml"]
+				Expect(data).To(ContainSubstring("dryRun: true"), "BAC-1: setting DryRun=true must render 'dryRun: true', got:\n%s", data)
+			})
+
+			It("BAC-4: custom hold period is rendered", func() {
+				kn := testKubernaut()
+				kn.Spec.RemediationOrchestrator.DryRun = true
+				kn.Spec.RemediationOrchestrator.DryRunHoldPeriod = "30m"
+				cm, err := RemediationOrchestratorConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["remediationorchestrator.yaml"]
+				Expect(data).To(ContainSubstring("dryRunHoldPeriod: 30m"), "BAC-4: custom hold period must be rendered, got:\n%s", data)
+			})
+
+			It("BAC-6: dry-run changes do not alter unrelated settings", func() {
+				kn := testKubernaut()
+				kn.Spec.RemediationOrchestrator.DryRun = true
+				kn.Spec.RemediationOrchestrator.DryRunHoldPeriod = "2h"
+				cm, err := RemediationOrchestratorConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["remediationorchestrator.yaml"]
+				unchanged := []string{
+					"global: 1h", "processing: 5m", "analyzing: 10m",
+					"consecutiveFailureThreshold: 3", "stabilizationWindow: 5m",
+					"gitOpsSyncDelay: 3m",
+				}
+				for _, want := range unchanged {
+					Expect(data).To(ContainSubstring(want), "BAC-6: enabling dry-run must not alter %q, got:\n%s", want, data)
+				}
+			})
+
+			It("BAC-7: default CR remains backward compatible", func() {
+				kn := testKubernaut()
+				cm, err := RemediationOrchestratorConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["remediationorchestrator.yaml"]
+				required := []string{
+					"dryRun: false",
+					"dryRunHoldPeriod: 1h",
+					"global: 1h",
+					"consecutiveFailureThreshold: 3",
+				}
+				for _, want := range required {
+					Expect(data).To(ContainSubstring(want), "BAC-7: upgraded CR must still render %q, got:\n%s", want, data)
+				}
+			})
+		})
+
+		It("renders v1.4 logging, notifications, retention, routing, and timeouts", func() {
+			kn := testKubernaut()
+			kn.Spec.RemediationOrchestrator.Logging.Level = "warn"
+			kn.Spec.RemediationOrchestrator.Notifications.NotifySelfResolved = true
+			kn.Spec.RemediationOrchestrator.Retention.Period = "72h"
+			kn.Spec.RemediationOrchestrator.Timeouts.AwaitingApproval = "25m"
+			kn.Spec.RemediationOrchestrator.Routing.ExponentialBackoffBase = "2m"
+			kn.Spec.RemediationOrchestrator.Routing.ExponentialBackoffMax = "20m"
+			exp := 6
+			kn.Spec.RemediationOrchestrator.Routing.ExponentialBackoffMaxExponent = &exp
+			kn.Spec.RemediationOrchestrator.Routing.ScopeBackoffBase = "10s"
+			kn.Spec.RemediationOrchestrator.Routing.ScopeBackoffMax = "10m"
+			delay := 48
+			kn.Spec.RemediationOrchestrator.Routing.NoActionRequiredDelayHours = &delay
+
+			cm, err := RemediationOrchestratorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["remediationorchestrator.yaml"]
+			for _, want := range []string{
+				"logging:",
+				"level: warn",
+				"notifications:",
+				"notifySelfResolved: true",
+				"retention:",
+				"period: 72h",
+				"routing:",
+				"exponentialBackoffBase: 2m",
+				"exponentialBackoffMax: 20m",
+				"exponentialBackoffMaxExponent: 6",
+				"scopeBackoffBase: 10s",
+				"scopeBackoffMax: 10m",
+				"noActionRequiredDelayHours: 48",
+				"timeouts:",
+				"awaitingApproval: 25m",
+			} {
+				Expect(data).To(ContainSubstring(want), "RO v1.4 config should contain %q, got:\n%s", want, data)
+			}
+		})
+	})
+
+	Describe("WorkflowExecution ConfigMap", func() {
+		It("uses default workflow namespace", func() {
+			kn := testKubernaut()
+			cm, err := WorkflowExecutionConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["workflowexecution.yaml"]
+			Expect(data).To(ContainSubstring("kubernaut-workflows"), "WE config should use default workflow namespace, got:\n%s", data)
+		})
+
+		It("uses custom workflow namespace from the CR", func() {
+			kn := testKubernaut()
+			kn.Spec.WorkflowExecution.WorkflowNamespace = "custom-wf"
+			cm, err := WorkflowExecutionConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["workflowexecution.yaml"]
+			Expect(data).To(ContainSubstring("custom-wf"), "WE config should use custom workflow namespace, got:\n%s", data)
+		})
+
+		It("wires Ansible when enabled", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.Enabled = true
+			kn.Spec.Ansible.APIURL = "https://awx.example.com"
+			kn.Spec.Ansible.OrganizationID = 42
+			kn.Spec.Ansible.TokenSecretRef = &kubernautv1alpha1.SecretKeyRef{
+				Name: "awx-token",
+				Key:  "api-token",
+			}
+			cm, err := WorkflowExecutionConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["workflowexecution.yaml"]
+
+			for _, want := range []string{
+				"ansible:",
+				"apiURL: https://awx.example.com",
+				"organizationID: 42",
+				"tokenSecretRef:",
+				"name: awx-token",
+				"key: api-token",
+			} {
+				Expect(data).To(ContainSubstring(want), "WE config should contain %q when Ansible enabled, got:\n%s", want, data)
+			}
+		})
+
+		It("omits Ansible when disabled", func() {
+			kn := testKubernaut()
+			cm, err := WorkflowExecutionConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["workflowexecution.yaml"]
+
+			Expect(data).NotTo(ContainSubstring("ansible:"), "WE config should not contain ansible section when disabled, got:\n%s", data)
+		})
+
+		It("uses nested execution, datastorage, and controller structure", func() {
+			kn := testKubernaut()
+			cm, err := WorkflowExecutionConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["workflowexecution.yaml"]
+
+			for _, want := range []string{
+				"execution:",
+				"namespace: kubernaut-workflows",
+				"cooldownPeriod:",
+				"datastorage:",
+				"url: https://data-storage-service",
+				"controller:",
+				"leaderElectionId: workflowexecution.kubernaut.ai",
+			} {
+				Expect(data).To(ContainSubstring(want), "WE config should contain %q, got:\n%s", want, data)
+			}
+		})
+
+		It("renders logging level", func() {
+			kn := testKubernaut()
+			kn.Spec.WorkflowExecution.Logging.Level = "error"
+			cm, err := WorkflowExecutionConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["workflowexecution.yaml"]
+			Expect(strings.Contains(data, "logging:") && strings.Contains(data, "level: error")).To(BeTrue(), "WE config should render logging.level, got:\n%s", data)
+		})
+
+		It("renders Tekton enabled when set", func() {
+			kn := testKubernaut()
+			on := true
+			kn.Spec.WorkflowExecution.Tekton.Enabled = &on
+			cm, err := WorkflowExecutionConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["workflowexecution.yaml"]
+			Expect(strings.Contains(data, "tekton:") && strings.Contains(data, "enabled: true")).To(BeTrue(), "WE config should render tekton.enabled, got:\n%s", data)
+		})
+	})
+
+	Describe("EffectivenessMonitor ConfigMap", func() {
+		It("includes default stabilization window", func() {
+			kn := testKubernaut()
+			cm, err := EffectivenessMonitorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["effectivenessmonitor.yaml"]
+			Expect(data).To(ContainSubstring("stabilizationWindow: 30s"), "EM config should have default stabilization window, got:\n%s", data)
+		})
+
+		It("includes monitoring URLs when monitoring is enabled", func() {
+			kn := testKubernaut()
+			cm, err := EffectivenessMonitorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["effectivenessmonitor.yaml"]
+
+			Expect(data).To(ContainSubstring(OCPPrometheusURL), "EM config should contain Prometheus URL when monitoring enabled, got:\n%s", data)
+			Expect(data).To(ContainSubstring(OCPAlertManagerURL), "EM config should contain AlertManager URL when monitoring enabled, got:\n%s", data)
+			Expect(data).To(ContainSubstring("external:"), "EM config should contain external section when monitoring enabled, got:\n%s", data)
+			Expect(data).To(ContainSubstring("tlsCaFile: /etc/ssl/em/service-ca.crt"), "EM config should contain external.tlsCaFile when monitoring enabled, got:\n%s", data)
+		})
+
+		It("omits external monitoring when monitoring is disabled", func() {
+			kn := testKubernaut()
+			disabled := false
+			kn.Spec.Monitoring.Enabled = &disabled
+			cm, err := EffectivenessMonitorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["effectivenessmonitor.yaml"]
+
+			Expect(data).NotTo(ContainSubstring("external:"), "EM config should not contain external monitoring section when disabled, got:\n%s", data)
+		})
+
+		It("renders v1.4 logging and datastorage buffer settings", func() {
+			kn := testKubernaut()
+			kn.Spec.EffectivenessMonitor.Logging.Level = "debug"
+			cm, err := EffectivenessMonitorConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["effectivenessmonitor.yaml"]
+			for _, want := range []string{
+				"logging:",
+				"level: debug",
+				"datastorage:",
+				"timeout: 10s",
+				"buffer:",
+				"bufferSize: 100",
+				"batchSize: 10",
+				"flushInterval: 1s",
+				"maxRetries: 3",
+			} {
+				Expect(data).To(ContainSubstring(want), "EM v1.4 config should contain %q, got:\n%s", want, data)
+			}
+		})
+	})
+
+	Describe("Notification ConfigMap", func() {
+		It("routing includes Slack when configured", func() {
+			kn := testKubernaut()
+			kn.Spec.Notification.Slack.SecretName = "slack-webhook"
+			kn.Spec.Notification.Slack.Channel = "#ops"
+			cm, err := NotificationRoutingConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["routing.yaml"]
+			Expect(data).To(ContainSubstring("slack"), "routing config should reference slack receiver, got:\n%s", data)
+			Expect(data).To(ContainSubstring("#ops"), "routing config should contain channel #ops, got:\n%s", data)
+		})
+
+		It("routing falls back to console without Slack", func() {
+			kn := testKubernaut()
+			cm, err := NotificationRoutingConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			data := cm.Data["routing.yaml"]
+			Expect(data).To(ContainSubstring("console"), "routing config without slack should use console receiver, got:\n%s", data)
+			Expect(data).NotTo(ContainSubstring("slack"), "routing config should not contain slack when Slack is unconfigured, got:\n%s", data)
+		})
+
+		It("controller config places credentials under delivery", func() {
+			kn := testKubernaut()
+			cm, err := NotificationControllerConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			Expect(data).To(ContainSubstring("delivery:"), "notification config should contain delivery: block, got:\n%s", data)
+			Expect(data).To(ContainSubstring("credentials:"), "notification config should contain credentials: block, got:\n%s", data)
+			Expect(data).To(ContainSubstring("dir: /etc/notification/credentials"), "notification config should contain credentials dir, got:\n%s", data)
+		})
+
+		It("routing still builds default content when Routing ConfigMap is BYO", func() {
+			kn := testKubernaut()
+			kn.Spec.Notification.Routing = &kubernautv1alpha1.ConfigMapRef{ConfigMapName: "my-routing"}
+			cm, err := NotificationRoutingConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cm.Name).To(Equal("notification-routing-config"), "NotificationRoutingConfigMap name = %q, want notification-routing-config (BYO affects deployment/controller, not this builder)", cm.Name)
+			data := cm.Data["routing.yaml"]
+			Expect(data).To(ContainSubstring("console"), "expected default routing content when builder invoked, got:\n%s", data)
+		})
+	})
+
+	Describe("KubernautAgent ConfigMap", func() {
+		It("includes monitoring and data storage integration when monitoring enabled", func() {
+			kn := testKubernaut()
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+
+			Expect(data).To(ContainSubstring(OCPPrometheusURL), "KA config should contain Prometheus URL when monitoring enabled, got:\n%s", data)
+			Expect(data).To(ContainSubstring("tlsCaFile: /etc/ssl/ka/service-ca.crt"), "KA config should contain Prometheus tlsCaFile for SA bearer auth, got:\n%s", data)
+			Expect(data).To(ContainSubstring("dataStorage:"), "KA config should contain dataStorage section, got:\n%s", data)
+			Expect(data).To(ContainSubstring("url: https://data-storage-service.kubernaut-system.svc.cluster.local:8080"), "KA config should contain HTTPS dataStorage.url, got:\n%s", data)
+			Expect(strings.Contains(data, "tools:") && strings.Contains(data, "prometheus:")).To(BeTrue(), "KA config should contain upstream tools.prometheus section when monitoring enabled, got:\n%s", data)
+		})
+
+		It("omits Prometheus tools when monitoring is disabled", func() {
+			kn := testKubernaut()
+			disabled := false
+			kn.Spec.Monitoring.Enabled = &disabled
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+
+			Expect(strings.Contains(data, "prometheusUrl") || strings.Contains(data, "tools:")).To(BeFalse(), "KA config should not contain Prometheus tools section when monitoring is disabled, got:\n%s", data)
+		})
+
+		It("matches expected v1.4 structure and defaults", func() {
+			kn := testKubernaut()
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			var root struct {
+				Runtime struct {
+					Logging struct {
+						Level string `yaml:"level"`
+					} `yaml:"logging"`
+					Server struct {
+						Address string `yaml:"address"`
+						Port    int    `yaml:"port"`
+					} `yaml:"server"`
+					Audit struct {
+						BufferSize int `yaml:"bufferSize"`
+					} `yaml:"audit"`
+				} `yaml:"runtime"`
+				AI struct {
+					LLM struct {
+						Provider string `yaml:"provider"`
+					} `yaml:"llm"`
+					Investigation struct {
+						MaxTurns int `yaml:"maxTurns"`
+					} `yaml:"investigation"`
+				} `yaml:"ai"`
+				Integrations struct {
+					DataStorage struct {
+						URL string `yaml:"url"`
+					} `yaml:"dataStorage"`
+					Tools *struct {
+						Prometheus struct {
+							URL       string `yaml:"url"`
+							TLSCaFile string `yaml:"tlsCaFile"`
+						} `yaml:"prometheus"`
+					} `yaml:"tools,omitempty"`
+				} `yaml:"integrations"`
+			}
+			err = yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(root.Runtime.Logging.Level).To(Equal("info"), "runtime.logging.level = %q, want info", root.Runtime.Logging.Level)
+			Expect(root.Runtime.Server.Port == 8080 && root.Runtime.Server.Address == "0.0.0.0").To(BeTrue(), "runtime.server = %#v, want address 0.0.0.0 port 8080", root.Runtime.Server)
+			Expect(root.Runtime.Audit.BufferSize).To(Equal(10000), "runtime.audit.bufferSize = %d, want 10000", root.Runtime.Audit.BufferSize)
+			Expect(root.AI.LLM.Provider).To(Equal("openai"), "ai.llm.provider = %q, want openai", root.AI.LLM.Provider)
+			Expect(root.AI.Investigation.MaxTurns).To(Equal(40), "ai.investigation.maxTurns = %d, want 40", root.AI.Investigation.MaxTurns)
+			wantDS := DataStorageURL(kn.Namespace)
+			Expect(root.Integrations.DataStorage.URL).To(Equal(wantDS), "integrations.dataStorage.url = %q, want %q", root.Integrations.DataStorage.URL, wantDS)
+			Expect(root.Integrations.Tools).NotTo(BeNil(), "integrations.tools should be present when monitoring is enabled by default")
+			Expect(root.Integrations.Tools.Prometheus.URL).To(Equal(OCPPrometheusURL), "integrations.tools.prometheus.url = %q, want %q", root.Integrations.Tools.Prometheus.URL, OCPPrometheusURL)
+			Expect(root.Integrations.Tools.Prometheus.TLSCaFile).To(Equal("/etc/ssl/ka/service-ca.crt"), "integrations.tools.prometheus.tlsCaFile = %q, want /etc/ssl/ka/service-ca.crt", root.Integrations.Tools.Prometheus.TLSCaFile)
+		})
+
+		It("renders alignment check settings when enabled", func() {
+			kn := testKubernaut()
+			kn.Spec.KubernautAgent.AlignmentCheck.Enabled = true
+			kn.Spec.KubernautAgent.AlignmentCheck.Timeout = "20s"
+			kn.Spec.KubernautAgent.AlignmentCheck.MaxStepTokens = 1024
+			kn.Spec.KubernautAgent.AlignmentCheck.LLM = &kubernautv1alpha1.AlignmentCheckLLMSpec{
+				Provider: "openai",
+				Model:    "gpt-4o-mini",
+				Endpoint: "https://align.example/v1",
+			}
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			data := cm.Data["config.yaml"]
+			for _, want := range []string{
+				"alignmentCheck:",
+				"enabled: true",
+				"timeout: 20s",
+				"maxStepTokens: 1024",
+				"llm:",
+				"provider: openai",
+				"model: gpt-4o-mini",
+				"endpoint: https://align.example/v1",
+			} {
+				Expect(data).To(ContainSubstring(want), "KA config should contain %q when alignment check enabled, got:\n%s", want, data)
+			}
+		})
+
+		It("propagates custom LLM TLS CA file", func() {
+			kn := testKubernaut()
+			kn.Spec.KubernautAgent.LLM.TLSCaFile = "/etc/custom-ca/llm.pem"
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			var root struct {
+				AI struct {
+					LLM struct {
+						TLSCaFile string `yaml:"tlsCaFile"`
+					} `yaml:"llm"`
+				} `yaml:"ai"`
+			}
+			err = yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(root.AI.LLM.TLSCaFile).To(Equal("/etc/custom-ca/llm.pem"), "ai.llm.tlsCaFile = %q, want /etc/custom-ca/llm.pem", root.AI.LLM.TLSCaFile)
+		})
+
+		It("renders non-default summarizer thresholds", func() {
+			kn := testKubernaut()
+			kn.Spec.KubernautAgent.Summarizer.Threshold = 5000
+			kn.Spec.KubernautAgent.Summarizer.MaxToolOutputSize = 50000
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			var root struct {
+				AI struct {
+					Summarizer *struct {
+						Threshold         int `yaml:"threshold"`
+						MaxToolOutputSize int `yaml:"maxToolOutputSize"`
+					} `yaml:"summarizer"`
+				} `yaml:"ai"`
+			}
+			err = yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(root.AI.Summarizer).NotTo(BeNil(), "expected ai.summarizer block for non-default summarizer settings")
+			Expect(root.AI.Summarizer.Threshold).To(Equal(5000), "summarizer.threshold = %d, want 5000", root.AI.Summarizer.Threshold)
+			Expect(root.AI.Summarizer.MaxToolOutputSize).To(Equal(50000), "summarizer.maxToolOutputSize = %d, want 50000", root.AI.Summarizer.MaxToolOutputSize)
+		})
+
+		It("renders safety anomaly max tool calls per tool", func() {
+			kn := testKubernaut()
+			maxPer := 5
+			kn.Spec.KubernautAgent.Safety.Anomaly.MaxToolCallsPerTool = &maxPer
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			var root struct {
+				AI struct {
+					Safety struct {
+						Anomaly struct {
+							MaxToolCallsPerTool int `yaml:"maxToolCallsPerTool"`
+						} `yaml:"anomaly"`
+					} `yaml:"safety"`
+				} `yaml:"ai"`
+			}
+			err = yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(root.AI.Safety.Anomaly.MaxToolCallsPerTool).To(Equal(5), "ai.safety.anomaly.maxToolCallsPerTool = %d, want 5", root.AI.Safety.Anomaly.MaxToolCallsPerTool)
+		})
+
+		It("renders LLM OAuth2 block when enabled", func() {
+			kn := testKubernaut()
+			kn.Spec.KubernautAgent.LLM.OAuth2.Enabled = true
+			kn.Spec.KubernautAgent.LLM.OAuth2.TokenURL = "https://idp.example/oauth/token"
+			kn.Spec.KubernautAgent.LLM.OAuth2.Scopes = []string{"openid", "api.read"}
+			cm, err := KubernautAgentConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+			var root struct {
+				AI struct {
+					LLM struct {
+						OAuth2 *struct {
+							Enabled  bool     `yaml:"enabled"`
+							TokenURL string   `yaml:"tokenURL"`
+							Scopes   []string `yaml:"scopes"`
+						} `yaml:"oauth2"`
+					} `yaml:"llm"`
+				} `yaml:"ai"`
+			}
+			err = yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(root.AI.LLM.OAuth2).NotTo(BeNil(), "expected ai.llm.oauth2 block when OAuth2 enabled")
+			Expect(root.AI.LLM.OAuth2.Enabled).To(BeTrue(), "oauth2.enabled should be true")
+			Expect(root.AI.LLM.OAuth2.TokenURL).To(Equal("https://idp.example/oauth/token"), "oauth2.tokenURL = %q", root.AI.LLM.OAuth2.TokenURL)
+			Expect(len(root.AI.LLM.OAuth2.Scopes) == 2 && root.AI.LLM.OAuth2.Scopes[0] == "openid" && root.AI.LLM.OAuth2.Scopes[1] == "api.read").To(BeTrue(), "oauth2.scopes = %#v, want [openid api.read]", root.AI.LLM.OAuth2.Scopes)
+		})
+
+		Describe("LLM runtime ConfigMap", func() {
+			It("is generated when no existing ConfigMap is specified", func() {
+				kn := testKubernaut()
+				cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(cm).NotTo(BeNil(), "KubernautAgentLLMRuntimeConfigMap should not be nil when no existing CM specified")
+				data := cm.Data["llm-runtime.yaml"]
+				Expect(data).To(ContainSubstring("model: gpt-4o"), "LLM runtime config should contain model, got:\n%s", data)
+				Expect(data).To(ContainSubstring("temperature:"), "LLM runtime config should contain temperature, got:\n%s", data)
+			})
+
+			It("is nil when user provides existing ConfigMap name", func() {
+				kn := testKubernaut()
+				kn.Spec.KubernautAgent.LLM.RuntimeConfigMapName = "my-llm-runtime-config"
+				cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cm).To(BeNil(), "KubernautAgentLLMRuntimeConfigMap should be nil when user provides existing CM")
+			})
+
+			It("includes default model and retry settings", func() {
+				kn := testKubernaut()
+				cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["llm-runtime.yaml"]
+				for _, want := range []string{
+					"model: gpt-4o",
+					"temperature: 0.7",
+					"maxRetries: 3",
+					"timeoutSeconds: 120",
+				} {
+					Expect(data).To(ContainSubstring(want), "llm-runtime defaults should contain %q, got:\n%s", want, data)
+				}
+			})
+
+			It("applies custom LLM runtime values", func() {
+				kn := testKubernaut()
+				kn.Spec.KubernautAgent.LLM.Temperature = "0.5"
+				kn.Spec.KubernautAgent.LLM.Endpoint = "https://llm-custom.example/v1"
+				maxR := 7
+				kn.Spec.KubernautAgent.LLM.MaxRetries = &maxR
+				cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data["llm-runtime.yaml"]
+				for _, want := range []string{
+					"temperature: 0.5",
+					"endpoint: https://llm-custom.example/v1",
+					"maxRetries: 7",
+				} {
+					Expect(data).To(ContainSubstring(want), "llm-runtime custom values should contain %q, got:\n%s", want, data)
+				}
+			})
+
+			It("returns nil when runtimeConfigMapName is set (BYO)", func() {
+				kn := testKubernaut()
+				kn.Spec.KubernautAgent.LLM.RuntimeConfigMapName = "user-llm-runtime"
+				cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cm).To(BeNil(), "KubernautAgentLLMRuntimeConfigMap should return nil when runtimeConfigMapName is set (BYO)")
+			})
+		})
+	})
+
+	Describe("AuthWebhook ConfigMap", func() {
+		It("writes authwebhook.yaml as the config key", func() {
+			kn := testKubernaut()
+			cm, err := AuthWebhookConfigMap(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cm.Data).To(HaveKey("authwebhook.yaml"), "AuthWebhookConfigMap should write authwebhook.yaml, keys: %#v", cm.Data)
+		})
+	})
+
+	Describe("Inter-service CA and service-ca ConfigMaps", func() {
+		It("inter-service CA ConfigMap has inject-cabundle annotation and expected name", func() {
+			kn := testKubernaut()
+			cm := InterServiceCAConfigMap(kn)
+			Expect(cm.Name).To(Equal(InterServiceCAConfigMapName))
+			v, ok := cm.Annotations[OCPServiceCAInjectAnnotation]
+			Expect(ok && v == injectCABundleAnnotationValue).To(BeTrue(), "inter-service-ca ConfigMap should have inject-cabundle annotation")
+		})
+
+		DescribeTable("OpenShift service-ca ConfigMaps have inject-cabundle annotation",
+			func(mkCM func(*kubernautv1alpha1.Kubernaut) *corev1.ConfigMap) {
+				kn := testKubernaut()
+				cm := mkCM(kn)
+				Expect(cm.Annotations["service.beta.openshift.io/inject-cabundle"]).To(Equal(injectCABundleAnnotationValue))
+			},
+			Entry("effectivenessmonitor-service-ca", EffectivenessMonitorServiceCAConfigMap),
+			Entry("kubernaut-agent-service-ca", KubernautAgentServiceCAConfigMap),
+		)
+	})
+
+	Describe("Policy ConfigMaps", func() {
+		It("AIAnalysis policies default Rego Policy is generated when ConfigMapName is empty", func() {
+			kn := testKubernaut()
+			kn.Spec.AIAnalysis.Policy.ConfigMapName = ""
+
+			cm := AIAnalysisPoliciesConfigMap(kn)
+			Expect(cm).NotTo(BeNil(), "AIAnalysisPoliciesConfigMap should return non-nil when ConfigMapName is empty")
+			Expect(cm.Name).To(Equal("aianalysis-policies"), "Name = %q, want %q", cm.Name, "aianalysis-policies")
+			rego, ok := cm.Data["approval.rego"]
+			Expect(ok).To(BeTrue(), "ConfigMap should contain approval.rego key")
+			Expect(rego).To(ContainSubstring("package kubernaut.aianalysis"), "approval.rego should contain Rego package declaration, got:\n%s", rego)
+		})
+
+		It("AIAnalysis policies returns nil when user provides ConfigMapName", func() {
+			kn := testKubernaut()
+			kn.Spec.AIAnalysis.Policy.ConfigMapName = "user-custom-policies"
+
+			cm := AIAnalysisPoliciesConfigMap(kn)
+			Expect(cm).To(BeNil(), "AIAnalysisPoliciesConfigMap should return nil when user provides ConfigMapName")
+		})
+
+		It("SignalProcessing policy default Rego is generated when ConfigMapName is empty", func() {
+			kn := testKubernaut()
+			kn.Spec.SignalProcessing.Policy.ConfigMapName = ""
+
+			cm := SignalProcessingPolicyConfigMap(kn)
+			Expect(cm).NotTo(BeNil(), "SignalProcessingPolicyConfigMap should return non-nil when ConfigMapName is empty")
+			Expect(cm.Name).To(Equal("signalprocessing-policy"), "Name = %q, want %q", cm.Name, "signalprocessing-policy")
+			rego, ok := cm.Data["policy.rego"]
+			Expect(ok).To(BeTrue(), "ConfigMap should contain policy.rego key")
+			Expect(rego).To(ContainSubstring("package kubernaut.signalprocessing"), "policy.rego should contain Rego package declaration, got:\n%s", rego)
+		})
+
+		It("SignalProcessing policy returns nil when user provides ConfigMapName", func() {
+			kn := testKubernaut()
+			kn.Spec.SignalProcessing.Policy.ConfigMapName = "user-sp-policy"
+
+			cm := SignalProcessingPolicyConfigMap(kn)
+			Expect(cm).To(BeNil(), "SignalProcessingPolicyConfigMap should return nil when user provides ConfigMapName")
+		})
+	})
+
+	Describe("ProactiveSignalMappings", func() {
+		It("default mappings are generated when no user override", func() {
+			kn := testKubernaut()
+
+			cm := ProactiveSignalMappingsConfigMap(kn)
+			Expect(cm).NotTo(BeNil(), "ProactiveSignalMappingsConfigMap should return non-nil when no user override")
+			Expect(cm.Name).To(Equal("signalprocessing-proactive-signal-mappings"), "Name = %q, want %q", cm.Name, "signalprocessing-proactive-signal-mappings")
+			data, ok := cm.Data["proactive-signal-mappings.yaml"]
+			Expect(ok).To(BeTrue(), "ConfigMap should contain proactive-signal-mappings.yaml key")
+			for _, mapping := range []string{
+				"PredictedOOMKill", "OOMKilled",
+				"PredictedCPUThrottling", "CPUThrottling",
+				"PredictedDiskPressure", "DiskPressure",
+				"PredictedNodeNotReady", "NodeNotReady",
+			} {
+				Expect(data).To(ContainSubstring(mapping), "proactive-signal-mappings.yaml should contain %q, got:\n%s", mapping, data)
+			}
+		})
+
+		It("returns nil when user provides ConfigMapName", func() {
+			kn := testKubernaut()
+			kn.Spec.SignalProcessing.ProactiveSignalMappings = &kubernautv1alpha1.ConfigMapRef{
+				ConfigMapName: "user-proactive-mappings",
+			}
+
+			cm := ProactiveSignalMappingsConfigMap(kn)
+			Expect(cm).To(BeNil(), "ProactiveSignalMappingsConfigMap should return nil when user provides ConfigMapName")
+		})
+	})
+
+	Describe("Cross-cutting", func() {
+		It("built service ConfigMaps use the system namespace", func() {
+			kn := testKubernaut()
+			type builder struct {
+				name string
+				fn   func() (*corev1.ConfigMap, error)
+			}
+			builders := []builder{
+				{"gateway", func() (*corev1.ConfigMap, error) { return GatewayConfigMap(kn) }},
+				{"datastorage", func() (*corev1.ConfigMap, error) { return DataStorageConfigMap(kn, "db", "user") }},
+				{"aianalysis", func() (*corev1.ConfigMap, error) { return AIAnalysisConfigMap(kn) }},
+				{"signalprocessing", func() (*corev1.ConfigMap, error) { return SignalProcessingConfigMap(kn) }},
+				{"remediationorchestrator", func() (*corev1.ConfigMap, error) { return RemediationOrchestratorConfigMap(kn) }},
+				{"workflowexecution", func() (*corev1.ConfigMap, error) { return WorkflowExecutionConfigMap(kn) }},
+				{"effectivenessmonitor", func() (*corev1.ConfigMap, error) { return EffectivenessMonitorConfigMap(kn) }},
+				{"notification-controller", func() (*corev1.ConfigMap, error) { return NotificationControllerConfigMap(kn) }},
+				{"kubernaut-agent", func() (*corev1.ConfigMap, error) { return KubernautAgentConfigMap(kn) }},
+				{"authwebhook", func() (*corev1.ConfigMap, error) { return AuthWebhookConfigMap(kn) }},
+			}
+			for _, b := range builders {
+				cm, err := b.fn()
+				Expect(err).NotTo(HaveOccurred(), "building %s ConfigMap", b.name)
+				Expect(cm.Namespace).To(Equal(testSystemNamespace), "ConfigMap %q namespace = %q, want %q", cm.Name, cm.Namespace, testSystemNamespace)
+			}
+		})
+
+		const loggingLevelAllServicesTestLevel = "error"
+
+		DescribeTable("logging level propagates to each service ConfigMap",
+			func(prep func(*kubernautv1alpha1.Kubernaut), key string, fn func(*kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error)) {
+				kn := testKubernaut()
+				prep(kn)
+				cm, err := fn(kn)
+				Expect(err).NotTo(HaveOccurred())
+				data := cm.Data[key]
+				Expect(data).To(ContainSubstring("level: "+loggingLevelAllServicesTestLevel), "expected logging level %q in %s, got:\n%s", loggingLevelAllServicesTestLevel, key, data)
+			},
+			Entry("gateway",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.Gateway.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"config.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return GatewayConfigMap(kn) },
+			),
+			Entry("datastorage",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.DataStorage.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"config.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
+					return DataStorageConfigMap(kn, "kubernautdb", "kubernautuser")
+				},
+			),
+			Entry("aianalysis",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.AIAnalysis.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"config.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return AIAnalysisConfigMap(kn) },
+			),
+			Entry("signalprocessing",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.SignalProcessing.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"config.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
+					return SignalProcessingConfigMap(kn)
+				},
+			),
+			Entry("remediationorchestrator",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.RemediationOrchestrator.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"remediationorchestrator.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
+					return RemediationOrchestratorConfigMap(kn)
+				},
+			),
+			Entry("workflowexecution",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.WorkflowExecution.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"workflowexecution.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
+					return WorkflowExecutionConfigMap(kn)
+				},
+			),
+			Entry("effectivenessmonitor",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.EffectivenessMonitor.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"effectivenessmonitor.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
+					return EffectivenessMonitorConfigMap(kn)
+				},
+			),
+			Entry("notification-controller",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.Notification.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"config.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) {
+					return NotificationControllerConfigMap(kn)
+				},
+			),
+			Entry("kubernaut-agent",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.KubernautAgent.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"config.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return KubernautAgentConfigMap(kn) },
+			),
+			Entry("authwebhook",
+				func(kn *kubernautv1alpha1.Kubernaut) {
+					kn.Spec.AuthWebhook.Logging.Level = loggingLevelAllServicesTestLevel
+				},
+				"authwebhook.yaml",
+				func(kn *kubernautv1alpha1.Kubernaut) (*corev1.ConfigMap, error) { return AuthWebhookConfigMap(kn) },
+			),
+		)
+	})
+})

--- a/internal/resources/crds_test.go
+++ b/internal/resources/crds_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
 	"io/fs"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	sigsyaml "sigs.k8s.io/yaml"
@@ -27,87 +30,73 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/assets"
 )
 
-func TestEnsureCRDs_EmbeddedYAMLParses(t *testing.T) {
-	entries, err := fs.ReadDir(assets.CRDsFS, "crds")
-	if err != nil {
-		t.Fatalf("reading embedded CRDs: %v", err)
-	}
+var _ = Describe("EnsureCRDs embedded assets", func() {
+	It("parses each embedded CRD YAML", func() {
+		entries, err := fs.ReadDir(assets.CRDsFS, "crds")
+		Expect(err).NotTo(HaveOccurred())
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		data, err := fs.ReadFile(assets.CRDsFS, "crds/"+entry.Name())
-		if err != nil {
-			t.Errorf("reading %s: %v", entry.Name(), err)
-			continue
-		}
+		var errs []string
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			data, err := fs.ReadFile(assets.CRDsFS, "crds/"+entry.Name())
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("reading %s: %v", entry.Name(), err))
+				continue
+			}
 
-		crd := &apiextensionsv1.CustomResourceDefinition{}
-		if err := sigsyaml.Unmarshal(data, crd); err != nil {
-			t.Errorf("CRD %s fails to unmarshal: %v", entry.Name(), err)
-			continue
-		}
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			if err := sigsyaml.Unmarshal(data, crd); err != nil {
+				errs = append(errs, fmt.Sprintf("CRD %s fails to unmarshal: %v", entry.Name(), err))
+				continue
+			}
 
-		if crd.Name == "" {
-			t.Errorf("CRD %s has no metadata.name", entry.Name())
-		}
-		if crd.Spec.Group == "" {
-			t.Errorf("CRD %s has no spec.group", entry.Name())
-		}
-	}
-}
-
-func TestEnsureCRDs_YamlToUnstructured_PreservesAllFields(t *testing.T) {
-	entries, err := fs.ReadDir(assets.CRDsFS, "crds")
-	if err != nil {
-		t.Fatalf("reading embedded CRDs: %v", err)
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		data, err := fs.ReadFile(assets.CRDsFS, "crds/"+entry.Name())
-		if err != nil {
-			t.Fatalf("reading %s: %v", entry.Name(), err)
-		}
-		raw := string(data)
-
-		obj, err := yamlToUnstructured(data)
-		if err != nil {
-			t.Fatalf("yamlToUnstructured(%s): %v", entry.Name(), err)
-		}
-
-		roundTripped, err := obj.MarshalJSON()
-		if err != nil {
-			t.Fatalf("re-marshalling %s: %v", entry.Name(), err)
-		}
-
-		if strings.Contains(raw, "serviceAccountName") {
-			if !strings.Contains(string(roundTripped), "serviceAccountName") {
-				t.Errorf("%s: raw YAML has serviceAccountName but yamlToUnstructured round-trip lost it", entry.Name())
+			if crd.Name == "" {
+				errs = append(errs, fmt.Sprintf("CRD %s has no metadata.name", entry.Name()))
+			}
+			if crd.Spec.Group == "" {
+				errs = append(errs, fmt.Sprintf("CRD %s has no spec.group", entry.Name()))
 			}
 		}
+		Expect(errs).To(BeEmpty())
+	})
 
-		if obj.GetName() == "" {
-			t.Errorf("%s has no metadata.name after yamlToUnstructured", entry.Name())
-		}
-	}
-}
+	It("preserves fields through yamlToUnstructured JSON round-trip", func() {
+		entries, err := fs.ReadDir(assets.CRDsFS, "crds")
+		Expect(err).NotTo(HaveOccurred())
 
-func TestEnsureCRDs_EmbeddedCRDCount(t *testing.T) {
-	entries, err := fs.ReadDir(assets.CRDsFS, "crds")
-	if err != nil {
-		t.Fatalf("reading embedded CRDs: %v", err)
-	}
-	count := 0
-	for _, e := range entries {
-		if !e.IsDir() {
-			count++
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			data, err := fs.ReadFile(assets.CRDsFS, "crds/"+entry.Name())
+			Expect(err).NotTo(HaveOccurred(), "reading %s", entry.Name())
+			raw := string(data)
+
+			obj, err := yamlToUnstructured(data)
+			Expect(err).NotTo(HaveOccurred(), "yamlToUnstructured(%s)", entry.Name())
+
+			roundTripped, err := obj.MarshalJSON()
+			Expect(err).NotTo(HaveOccurred(), "re-marshalling %s", entry.Name())
+
+			if strings.Contains(raw, "serviceAccountName") {
+				Expect(string(roundTripped)).To(ContainSubstring("serviceAccountName"), "%s: raw YAML has serviceAccountName but yamlToUnstructured round-trip lost it", entry.Name())
+			}
+
+			Expect(obj.GetName()).NotTo(BeEmpty(), "%s has no metadata.name after yamlToUnstructured", entry.Name())
 		}
-	}
-	if count < 9 {
-		t.Errorf("expected at least 9 embedded CRD files, got %d", count)
-	}
-}
+	})
+
+	It("embeds at least 9 CRD files", func() {
+		entries, err := fs.ReadDir(assets.CRDsFS, "crds")
+		Expect(err).NotTo(HaveOccurred())
+		count := 0
+		for _, e := range entries {
+			if !e.IsDir() {
+				count++
+			}
+		}
+		Expect(count).To(BeNumerically(">=", 9))
+	})
+})

--- a/internal/resources/deployments_test.go
+++ b/internal/resources/deployments_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package resources
 
 import (
-	"strings"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,1116 +26,13 @@ import (
 	kubernautv1alpha1 "github.com/jordigilh/kubernaut-operator/api/v1alpha1"
 )
 
-func TestGatewayDeployment_Basic(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := GatewayDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertDeploymentBasics(t, dep, "gateway")
-	assertHasVolume(t, dep, "config")
-	assertVolumeSourceConfigMap(t, dep, "config", "gateway-config")
-	assertHasVolumeMount(t, dep, "config", "/etc/gateway")
-}
-
-func TestGatewayDeployment_CORSEnvVar(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := GatewayDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	found := false
-	for _, env := range container.Env {
-		if env.Name == "CORS_ALLOWED_ORIGINS" {
-			found = true
-			if env.Value != "https://no-browser-clients.invalid" {
-				t.Errorf("CORS_ALLOWED_ORIGINS = %q, want default deny-all origin", env.Value)
-			}
-		}
-	}
-	if !found {
-		t.Error("Gateway deployment should have CORS_ALLOWED_ORIGINS env var")
-	}
-}
-
-func TestGatewayDeployment_CustomCORS(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Gateway.Config.CORSAllowedOrigins = "https://my-dashboard.example.com"
-	dep, err := GatewayDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	for _, env := range container.Env {
-		if env.Name == "CORS_ALLOWED_ORIGINS" {
-			if env.Value != "https://my-dashboard.example.com" {
-				t.Errorf("CORS_ALLOWED_ORIGINS = %q, want custom value", env.Value)
-			}
-			return
-		}
-	}
-	t.Error("CORS_ALLOWED_ORIGINS env var not found")
-}
-
-func TestDataStorageDeployment_InitContainer(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := DataStorageDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertDeploymentBasics(t, dep, "datastorage")
-
-	if len(dep.Spec.Template.Spec.InitContainers) != 1 {
-		t.Fatalf("DataStorage should have 1 init container, got %d", len(dep.Spec.Template.Spec.InitContainers))
-	}
-	init := dep.Spec.Template.Spec.InitContainers[0]
-	if init.Name != "wait-for-postgres" {
-		t.Errorf("init container name = %q, want %q", init.Name, "wait-for-postgres")
-	}
-	if init.Resources.Requests == nil {
-		t.Error("init container should have resource requests")
-	}
-}
-
-func TestDataStorageDeployment_ProjectedSecretsVolume(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := DataStorageDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var found bool
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == "secrets" && v.Projected != nil {
-			found = true
-			if len(v.Projected.Sources) != 2 {
-				t.Errorf("secrets projected volume should have 2 sources, got %d", len(v.Projected.Sources))
-			}
-		}
-	}
-	if !found {
-		t.Error("DataStorage should have a 'secrets' projected volume")
-	}
-}
-
-func TestAIAnalysisDeployment_PolicyVolume(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := AIAnalysisDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertDeploymentBasics(t, dep, "aianalysis")
-	assertHasVolume(t, dep, "rego-policies")
-	assertVolumeSourceConfigMap(t, dep, "rego-policies", "aianalysis-policies")
-	assertHasVolumeMount(t, dep, "rego-policies", "/etc/aianalysis/policies")
-}
-
-func TestSignalProcessingDeployment_PolicyMount(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := SignalProcessingDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "policy")
-	assertVolumeSourceConfigMap(t, dep, "policy", "signalprocessing-policy")
-	assertHasVolumeMount(t, dep, "policy", "/etc/signalprocessing/policies")
-}
-
-func TestSignalProcessingDeployment_ProactiveSignalMappings(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.SignalProcessing.ProactiveSignalMappings = &kubernautv1alpha1.ConfigMapRef{ConfigMapName: "my-mappings"}
-	dep, err := SignalProcessingDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "proactive-mappings")
-	assertHasVolumeMount(t, dep, "proactive-mappings", "/etc/signalprocessing/proactive-signal-mappings.yaml")
-}
-
-func TestSignalProcessingDeployment_DefaultProactiveSignalMappings(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := SignalProcessingDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "proactive-mappings")
-	assertVolumeSourceConfigMap(t, dep, "proactive-mappings", "signalprocessing-proactive-signal-mappings")
-	assertHasVolumeMount(t, dep, "proactive-mappings", "/etc/signalprocessing/proactive-signal-mappings.yaml")
-}
-
-func TestNotificationDeployment_SlackCredentialsVolume(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Notification.Slack.SecretName = "slack-secret"
-	dep, err := NotificationDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "credentials")
-	assertHasVolumeMount(t, dep, "credentials", "/etc/notification/credentials")
-}
-
-func TestNotificationDeployment_NoSlack_EmptyDirCredentials(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := NotificationDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == "credentials" {
-			if v.EmptyDir == nil {
-				t.Error("Notification credentials volume should be an emptyDir when Slack is not configured")
-			}
-			return
-		}
-	}
-	t.Error("Notification should still have a credentials volume (emptyDir) even without Slack")
-}
-
-func TestNotificationDeployment_OutputEmptyDir(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := NotificationDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "notification-output")
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == "notification-output" {
-			if v.EmptyDir == nil {
-				t.Error("notification-output volume should be an emptyDir")
-			}
-		}
-	}
-}
-
-func TestNotificationDeployment_RoutingConfigMount(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := NotificationDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "routing-config")
-	assertVolumeSourceConfigMap(t, dep, "routing-config", "notification-routing-config")
-	assertHasVolumeMount(t, dep, "routing-config", "/etc/notification-routing")
-}
-
-func TestNotificationDeployment_BYORoutingConfigMapName(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Notification.Routing = &kubernautv1alpha1.ConfigMapRef{ConfigMapName: "my-routing"}
-	dep, err := NotificationDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertHasVolume(t, dep, "routing-config")
-	assertVolumeSourceConfigMap(t, dep, "routing-config", "my-routing")
-	assertHasVolumeMount(t, dep, "routing-config", "/etc/notification-routing")
-}
-
-func TestKubernautAgentDeployment_LLMCredentials(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertDeploymentBasics(t, dep, "kubernautagent")
-	assertHasVolume(t, dep, "llm-credentials")
-	assertHasVolumeMount(t, dep, "llm-credentials", "/etc/kubernaut-agent/credentials")
-}
-
-func TestKubernautAgentDeployment_ConfigArgs(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	want := []string{
-		"-config", "/etc/kubernaut-agent/config.yaml",
-		"-llm-runtime", "/etc/kubernaut-agent/llm-runtime/llm-runtime.yaml",
-	}
-	if len(container.Args) != len(want) {
-		t.Fatalf("KA args len = %d, want %d (%v)", len(container.Args), len(want), container.Args)
-	}
-	for i := range want {
-		if container.Args[i] != want[i] {
-			t.Errorf("KA args[%d] = %q, want %q", i, container.Args[i], want[i])
-		}
-	}
-}
-
-func TestKubernautAgentDeployment_LLMRuntime(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == "sdk-config" {
-			t.Error("Kubernaut Agent deployment should not use sdk-config volume; v1.4 uses llm-runtime")
-		}
-	}
-	assertHasVolume(t, dep, "llm-runtime")
-	assertVolumeSourceConfigMap(t, dep, "llm-runtime", "kubernaut-agent-llm-runtime")
-	assertHasVolumeMount(t, dep, "llm-runtime", "/etc/kubernaut-agent/llm-runtime")
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	var hasPair bool
-	for i := 0; i < len(container.Args)-1; i++ {
-		if container.Args[i] == "-llm-runtime" && container.Args[i+1] == "/etc/kubernaut-agent/llm-runtime/llm-runtime.yaml" {
-			hasPair = true
-			break
-		}
-	}
-	if !hasPair {
-		t.Errorf("KA container should pass -llm-runtime with llm-runtime.yaml path, got args %v", container.Args)
-	}
-}
-
-func TestKubernautAgentDeployment_OAuth2(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.LLM.OAuth2.Enabled = true
-	kn.Spec.KubernautAgent.LLM.OAuth2.CredentialsSecretRef = "oauth2-credentials-secret"
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "oauth2-credentials")
-	assertHasVolumeMount(t, dep, "oauth2-credentials", "/etc/kubernaut-agent/oauth2")
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == "oauth2-credentials" {
-			if v.Secret == nil || v.Secret.SecretName != "oauth2-credentials-secret" {
-				t.Errorf("oauth2-credentials volume: got %#v, want Secret secretName=%q", v.Secret, "oauth2-credentials-secret")
-			}
-			return
-		}
-	}
-	t.Error("oauth2-credentials volume not found")
-}
-
-func TestKubernautAgentDeployment_ServiceCA_WhenMonitoringEnabled(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "service-ca")
-	assertHasVolumeMount(t, dep, "service-ca", "/etc/ssl/ka")
-}
-
-func TestKubernautAgentDeployment_IsOpenShiftEnv_WhenMonitoringEnabled(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	found := false
-	for _, env := range container.Env {
-		if env.Name == "IS_OPENSHIFT" && env.Value == "True" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("KA container should have IS_OPENSHIFT=True env var when monitoring is enabled")
-	}
-}
-
-func TestKubernautAgentDeployment_NoIsOpenShiftEnv_WhenMonitoringDisabled(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.Monitoring.Enabled = &disabled
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	for _, env := range container.Env {
-		if env.Name == "IS_OPENSHIFT" {
-			t.Error("KA container should not have IS_OPENSHIFT env var when monitoring is disabled")
-		}
-	}
-}
-
-func TestKubernautAgentDeployment_NoServiceCA_WhenMonitoringDisabled(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.Monitoring.Enabled = &disabled
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == "service-ca" {
-			t.Error("KA should not have service-ca volume when monitoring is disabled")
-		}
-	}
-}
-
-func TestEffectivenessMonitorDeployment_ServiceCA(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := EffectivenessMonitorDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertHasVolume(t, dep, "service-ca")
-}
-
-func TestEffectivenessMonitorDeployment_WaitForServiceCA_InitContainer(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := EffectivenessMonitorDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(dep.Spec.Template.Spec.InitContainers) != 1 {
-		t.Fatalf("EM should have 1 init container when monitoring enabled, got %d", len(dep.Spec.Template.Spec.InitContainers))
-	}
-	init := dep.Spec.Template.Spec.InitContainers[0]
-	if init.Name != "wait-for-service-ca" {
-		t.Errorf("init container name = %q, want %q", init.Name, "wait-for-service-ca")
-	}
-	if init.Resources.Requests == nil {
-		t.Error("init container should have resource requests")
-	}
-
-	hasMount := false
-	for _, vm := range init.VolumeMounts {
-		if vm.Name == "service-ca" && vm.MountPath == "/etc/ssl/em" {
-			hasMount = true
-		}
-	}
-	if !hasMount {
-		t.Error("init container should mount service-ca at /etc/ssl/em")
-	}
-}
-
-func TestEffectivenessMonitorDeployment_NoInitContainer_MonitoringDisabled(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.Monitoring.Enabled = &disabled
-	dep, err := EffectivenessMonitorDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(dep.Spec.Template.Spec.InitContainers) != 0 {
-		t.Errorf("EM should have 0 init containers when monitoring disabled, got %d", len(dep.Spec.Template.Spec.InitContainers))
-	}
-}
-
-func TestAuthWebhookDeployment_TLSAndPort(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := AuthWebhookDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assertDeploymentBasics(t, dep, "authwebhook")
-	assertHasVolume(t, dep, "webhook-certs")
-	assertHasVolumeMount(t, dep, "webhook-certs", "/tmp/k8s-webhook-server/serving-certs")
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	found := false
-	for _, p := range container.Ports {
-		if p.ContainerPort == 9443 && p.Name == "webhook" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("AuthWebhook should expose port 9443 named 'webhook'")
-	}
-}
-
-func TestAuthWebhookDeployment_RecreateStrategy(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := AuthWebhookDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if dep.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
-		t.Errorf("AuthWebhook strategy = %q, want Recreate", dep.Spec.Strategy.Type)
-	}
-}
-
-func TestAllDeployments_HTTPGetProbes(t *testing.T) {
-	kn := testKubernaut()
-	deps := getAllDeployments(t, kn)
-
-	for _, dep := range deps {
-		container := dep.Spec.Template.Spec.Containers[0]
-		component := dep.Spec.Template.Labels["app"]
-
-		if container.LivenessProbe == nil {
-			t.Fatalf("Deployment %q should have liveness probe", dep.Name)
-		}
-		if container.ReadinessProbe == nil {
-			t.Fatalf("Deployment %q should have readiness probe", dep.Name)
-		}
-
-		if container.LivenessProbe.HTTPGet == nil {
-			t.Errorf("Deployment %q liveness probe should use HTTPGet (not TCPSocket)", dep.Name)
-		}
-		if container.ReadinessProbe.HTTPGet == nil {
-			t.Errorf("Deployment %q readiness probe should use HTTPGet (not TCPSocket)", dep.Name)
-		}
-
-		pc := probeConfigForComponent(component)
-		lp := container.LivenessProbe
-		rp := container.ReadinessProbe
-
-		if lp.HTTPGet != nil && lp.HTTPGet.Path != pc.LivenessPath {
-			t.Errorf("Deployment %q liveness path = %q, want %q", dep.Name, lp.HTTPGet.Path, pc.LivenessPath)
-		}
-		if rp.HTTPGet != nil && rp.HTTPGet.Path != pc.ReadinessPath {
-			t.Errorf("Deployment %q readiness path = %q, want %q", dep.Name, rp.HTTPGet.Path, pc.ReadinessPath)
-		}
-	}
-}
-
-func TestAllDeployments_ProbeTimingMatchesHelmChart(t *testing.T) {
-	kn := testKubernaut()
-	deps := getAllDeployments(t, kn)
-
-	for _, dep := range deps {
-		container := dep.Spec.Template.Spec.Containers[0]
-		component := dep.Spec.Template.Labels["app"]
-		pc := probeConfigForComponent(component)
-
-		lp := container.LivenessProbe
-		rp := container.ReadinessProbe
-
-		if lp.InitialDelaySeconds != pc.LivenessInitialDelay {
-			t.Errorf("%s liveness InitialDelaySeconds = %d, want %d", dep.Name, lp.InitialDelaySeconds, pc.LivenessInitialDelay)
-		}
-		if lp.PeriodSeconds != pc.LivenessPeriod {
-			t.Errorf("%s liveness PeriodSeconds = %d, want %d", dep.Name, lp.PeriodSeconds, pc.LivenessPeriod)
-		}
-		if lp.TimeoutSeconds != pc.LivenessTimeout {
-			t.Errorf("%s liveness TimeoutSeconds = %d, want %d", dep.Name, lp.TimeoutSeconds, pc.LivenessTimeout)
-		}
-		if lp.FailureThreshold != pc.LivenessFailureThreshold {
-			t.Errorf("%s liveness FailureThreshold = %d, want %d", dep.Name, lp.FailureThreshold, pc.LivenessFailureThreshold)
-		}
-
-		if rp.InitialDelaySeconds != pc.ReadinessInitialDelay {
-			t.Errorf("%s readiness InitialDelaySeconds = %d, want %d", dep.Name, rp.InitialDelaySeconds, pc.ReadinessInitialDelay)
-		}
-		if rp.PeriodSeconds != pc.ReadinessPeriod {
-			t.Errorf("%s readiness PeriodSeconds = %d, want %d", dep.Name, rp.PeriodSeconds, pc.ReadinessPeriod)
-		}
-		if rp.TimeoutSeconds != pc.ReadinessTimeout {
-			t.Errorf("%s readiness TimeoutSeconds = %d, want %d", dep.Name, rp.TimeoutSeconds, pc.ReadinessTimeout)
-		}
-		if rp.FailureThreshold != pc.ReadinessFailureThreshold {
-			t.Errorf("%s readiness FailureThreshold = %d, want %d", dep.Name, rp.FailureThreshold, pc.ReadinessFailureThreshold)
-		}
-	}
-}
-
-func TestDeployments_MetricsPort(t *testing.T) {
-	kn := testKubernaut()
-	withMetrics := map[string]bool{
-		ComponentGateway:                 true,
-		ComponentDataStorage:             true,
-		ComponentAIAnalysis:              true,
-		ComponentSignalProcessing:        true,
-		ComponentRemediationOrchestrator: true,
-		ComponentWorkflowExecution:       true,
-		ComponentEffectivenessMonitor:    true,
-		ComponentNotification:            true,
-		ComponentKubernautAgent:          true,
-	}
-
-	for _, dep := range getAllDeployments(t, kn) {
-		component := dep.Spec.Template.Labels["app"]
-		container := dep.Spec.Template.Spec.Containers[0]
-
-		hasMetrics := false
-		for _, p := range container.Ports {
-			if p.ContainerPort == PortMetrics && p.Name == "metrics" {
-				hasMetrics = true
-			}
-		}
-
-		if withMetrics[component] && !hasMetrics {
-			t.Errorf("Deployment %q should expose metrics port 9090", dep.Name)
-		}
-		if !withMetrics[component] && hasMetrics {
-			t.Errorf("Deployment %q should NOT expose metrics port 9090", dep.Name)
-		}
-	}
-}
-
-func TestDeployments_ConfigArgs(t *testing.T) {
-	kn := testKubernaut()
-
-	wantArgs := map[string][]string{
-		ComponentGateway:                 {"--config=/etc/gateway/config.yaml"},
-		ComponentAIAnalysis:              {"-config", "/etc/aianalysis/config.yaml"},
-		ComponentSignalProcessing:        {"--config=/etc/signalprocessing/config.yaml"},
-		ComponentRemediationOrchestrator: {"--config=/etc/config/remediationorchestrator.yaml"},
-		ComponentWorkflowExecution:       {"--config=/etc/config/workflowexecution.yaml"},
-		ComponentEffectivenessMonitor:    {"--config=/etc/effectivenessmonitor/effectivenessmonitor.yaml"},
-		ComponentNotification:            {"-config", "/etc/notification/config.yaml"},
-		ComponentKubernautAgent:          {"-config", "/etc/kubernaut-agent/config.yaml", "-llm-runtime", "/etc/kubernaut-agent/llm-runtime/llm-runtime.yaml"},
-		ComponentAuthWebhook:             {"-config=/etc/authwebhook/authwebhook.yaml"},
-	}
-
-	for _, dep := range getAllDeployments(t, kn) {
-		component := dep.Spec.Template.Labels["app"]
-		container := dep.Spec.Template.Spec.Containers[0]
-
-		want, hasExpected := wantArgs[component]
-		if !hasExpected {
-			if len(container.Args) != 0 {
-				t.Errorf("Deployment %q should have no args, got %v", dep.Name, container.Args)
-			}
-			continue
-		}
-
-		if len(container.Args) != len(want) {
-			t.Errorf("Deployment %q args len = %d, want %d (%v vs %v)", dep.Name, len(container.Args), len(want), container.Args, want)
-			continue
-		}
-		for i := range want {
-			if container.Args[i] != want[i] {
-				t.Errorf("Deployment %q args[%d] = %q, want %q", dep.Name, i, container.Args[i], want[i])
-			}
-		}
-	}
-}
-
-func TestAllDeployments_SecurityContexts(t *testing.T) {
-	kn := testKubernaut()
-	allDeps := getAllDeployments(t, kn)
-	for _, dep := range allDeps {
-		psc := dep.Spec.Template.Spec.SecurityContext
-		if psc == nil {
-			t.Errorf("Deployment %q should have pod security context", dep.Name)
-			continue
-		}
-		if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
-			t.Errorf("Deployment %q should have RunAsNonRoot=true", dep.Name)
-		}
-
-		for _, c := range dep.Spec.Template.Spec.Containers {
-			if c.SecurityContext == nil {
-				t.Errorf("Deployment %q container %q should have security context", dep.Name, c.Name)
-				continue
-			}
-			if c.SecurityContext.AllowPrivilegeEscalation == nil || *c.SecurityContext.AllowPrivilegeEscalation {
-				t.Errorf("Deployment %q container %q should have AllowPrivilegeEscalation=false", dep.Name, c.Name)
-			}
-		}
-	}
-}
-
-func TestAllDeployments_ImagePullPolicy(t *testing.T) {
-	kn := testKubernaut()
-	for _, dep := range getAllDeployments(t, kn) {
-		for _, c := range dep.Spec.Template.Spec.Containers {
-			if c.ImagePullPolicy != corev1.PullIfNotPresent {
-				t.Errorf("Deployment %q container %q pullPolicy = %q, want %q",
-					dep.Name, c.Name, c.ImagePullPolicy, corev1.PullIfNotPresent)
-			}
-		}
-	}
-}
-
-func TestAllDeployments_ServiceAccounts(t *testing.T) {
-	kn := testKubernaut()
-	for _, dep := range getAllDeployments(t, kn) {
-		component := dep.Spec.Template.Labels["app"]
-		if component == "" {
-			t.Fatalf("Deployment %q missing 'app' label on pod template", dep.Name)
-		}
-		wantSA := ServiceAccountName(component)
-		gotSA := dep.Spec.Template.Spec.ServiceAccountName
-		if gotSA != wantSA {
-			t.Errorf("Deployment %q SA = %q, want %q (component %q)", dep.Name, gotSA, wantSA, component)
-		}
-	}
-}
-
-func TestAllDeployments_HaveInterServiceTLSCA(t *testing.T) {
-	kn := testKubernaut()
-	deps := getAllDeployments(t, kn)
-
-	for _, dep := range deps {
-		name := dep.Name
-		container := dep.Spec.Template.Spec.Containers[0]
-
-		hasCAVolume := false
-		for _, v := range dep.Spec.Template.Spec.Volumes {
-			if v.Name == "tls-ca" && v.ConfigMap != nil && v.ConfigMap.Name == InterServiceCAConfigMapName {
-				hasCAVolume = true
-			}
-		}
-		if !hasCAVolume {
-			t.Errorf("Deployment %q missing tls-ca volume backed by %q ConfigMap", name, InterServiceCAConfigMapName)
-		}
-
-		hasCAMount := false
-		for _, vm := range container.VolumeMounts {
-			if vm.Name == "tls-ca" && vm.MountPath == "/etc/tls-ca" {
-				hasCAMount = true
-			}
-		}
-		if !hasCAMount {
-			t.Errorf("Deployment %q missing tls-ca volume mount at /etc/tls-ca", name)
-		}
-
-		hasCAEnv := false
-		for _, env := range container.Env {
-			if env.Name == "TLS_CA_FILE" && env.Value == InterServiceTLSCAFile {
-				hasCAEnv = true
-			}
-		}
-		if !hasCAEnv {
-			t.Errorf("Deployment %q missing TLS_CA_FILE env var", name)
-		}
-	}
-}
-
-func TestGatewayDeployment_NoTLSCertVolume(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := GatewayDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == "tls-certs" {
-			t.Error("Gateway should NOT have tls-certs volume (OCP Route handles TLS)")
-		}
-	}
-}
-
-func TestKubernautAgentDeployment_HasTLSCertVolume(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := KubernautAgentDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertHasVolume(t, dep, "tls-certs")
-	assertHasVolumeMount(t, dep, "tls-certs", InterServiceTLSCertDir)
-}
-
-func TestDataStorageDeployment_HasTLSCertVolume(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := DataStorageDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertHasVolume(t, dep, "tls-certs")
-	assertHasVolumeMount(t, dep, "tls-certs", InterServiceTLSCertDir)
-}
-
-func TestServiceAccountNaming(t *testing.T) {
-	expected := map[string]string{
-		ComponentGateway:                 "gateway",
-		ComponentDataStorage:             "data-storage-sa",
-		ComponentAIAnalysis:              "aianalysis-controller",
-		ComponentSignalProcessing:        "signalprocessing-controller",
-		ComponentRemediationOrchestrator: "remediationorchestrator-controller",
-		ComponentWorkflowExecution:       "workflowexecution-controller",
-		ComponentEffectivenessMonitor:    "effectivenessmonitor-controller",
-		ComponentNotification:            "notification-controller",
-		ComponentKubernautAgent:          "kubernaut-agent-sa",
-		ComponentAuthWebhook:             "authwebhook",
-	}
-	for component, wantName := range expected {
-		got := ServiceAccountName(component)
-		if got != wantName {
-			t.Errorf("ServiceAccountName(%q) = %q, want %q", component, got, wantName)
-		}
-	}
-}
-
-func TestServiceAccountNaming_AllComponentsCovered(t *testing.T) {
-	for _, component := range AllComponents() {
-		name := ServiceAccountName(component)
-		if name == "" {
-			t.Errorf("ServiceAccountName(%q) returned empty string", component)
-		}
-	}
-}
-
-func TestAllDeployments_PodAntiAffinity(t *testing.T) {
-	kn := testKubernaut()
-	deps := getAllDeployments(t, kn)
-
-	for _, dep := range deps {
-		component := dep.Spec.Template.Labels["app"]
-
-		affinity := dep.Spec.Template.Spec.Affinity
-		if affinity == nil {
-			t.Fatalf("Deployment %q: Affinity must not be nil", dep.Name)
-		}
-		paa := affinity.PodAntiAffinity
-		if paa == nil {
-			t.Fatalf("Deployment %q: PodAntiAffinity must not be nil", dep.Name)
-		}
-
-		preferred := paa.PreferredDuringSchedulingIgnoredDuringExecution
-		if len(preferred) == 0 {
-			t.Fatalf("Deployment %q: expected at least one preferred anti-affinity term", dep.Name)
-		}
-
-		term := preferred[0]
-
-		if term.Weight != 100 {
-			t.Errorf("Deployment %q: anti-affinity weight = %d, want 100", dep.Name, term.Weight)
-		}
-
-		if term.PodAffinityTerm.TopologyKey != "kubernetes.io/hostname" {
-			t.Errorf("Deployment %q: topology key = %q, want %q",
-				dep.Name, term.PodAffinityTerm.TopologyKey, "kubernetes.io/hostname")
-		}
-
-		sel := term.PodAffinityTerm.LabelSelector
-		if sel == nil {
-			t.Fatalf("Deployment %q: anti-affinity label selector must not be nil", dep.Name)
-		}
-
-		expectedLabels := SelectorLabels(component)
-		for k, v := range expectedLabels {
-			if sel.MatchLabels[k] != v {
-				t.Errorf("Deployment %q: anti-affinity selector label %q = %q, want %q",
-					dep.Name, k, sel.MatchLabels[k], v)
-			}
-		}
-	}
-}
-
-// --- AAP CA cert tests (Issue #32) ---
-
 const (
 	testEnvTLSCAFile     = "TLS_CA_FILE"
 	testVolumeAAPCA      = "aap-ca"
 	testVolumeCombinedCA = "combined-ca"
 )
 
-func TestWFEDeployment_NoCACert_NoInitContainer(t *testing.T) {
-	kn := testKubernaut()
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(dep.Spec.Template.Spec.InitContainers) != 0 {
-		t.Errorf("WFE without caCertSecretRef should have no init containers, got %d",
-			len(dep.Spec.Template.Spec.InitContainers))
-	}
-
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == testVolumeAAPCA || v.Name == testVolumeCombinedCA {
-			t.Errorf("WFE without caCertSecretRef should not have volume %q", v.Name)
-		}
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	for _, e := range container.Env {
-		if e.Name == testEnvTLSCAFile && e.Value != InterServiceTLSCAFile {
-			t.Errorf("TLS_CA_FILE should be %q without CA override, got %q",
-				InterServiceTLSCAFile, e.Value)
-		}
-	}
-}
-
-func TestWFEDeployment_NoSSLCertFile(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	for _, e := range container.Env {
-		if e.Name == "SSL_CERT_FILE" {
-			t.Errorf("WFE must not set SSL_CERT_FILE env var (removed in v1.4); got %q", e.Value)
-		}
-	}
-}
-
-func TestWFEDeployment_WithCACert_HasInitContainer(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(dep.Spec.Template.Spec.InitContainers) != 1 {
-		t.Fatalf("WFE with caCertSecretRef should have 1 init container, got %d",
-			len(dep.Spec.Template.Spec.InitContainers))
-	}
-
-	init := dep.Spec.Template.Spec.InitContainers[0]
-	if init.Name != "build-ca-bundle" {
-		t.Errorf("init container name = %q, want %q", init.Name, "build-ca-bundle")
-	}
-}
-
-func TestWFEDeployment_WithCACert_MountsSecretVolume(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-		Key:  "custom-ca.pem",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var found bool
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == testVolumeAAPCA {
-			found = true
-			if v.Secret == nil {
-				t.Fatal("aap-ca volume should be backed by a Secret")
-			}
-			if v.Secret.SecretName != "aap-ca-secret" {
-				t.Errorf("aap-ca secret name = %q, want %q", v.Secret.SecretName, "aap-ca-secret")
-			}
-			if len(v.Secret.Items) != 1 || v.Secret.Items[0].Key != "custom-ca.pem" {
-				t.Errorf("aap-ca secret key = %v, want key %q", v.Secret.Items, "custom-ca.pem")
-			}
-		}
-	}
-	if !found {
-		t.Error("WFE with caCertSecretRef should have aap-ca volume")
-	}
-}
-
-func TestWFEDeployment_WithCACert_DefaultKey(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == testVolumeAAPCA {
-			if len(v.Secret.Items) != 1 || v.Secret.Items[0].Key != "ca.crt" {
-				t.Errorf("aap-ca default key should be %q, got %v", "ca.crt", v.Secret.Items)
-			}
-			return
-		}
-	}
-	t.Error("aap-ca volume not found")
-}
-
-func TestWFEDeployment_WithCACert_CombinedCAEmptyDir(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, v := range dep.Spec.Template.Spec.Volumes {
-		if v.Name == testVolumeCombinedCA {
-			if v.EmptyDir == nil {
-				t.Error("combined-ca volume should be EmptyDir")
-			}
-			return
-		}
-	}
-	t.Error("combined-ca volume not found")
-}
-
-func TestWFEDeployment_WithCACert_OverridesTLSCAFile(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	for _, e := range container.Env {
-		if e.Name == testEnvTLSCAFile {
-			if e.Value != "/etc/combined-ca/ca-bundle.crt" {
-				t.Errorf("TLS_CA_FILE = %q, want %q", e.Value, "/etc/combined-ca/ca-bundle.crt")
-			}
-			return
-		}
-	}
-	t.Error("TLS_CA_FILE env var not found")
-}
-
-func TestWFEDeployment_WithCACert_InitContainerConcatenatesCorrectSources(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	init := dep.Spec.Template.Spec.InitContainers[0]
-
-	if len(init.Args) == 0 {
-		t.Fatal("init container should have args with the cat command")
-	}
-	cmd := init.Args[0]
-	if !strings.Contains(cmd, "/etc/tls-ca/service-ca.crt") {
-		t.Errorf("init container command should read inter-service CA, got: %s", cmd)
-	}
-	if !strings.Contains(cmd, "/aap-ca/aap-ca.crt") {
-		t.Errorf("init container command should read AAP CA, got: %s", cmd)
-	}
-	if !strings.Contains(cmd, "/combined/ca-bundle.crt") {
-		t.Errorf("init container command should write combined bundle, got: %s", cmd)
-	}
-}
-
-func TestWFEDeployment_WithCACert_InitContainerVolumeMounts(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	init := dep.Spec.Template.Spec.InitContainers[0]
-	mountNames := make(map[string]bool)
-	for _, vm := range init.VolumeMounts {
-		mountNames[vm.Name] = true
-	}
-	for _, required := range []string{"tls-ca", testVolumeAAPCA, testVolumeCombinedCA} {
-		if !mountNames[required] {
-			t.Errorf("init container should mount volume %q", required)
-		}
-	}
-}
-
-func TestWFEDeployment_WithCACert_MainContainerMountsCombinedCA(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	container := dep.Spec.Template.Spec.Containers[0]
-	for _, vm := range container.VolumeMounts {
-		if vm.Name == testVolumeCombinedCA {
-			if vm.MountPath != "/etc/combined-ca" {
-				t.Errorf("combined-ca mount path = %q, want %q", vm.MountPath, "/etc/combined-ca")
-			}
-			if !vm.ReadOnly {
-				t.Error("combined-ca mount should be read-only")
-			}
-			return
-		}
-	}
-	t.Error("main container should mount combined-ca volume")
-}
-
-func TestWFEDeployment_WithCACert_InitContainerSecurityContext(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
-		Name: "aap-ca-secret",
-	}
-	dep, err := WorkflowExecutionDeployment(kn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	init := dep.Spec.Template.Spec.InitContainers[0]
-	sc := init.SecurityContext
-	if sc == nil {
-		t.Fatal("init container should have a security context")
-	}
-	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
-		t.Error("init container should disallow privilege escalation")
-	}
-	if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
-		t.Error("init container should have read-only root filesystem")
-	}
-	if sc.Capabilities == nil || len(sc.Capabilities.Drop) == 0 {
-		t.Error("init container should drop ALL capabilities")
-	}
-}
-
-func TestOverrideTLSCAFile_ReplacesExisting(t *testing.T) {
-	env := []corev1.EnvVar{
-		{Name: "OTHER", Value: "foo"},
-		{Name: testEnvTLSCAFile, Value: "/old/path"},
-	}
-	result := overrideTLSCAFile(env, "/new/path")
-	for _, e := range result {
-		if e.Name == testEnvTLSCAFile {
-			if e.Value != "/new/path" {
-				t.Errorf("TLS_CA_FILE = %q, want %q", e.Value, "/new/path")
-			}
-			return
-		}
-	}
-	t.Error("TLS_CA_FILE not found after override")
-}
-
-func TestOverrideTLSCAFile_AppendsWhenMissing(t *testing.T) {
-	env := []corev1.EnvVar{{Name: "OTHER", Value: "foo"}}
-	result := overrideTLSCAFile(env, "/new/path")
-	if len(result) != 2 {
-		t.Fatalf("expected 2 env vars, got %d", len(result))
-	}
-	found := false
-	for _, e := range result {
-		if e.Name == testEnvTLSCAFile && e.Value == "/new/path" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("TLS_CA_FILE should be appended when missing")
-	}
-}
-
-// --- helpers ---
-
-func getAllDeployments(t *testing.T, kn *kubernautv1alpha1.Kubernaut) []*appsv1.Deployment {
-	t.Helper()
+func getAllDeployments(kn *kubernautv1alpha1.Kubernaut) []*appsv1.Deployment {
 	type builder func(*kubernautv1alpha1.Kubernaut) (*appsv1.Deployment, error)
 	builders := []builder{
 		GatewayDeployment,
@@ -1152,75 +49,893 @@ func getAllDeployments(t *testing.T, kn *kubernautv1alpha1.Kubernaut) []*appsv1.
 	deps := make([]*appsv1.Deployment, 0, len(builders))
 	for _, b := range builders {
 		dep, err := b(kn)
-		if err != nil {
-			t.Fatalf("unexpected error building deployment: %v", err)
-		}
+		Expect(err).NotTo(HaveOccurred())
 		deps = append(deps, dep)
 	}
 	return deps
 }
 
-func assertDeploymentBasics(t *testing.T, dep *appsv1.Deployment, imageSuffix string) {
-	t.Helper()
-
-	if dep.Namespace != testSystemNamespace {
-		t.Errorf("Deployment %q namespace = %q, want %q", dep.Name, dep.Namespace, testSystemNamespace)
-	}
-	if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 1 {
-		t.Errorf("Deployment %q should have 1 replica", dep.Name)
-	}
-	if len(dep.Spec.Template.Spec.Containers) == 0 {
-		t.Fatalf("Deployment %q should have at least 1 container", dep.Name)
-	}
+func expectDeploymentBasics(dep *appsv1.Deployment, imageSuffix string) {
+	Expect(dep.Namespace).To(Equal(testSystemNamespace), "Deployment %q namespace", dep.Name)
+	Expect(dep.Spec.Replicas).NotTo(BeNil(), "Deployment %q replicas", dep.Name)
+	Expect(*dep.Spec.Replicas).To(Equal(int32(1)), "Deployment %q replicas", dep.Name)
+	Expect(dep.Spec.Template.Spec.Containers).NotTo(BeEmpty(), "Deployment %q containers", dep.Name)
 
 	container := dep.Spec.Template.Spec.Containers[0]
-	if container.Image == "" {
-		t.Errorf("Deployment %q should have a non-empty image", dep.Name)
-	}
-	if !strings.Contains(container.Image, imageSuffix) {
-		t.Errorf("Deployment %q image %q should contain %q", dep.Name, container.Image, imageSuffix)
-	}
+	Expect(container.Image).NotTo(BeEmpty(), "Deployment %q image", dep.Name)
+	Expect(container.Image).To(ContainSubstring(imageSuffix), "Deployment %q image should contain %q", dep.Name, imageSuffix)
 }
 
-func assertHasVolume(t *testing.T, dep *appsv1.Deployment, name string) {
-	t.Helper()
+func expectHasVolume(dep *appsv1.Deployment, name string) {
+	found := false
 	for _, v := range dep.Spec.Template.Spec.Volumes {
 		if v.Name == name {
-			return
+			found = true
+			break
 		}
 	}
-	t.Errorf("Deployment %q should have volume %q", dep.Name, name)
+	Expect(found).To(BeTrue(), "Deployment %q should have volume %q", dep.Name, name)
 }
 
-func assertVolumeSourceConfigMap(t *testing.T, dep *appsv1.Deployment, volumeName, expectedCMName string) {
-	t.Helper()
+func expectVolumeSourceConfigMap(dep *appsv1.Deployment, volumeName, expectedCMName string) {
 	for _, v := range dep.Spec.Template.Spec.Volumes {
 		if v.Name == volumeName {
-			if v.ConfigMap == nil {
-				t.Errorf("Deployment %q volume %q should be backed by a ConfigMap", dep.Name, volumeName)
-				return
-			}
-			if v.ConfigMap.Name != expectedCMName {
-				t.Errorf("Deployment %q volume %q ConfigMap = %q, want %q",
-					dep.Name, volumeName, v.ConfigMap.Name, expectedCMName)
-			}
+			Expect(v.ConfigMap).NotTo(BeNil(), "Deployment %q volume %q should be backed by a ConfigMap", dep.Name, volumeName)
+			Expect(v.ConfigMap.Name).To(Equal(expectedCMName), "Deployment %q volume %q ConfigMap name", dep.Name, volumeName)
 			return
 		}
 	}
-	t.Errorf("Deployment %q should have volume %q", dep.Name, volumeName)
+	Fail("Deployment " + dep.Name + " should have volume " + volumeName)
 }
 
-func assertHasVolumeMount(t *testing.T, dep *appsv1.Deployment, name, mountPath string) {
-	t.Helper()
+func expectHasVolumeMount(dep *appsv1.Deployment, name, mountPath string) {
 	container := dep.Spec.Template.Spec.Containers[0]
 	for _, vm := range container.VolumeMounts {
 		if vm.Name == name {
-			if vm.MountPath != mountPath {
-				t.Errorf("Deployment %q volume mount %q path = %q, want %q",
-					dep.Name, name, vm.MountPath, mountPath)
-			}
+			Expect(vm.MountPath).To(Equal(mountPath), "Deployment %q volume mount %q path", dep.Name, name)
 			return
 		}
 	}
-	t.Errorf("Deployment %q container should have volume mount %q", dep.Name, name)
+	Fail("Deployment " + dep.Name + " container should have volume mount " + name)
 }
+
+var _ = Describe("Deployments", func() {
+	Context("Gateway", func() {
+		It("has basic deployment properties", func() {
+			kn := testKubernaut()
+			dep, err := GatewayDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectDeploymentBasics(dep, "gateway")
+			expectHasVolume(dep, "config")
+			expectVolumeSourceConfigMap(dep, "config", "gateway-config")
+			expectHasVolumeMount(dep, "config", "/etc/gateway")
+		})
+
+		It("sets default CORS_ALLOWED_ORIGINS", func() {
+			kn := testKubernaut()
+			dep, err := GatewayDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			found := false
+			for _, env := range container.Env {
+				if env.Name == "CORS_ALLOWED_ORIGINS" {
+					found = true
+					Expect(env.Value).To(Equal("https://no-browser-clients.invalid"))
+				}
+			}
+			Expect(found).To(BeTrue(), "Gateway deployment should have CORS_ALLOWED_ORIGINS env var")
+		})
+
+		It("uses custom CORS when specified", func() {
+			kn := testKubernaut()
+			kn.Spec.Gateway.Config.CORSAllowedOrigins = "https://my-dashboard.example.com"
+			dep, err := GatewayDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			found := false
+			for _, env := range container.Env {
+				if env.Name == "CORS_ALLOWED_ORIGINS" {
+					found = true
+					Expect(env.Value).To(Equal("https://my-dashboard.example.com"))
+				}
+			}
+			Expect(found).To(BeTrue(), "CORS_ALLOWED_ORIGINS env var not found")
+		})
+
+		It("does not have tls-certs volume", func() {
+			kn := testKubernaut()
+			dep, err := GatewayDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				Expect(v.Name).NotTo(Equal("tls-certs"), "Gateway should NOT have tls-certs volume")
+			}
+		})
+	})
+
+	Context("DataStorage", func() {
+		It("has init container for postgres", func() {
+			kn := testKubernaut()
+			dep, err := DataStorageDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectDeploymentBasics(dep, "datastorage")
+			Expect(dep.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			init := dep.Spec.Template.Spec.InitContainers[0]
+			Expect(init.Name).To(Equal("wait-for-postgres"))
+			Expect(init.Resources.Requests).NotTo(BeNil())
+		})
+
+		It("has projected secrets volume", func() {
+			kn := testKubernaut()
+			dep, err := DataStorageDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			found := false
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == "secrets" && v.Projected != nil {
+					found = true
+					Expect(v.Projected.Sources).To(HaveLen(2))
+				}
+			}
+			Expect(found).To(BeTrue(), "DataStorage should have a 'secrets' projected volume")
+		})
+
+		It("has TLS cert volume", func() {
+			kn := testKubernaut()
+			dep, err := DataStorageDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+			expectHasVolume(dep, "tls-certs")
+			expectHasVolumeMount(dep, "tls-certs", InterServiceTLSCertDir)
+		})
+	})
+
+	Context("AIAnalysis", func() {
+		It("has policy volume", func() {
+			kn := testKubernaut()
+			dep, err := AIAnalysisDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectDeploymentBasics(dep, "aianalysis")
+			expectHasVolume(dep, "rego-policies")
+			expectVolumeSourceConfigMap(dep, "rego-policies", "aianalysis-policies")
+			expectHasVolumeMount(dep, "rego-policies", "/etc/aianalysis/policies")
+		})
+	})
+
+	Context("SignalProcessing", func() {
+		It("has policy mount", func() {
+			kn := testKubernaut()
+			dep, err := SignalProcessingDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "policy")
+			expectVolumeSourceConfigMap(dep, "policy", "signalprocessing-policy")
+			expectHasVolumeMount(dep, "policy", "/etc/signalprocessing/policies")
+		})
+
+		It("uses custom proactive signal mappings", func() {
+			kn := testKubernaut()
+			kn.Spec.SignalProcessing.ProactiveSignalMappings = &kubernautv1alpha1.ConfigMapRef{ConfigMapName: "my-mappings"}
+			dep, err := SignalProcessingDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "proactive-mappings")
+			expectHasVolumeMount(dep, "proactive-mappings", "/etc/signalprocessing/proactive-signal-mappings.yaml")
+		})
+
+		It("uses default proactive signal mappings", func() {
+			kn := testKubernaut()
+			dep, err := SignalProcessingDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "proactive-mappings")
+			expectVolumeSourceConfigMap(dep, "proactive-mappings", "signalprocessing-proactive-signal-mappings")
+			expectHasVolumeMount(dep, "proactive-mappings", "/etc/signalprocessing/proactive-signal-mappings.yaml")
+		})
+	})
+
+	Context("Notification", func() {
+		It("mounts Slack credentials when configured", func() {
+			kn := testKubernaut()
+			kn.Spec.Notification.Slack.SecretName = "slack-secret"
+			dep, err := NotificationDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "credentials")
+			expectHasVolumeMount(dep, "credentials", "/etc/notification/credentials")
+		})
+
+		It("uses emptyDir credentials when Slack is not configured", func() {
+			kn := testKubernaut()
+			dep, err := NotificationDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			found := false
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == "credentials" {
+					found = true
+					Expect(v.EmptyDir).NotTo(BeNil(), "credentials volume should be an emptyDir without Slack")
+				}
+			}
+			Expect(found).To(BeTrue(), "Notification should have a credentials volume even without Slack")
+		})
+
+		It("has notification-output emptyDir volume", func() {
+			kn := testKubernaut()
+			dep, err := NotificationDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "notification-output")
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == "notification-output" {
+					Expect(v.EmptyDir).NotTo(BeNil())
+				}
+			}
+		})
+
+		It("has routing config mount", func() {
+			kn := testKubernaut()
+			dep, err := NotificationDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "routing-config")
+			expectVolumeSourceConfigMap(dep, "routing-config", "notification-routing-config")
+			expectHasVolumeMount(dep, "routing-config", "/etc/notification-routing")
+		})
+
+		It("uses BYO routing config map name", func() {
+			kn := testKubernaut()
+			kn.Spec.Notification.Routing = &kubernautv1alpha1.ConfigMapRef{ConfigMapName: "my-routing"}
+			dep, err := NotificationDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+			expectHasVolume(dep, "routing-config")
+			expectVolumeSourceConfigMap(dep, "routing-config", "my-routing")
+			expectHasVolumeMount(dep, "routing-config", "/etc/notification-routing")
+		})
+	})
+
+	Context("KubernautAgent", func() {
+		It("has LLM credentials volume", func() {
+			kn := testKubernaut()
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectDeploymentBasics(dep, "kubernautagent")
+			expectHasVolume(dep, "llm-credentials")
+			expectHasVolumeMount(dep, "llm-credentials", "/etc/kubernaut-agent/credentials")
+		})
+
+		It("passes config args", func() {
+			kn := testKubernaut()
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			want := []string{
+				"-config", "/etc/kubernaut-agent/config.yaml",
+				"-llm-runtime", "/etc/kubernaut-agent/llm-runtime/llm-runtime.yaml",
+			}
+			Expect(container.Args).To(Equal(want))
+		})
+
+		It("uses llm-runtime volume instead of sdk-config", func() {
+			kn := testKubernaut()
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				Expect(v.Name).NotTo(Equal("sdk-config"), "should not use sdk-config volume")
+			}
+			expectHasVolume(dep, "llm-runtime")
+			expectVolumeSourceConfigMap(dep, "llm-runtime", "kubernaut-agent-llm-runtime")
+			expectHasVolumeMount(dep, "llm-runtime", "/etc/kubernaut-agent/llm-runtime")
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			hasPair := false
+			for i := 0; i < len(container.Args)-1; i++ {
+				if container.Args[i] == "-llm-runtime" && container.Args[i+1] == "/etc/kubernaut-agent/llm-runtime/llm-runtime.yaml" {
+					hasPair = true
+					break
+				}
+			}
+			Expect(hasPair).To(BeTrue(), "should pass -llm-runtime with llm-runtime.yaml path")
+		})
+
+		It("mounts OAuth2 credentials when enabled", func() {
+			kn := testKubernaut()
+			kn.Spec.KubernautAgent.LLM.OAuth2.Enabled = true
+			kn.Spec.KubernautAgent.LLM.OAuth2.CredentialsSecretRef = "oauth2-credentials-secret"
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "oauth2-credentials")
+			expectHasVolumeMount(dep, "oauth2-credentials", "/etc/kubernaut-agent/oauth2")
+			found := false
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == "oauth2-credentials" {
+					found = true
+					Expect(v.Secret).NotTo(BeNil())
+					Expect(v.Secret.SecretName).To(Equal("oauth2-credentials-secret"))
+				}
+			}
+			Expect(found).To(BeTrue(), "oauth2-credentials volume not found")
+		})
+
+		It("has service-ca volume when monitoring enabled", func() {
+			kn := testKubernaut()
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectHasVolume(dep, "service-ca")
+			expectHasVolumeMount(dep, "service-ca", "/etc/ssl/ka")
+		})
+
+		It("sets IS_OPENSHIFT env when monitoring enabled", func() {
+			kn := testKubernaut()
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			found := false
+			for _, env := range container.Env {
+				if env.Name == "IS_OPENSHIFT" && env.Value == "True" {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(), "should have IS_OPENSHIFT=True when monitoring enabled")
+		})
+
+		It("omits IS_OPENSHIFT env when monitoring disabled", func() {
+			kn := testKubernaut()
+			disabled := false
+			kn.Spec.Monitoring.Enabled = &disabled
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			for _, env := range container.Env {
+				Expect(env.Name).NotTo(Equal("IS_OPENSHIFT"), "should not have IS_OPENSHIFT when monitoring disabled")
+			}
+		})
+
+		It("omits service-ca volume when monitoring disabled", func() {
+			kn := testKubernaut()
+			disabled := false
+			kn.Spec.Monitoring.Enabled = &disabled
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				Expect(v.Name).NotTo(Equal("service-ca"), "should not have service-ca when monitoring disabled")
+			}
+		})
+
+		It("has TLS cert volume", func() {
+			kn := testKubernaut()
+			dep, err := KubernautAgentDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+			expectHasVolume(dep, "tls-certs")
+			expectHasVolumeMount(dep, "tls-certs", InterServiceTLSCertDir)
+		})
+	})
+
+	Context("EffectivenessMonitor", func() {
+		It("has service-ca volume", func() {
+			kn := testKubernaut()
+			dep, err := EffectivenessMonitorDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+			expectHasVolume(dep, "service-ca")
+		})
+
+		It("has wait-for-service-ca init container when monitoring enabled", func() {
+			kn := testKubernaut()
+			dep, err := EffectivenessMonitorDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dep.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			init := dep.Spec.Template.Spec.InitContainers[0]
+			Expect(init.Name).To(Equal("wait-for-service-ca"))
+			Expect(init.Resources.Requests).NotTo(BeNil())
+
+			hasMount := false
+			for _, vm := range init.VolumeMounts {
+				if vm.Name == "service-ca" && vm.MountPath == "/etc/ssl/em" {
+					hasMount = true
+				}
+			}
+			Expect(hasMount).To(BeTrue(), "init container should mount service-ca at /etc/ssl/em")
+		})
+
+		It("has no init container when monitoring disabled", func() {
+			kn := testKubernaut()
+			disabled := false
+			kn.Spec.Monitoring.Enabled = &disabled
+			dep, err := EffectivenessMonitorDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dep.Spec.Template.Spec.InitContainers).To(BeEmpty())
+		})
+	})
+
+	Context("AuthWebhook", func() {
+		It("has TLS and webhook port", func() {
+			kn := testKubernaut()
+			dep, err := AuthWebhookDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectDeploymentBasics(dep, "authwebhook")
+			expectHasVolume(dep, "webhook-certs")
+			expectHasVolumeMount(dep, "webhook-certs", "/tmp/k8s-webhook-server/serving-certs")
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			found := false
+			for _, p := range container.Ports {
+				if p.ContainerPort == 9443 && p.Name == "webhook" {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(), "AuthWebhook should expose port 9443 named 'webhook'")
+		})
+
+		It("uses Recreate strategy", func() {
+			kn := testKubernaut()
+			dep, err := AuthWebhookDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dep.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+		})
+	})
+
+	Context("WorkflowExecution AAP CA cert", func() {
+		It("has no init container without caCertSecretRef", func() {
+			kn := testKubernaut()
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dep.Spec.Template.Spec.InitContainers).To(BeEmpty())
+
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				Expect(v.Name).NotTo(Equal(testVolumeAAPCA))
+				Expect(v.Name).NotTo(Equal(testVolumeCombinedCA))
+			}
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			for _, e := range container.Env {
+				if e.Name == testEnvTLSCAFile {
+					Expect(e.Value).To(Equal(InterServiceTLSCAFile))
+				}
+			}
+		})
+
+		It("does not set SSL_CERT_FILE", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			for _, e := range container.Env {
+				Expect(e.Name).NotTo(Equal("SSL_CERT_FILE"), "WFE must not set SSL_CERT_FILE env var")
+			}
+		})
+
+		It("has init container with caCertSecretRef", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dep.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(dep.Spec.Template.Spec.InitContainers[0].Name).To(Equal("build-ca-bundle"))
+		})
+
+		It("mounts secret volume with custom key", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{
+				Name: "aap-ca-secret",
+				Key:  "custom-ca.pem",
+			}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			found := false
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == testVolumeAAPCA {
+					found = true
+					Expect(v.Secret).NotTo(BeNil())
+					Expect(v.Secret.SecretName).To(Equal("aap-ca-secret"))
+					Expect(v.Secret.Items).To(HaveLen(1))
+					Expect(v.Secret.Items[0].Key).To(Equal("custom-ca.pem"))
+				}
+			}
+			Expect(found).To(BeTrue(), "WFE with caCertSecretRef should have aap-ca volume")
+		})
+
+		It("uses default key ca.crt", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == testVolumeAAPCA {
+					Expect(v.Secret.Items).To(HaveLen(1))
+					Expect(v.Secret.Items[0].Key).To(Equal("ca.crt"))
+					return
+				}
+			}
+			Fail("aap-ca volume not found")
+		})
+
+		It("has combined-ca emptyDir volume", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == testVolumeCombinedCA {
+					Expect(v.EmptyDir).NotTo(BeNil())
+					return
+				}
+			}
+			Fail("combined-ca volume not found")
+		})
+
+		It("overrides TLS_CA_FILE", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			for _, e := range container.Env {
+				if e.Name == testEnvTLSCAFile {
+					Expect(e.Value).To(Equal("/etc/combined-ca/ca-bundle.crt"))
+					return
+				}
+			}
+			Fail("TLS_CA_FILE env var not found")
+		})
+
+		It("init container concatenates correct sources", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			init := dep.Spec.Template.Spec.InitContainers[0]
+			Expect(init.Args).NotTo(BeEmpty())
+			cmd := init.Args[0]
+			Expect(cmd).To(ContainSubstring("/etc/tls-ca/service-ca.crt"))
+			Expect(cmd).To(ContainSubstring("/aap-ca/aap-ca.crt"))
+			Expect(cmd).To(ContainSubstring("/combined/ca-bundle.crt"))
+		})
+
+		It("init container has required volume mounts", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			init := dep.Spec.Template.Spec.InitContainers[0]
+			mountNames := make(map[string]bool)
+			for _, vm := range init.VolumeMounts {
+				mountNames[vm.Name] = true
+			}
+			for _, required := range []string{"tls-ca", testVolumeAAPCA, testVolumeCombinedCA} {
+				Expect(mountNames[required]).To(BeTrue(), "init container should mount volume %q", required)
+			}
+		})
+
+		It("main container mounts combined-ca", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := dep.Spec.Template.Spec.Containers[0]
+			for _, vm := range container.VolumeMounts {
+				if vm.Name == testVolumeCombinedCA {
+					Expect(vm.MountPath).To(Equal("/etc/combined-ca"))
+					Expect(vm.ReadOnly).To(BeTrue())
+					return
+				}
+			}
+			Fail("main container should mount combined-ca volume")
+		})
+
+		It("init container has restricted security context", func() {
+			kn := testKubernaut()
+			kn.Spec.Ansible.CACertSecretRef = &kubernautv1alpha1.CACertSecretRef{Name: "aap-ca-secret"}
+			dep, err := WorkflowExecutionDeployment(kn)
+			Expect(err).NotTo(HaveOccurred())
+
+			init := dep.Spec.Template.Spec.InitContainers[0]
+			sc := init.SecurityContext
+			Expect(sc).NotTo(BeNil())
+			Expect(sc.AllowPrivilegeEscalation).NotTo(BeNil())
+			Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(sc.ReadOnlyRootFilesystem).NotTo(BeNil())
+			Expect(*sc.ReadOnlyRootFilesystem).To(BeTrue())
+			Expect(sc.Capabilities).NotTo(BeNil())
+			Expect(sc.Capabilities.Drop).NotTo(BeEmpty())
+		})
+	})
+
+	Context("overrideTLSCAFile helper", func() {
+		It("replaces existing TLS_CA_FILE", func() {
+			env := []corev1.EnvVar{
+				{Name: "OTHER", Value: "foo"},
+				{Name: testEnvTLSCAFile, Value: "/old/path"},
+			}
+			result := overrideTLSCAFile(env, "/new/path")
+			found := false
+			for _, e := range result {
+				if e.Name == testEnvTLSCAFile {
+					found = true
+					Expect(e.Value).To(Equal("/new/path"))
+				}
+			}
+			Expect(found).To(BeTrue(), "TLS_CA_FILE not found after override")
+		})
+
+		It("appends when missing", func() {
+			env := []corev1.EnvVar{{Name: "OTHER", Value: "foo"}}
+			result := overrideTLSCAFile(env, "/new/path")
+			Expect(result).To(HaveLen(2))
+			found := false
+			for _, e := range result {
+				if e.Name == testEnvTLSCAFile && e.Value == "/new/path" {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(), "TLS_CA_FILE should be appended when missing")
+		})
+	})
+
+	Context("cross-cutting: all deployments", func() {
+		It("have HTTPGet probes with correct paths and timing", func() {
+			kn := testKubernaut()
+			deps := getAllDeployments(kn)
+
+			for _, dep := range deps {
+				container := dep.Spec.Template.Spec.Containers[0]
+				component := dep.Spec.Template.Labels["app"]
+
+				Expect(container.LivenessProbe).NotTo(BeNil(), "Deployment %q should have liveness probe", dep.Name)
+				Expect(container.ReadinessProbe).NotTo(BeNil(), "Deployment %q should have readiness probe", dep.Name)
+
+				Expect(container.LivenessProbe.HTTPGet).NotTo(BeNil(), "Deployment %q liveness probe should use HTTPGet", dep.Name)
+				Expect(container.ReadinessProbe.HTTPGet).NotTo(BeNil(), "Deployment %q readiness probe should use HTTPGet", dep.Name)
+
+				pc := probeConfigForComponent(component)
+				lp := container.LivenessProbe
+				rp := container.ReadinessProbe
+
+				Expect(lp.HTTPGet.Path).To(Equal(pc.LivenessPath), "Deployment %q liveness path", dep.Name)
+				Expect(rp.HTTPGet.Path).To(Equal(pc.ReadinessPath), "Deployment %q readiness path", dep.Name)
+
+				Expect(lp.InitialDelaySeconds).To(Equal(pc.LivenessInitialDelay), "%s liveness InitialDelaySeconds", dep.Name)
+				Expect(lp.PeriodSeconds).To(Equal(pc.LivenessPeriod), "%s liveness PeriodSeconds", dep.Name)
+				Expect(lp.TimeoutSeconds).To(Equal(pc.LivenessTimeout), "%s liveness TimeoutSeconds", dep.Name)
+				Expect(lp.FailureThreshold).To(Equal(pc.LivenessFailureThreshold), "%s liveness FailureThreshold", dep.Name)
+
+				Expect(rp.InitialDelaySeconds).To(Equal(pc.ReadinessInitialDelay), "%s readiness InitialDelaySeconds", dep.Name)
+				Expect(rp.PeriodSeconds).To(Equal(pc.ReadinessPeriod), "%s readiness PeriodSeconds", dep.Name)
+				Expect(rp.TimeoutSeconds).To(Equal(pc.ReadinessTimeout), "%s readiness TimeoutSeconds", dep.Name)
+				Expect(rp.FailureThreshold).To(Equal(pc.ReadinessFailureThreshold), "%s readiness FailureThreshold", dep.Name)
+			}
+		})
+
+		It("expose metrics port on expected components", func() {
+			kn := testKubernaut()
+			withMetrics := map[string]bool{
+				ComponentGateway:                 true,
+				ComponentDataStorage:             true,
+				ComponentAIAnalysis:              true,
+				ComponentSignalProcessing:        true,
+				ComponentRemediationOrchestrator: true,
+				ComponentWorkflowExecution:       true,
+				ComponentEffectivenessMonitor:    true,
+				ComponentNotification:            true,
+				ComponentKubernautAgent:          true,
+			}
+
+			for _, dep := range getAllDeployments(kn) {
+				component := dep.Spec.Template.Labels["app"]
+				container := dep.Spec.Template.Spec.Containers[0]
+
+				hasMetrics := false
+				for _, p := range container.Ports {
+					if p.ContainerPort == PortMetrics && p.Name == "metrics" {
+						hasMetrics = true
+					}
+				}
+
+				if withMetrics[component] {
+					Expect(hasMetrics).To(BeTrue(), "Deployment %q should expose metrics port 9090", dep.Name)
+				} else {
+					Expect(hasMetrics).To(BeFalse(), "Deployment %q should NOT expose metrics port 9090", dep.Name)
+				}
+			}
+		})
+
+		It("pass correct config args", func() {
+			kn := testKubernaut()
+
+			wantArgs := map[string][]string{
+				ComponentGateway:                 {"--config=/etc/gateway/config.yaml"},
+				ComponentAIAnalysis:              {"-config", "/etc/aianalysis/config.yaml"},
+				ComponentSignalProcessing:        {"--config=/etc/signalprocessing/config.yaml"},
+				ComponentRemediationOrchestrator: {"--config=/etc/config/remediationorchestrator.yaml"},
+				ComponentWorkflowExecution:       {"--config=/etc/config/workflowexecution.yaml"},
+				ComponentEffectivenessMonitor:    {"--config=/etc/effectivenessmonitor/effectivenessmonitor.yaml"},
+				ComponentNotification:            {"-config", "/etc/notification/config.yaml"},
+				ComponentKubernautAgent:          {"-config", "/etc/kubernaut-agent/config.yaml", "-llm-runtime", "/etc/kubernaut-agent/llm-runtime/llm-runtime.yaml"},
+				ComponentAuthWebhook:             {"-config=/etc/authwebhook/authwebhook.yaml"},
+			}
+
+			for _, dep := range getAllDeployments(kn) {
+				component := dep.Spec.Template.Labels["app"]
+				container := dep.Spec.Template.Spec.Containers[0]
+
+				want, hasExpected := wantArgs[component]
+				if !hasExpected {
+					Expect(container.Args).To(BeEmpty(), "Deployment %q should have no args", dep.Name)
+					continue
+				}
+				Expect(container.Args).To(Equal(want), "Deployment %q args", dep.Name)
+			}
+		})
+
+		It("have restricted security contexts", func() {
+			kn := testKubernaut()
+			for _, dep := range getAllDeployments(kn) {
+				psc := dep.Spec.Template.Spec.SecurityContext
+				Expect(psc).NotTo(BeNil(), "Deployment %q should have pod security context", dep.Name)
+				Expect(psc.RunAsNonRoot).NotTo(BeNil(), "Deployment %q RunAsNonRoot", dep.Name)
+				Expect(*psc.RunAsNonRoot).To(BeTrue(), "Deployment %q RunAsNonRoot should be true", dep.Name)
+
+				for _, c := range dep.Spec.Template.Spec.Containers {
+					Expect(c.SecurityContext).NotTo(BeNil(), "Deployment %q container %q security context", dep.Name, c.Name)
+					Expect(c.SecurityContext.AllowPrivilegeEscalation).NotTo(BeNil(), "Deployment %q container %q AllowPrivilegeEscalation", dep.Name, c.Name)
+					Expect(*c.SecurityContext.AllowPrivilegeEscalation).To(BeFalse(), "Deployment %q container %q AllowPrivilegeEscalation should be false", dep.Name, c.Name)
+				}
+			}
+		})
+
+		It("use IfNotPresent pull policy", func() {
+			kn := testKubernaut()
+			for _, dep := range getAllDeployments(kn) {
+				for _, c := range dep.Spec.Template.Spec.Containers {
+					Expect(c.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent), "Deployment %q container %q pullPolicy", dep.Name, c.Name)
+				}
+			}
+		})
+
+		It("set correct service accounts", func() {
+			kn := testKubernaut()
+			for _, dep := range getAllDeployments(kn) {
+				component := dep.Spec.Template.Labels["app"]
+				Expect(component).NotTo(BeEmpty(), "Deployment %q missing 'app' label", dep.Name)
+				wantSA := ServiceAccountName(component)
+				Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal(wantSA), "Deployment %q SA", dep.Name)
+			}
+		})
+
+		It("have inter-service TLS CA volume, mount, and env var", func() {
+			kn := testKubernaut()
+			for _, dep := range getAllDeployments(kn) {
+				container := dep.Spec.Template.Spec.Containers[0]
+
+				hasCAVolume := false
+				for _, v := range dep.Spec.Template.Spec.Volumes {
+					if v.Name == "tls-ca" && v.ConfigMap != nil && v.ConfigMap.Name == InterServiceCAConfigMapName {
+						hasCAVolume = true
+					}
+				}
+				Expect(hasCAVolume).To(BeTrue(), "Deployment %q missing tls-ca volume", dep.Name)
+
+				hasCAMount := false
+				for _, vm := range container.VolumeMounts {
+					if vm.Name == "tls-ca" && vm.MountPath == "/etc/tls-ca" {
+						hasCAMount = true
+					}
+				}
+				Expect(hasCAMount).To(BeTrue(), "Deployment %q missing tls-ca volume mount", dep.Name)
+
+				hasCAEnv := false
+				for _, env := range container.Env {
+					if env.Name == "TLS_CA_FILE" && env.Value == InterServiceTLSCAFile {
+						hasCAEnv = true
+					}
+				}
+				Expect(hasCAEnv).To(BeTrue(), "Deployment %q missing TLS_CA_FILE env var", dep.Name)
+			}
+		})
+
+		It("map ServiceAccountName correctly for all components", func() {
+			expected := map[string]string{
+				ComponentGateway:                 "gateway",
+				ComponentDataStorage:             "data-storage-sa",
+				ComponentAIAnalysis:              "aianalysis-controller",
+				ComponentSignalProcessing:        "signalprocessing-controller",
+				ComponentRemediationOrchestrator: "remediationorchestrator-controller",
+				ComponentWorkflowExecution:       "workflowexecution-controller",
+				ComponentEffectivenessMonitor:    "effectivenessmonitor-controller",
+				ComponentNotification:            "notification-controller",
+				ComponentKubernautAgent:          "kubernaut-agent-sa",
+				ComponentAuthWebhook:             "authwebhook",
+			}
+			for component, wantName := range expected {
+				Expect(ServiceAccountName(component)).To(Equal(wantName), "ServiceAccountName(%q)", component)
+			}
+		})
+
+		It("cover all components in ServiceAccountName", func() {
+			for _, component := range AllComponents() {
+				Expect(ServiceAccountName(component)).NotTo(BeEmpty(), "ServiceAccountName(%q)", component)
+			}
+		})
+
+		It("have preferred pod anti-affinity", func() {
+			kn := testKubernaut()
+			for _, dep := range getAllDeployments(kn) {
+				component := dep.Spec.Template.Labels["app"]
+
+				affinity := dep.Spec.Template.Spec.Affinity
+				Expect(affinity).NotTo(BeNil(), "Deployment %q Affinity", dep.Name)
+				paa := affinity.PodAntiAffinity
+				Expect(paa).NotTo(BeNil(), "Deployment %q PodAntiAffinity", dep.Name)
+
+				preferred := paa.PreferredDuringSchedulingIgnoredDuringExecution
+				Expect(preferred).NotTo(BeEmpty(), "Deployment %q preferred anti-affinity terms", dep.Name)
+
+				term := preferred[0]
+				Expect(term.Weight).To(Equal(int32(100)), "Deployment %q anti-affinity weight", dep.Name)
+				Expect(term.PodAffinityTerm.TopologyKey).To(Equal("kubernetes.io/hostname"), "Deployment %q topology key", dep.Name)
+
+				sel := term.PodAffinityTerm.LabelSelector
+				Expect(sel).NotTo(BeNil(), "Deployment %q anti-affinity label selector", dep.Name)
+
+				for k, v := range SelectorLabels(component) {
+					Expect(sel.MatchLabels[k]).To(Equal(v), "Deployment %q anti-affinity selector label %q", dep.Name, k)
+				}
+			}
+		})
+	})
+})
+
+var _ = Describe("overrideTLSCAFile standalone", func() {
+	It("replaces existing entry", func() {
+		env := []corev1.EnvVar{
+			{Name: "OTHER", Value: "foo"},
+			{Name: testEnvTLSCAFile, Value: "/old/path"},
+		}
+		result := overrideTLSCAFile(env, "/new/path")
+		for _, e := range result {
+			if e.Name == testEnvTLSCAFile {
+				Expect(e.Value).To(Equal("/new/path"))
+				return
+			}
+		}
+		Fail("TLS_CA_FILE not found after override")
+	})
+
+	It("appends when missing", func() {
+		env := []corev1.EnvVar{{Name: "OTHER", Value: "foo"}}
+		result := overrideTLSCAFile(env, "/new/path")
+		Expect(result).To(HaveLen(2))
+		found := false
+		for _, e := range result {
+			if e.Name == testEnvTLSCAFile && e.Value == "/new/path" {
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue())
+	})
+})

--- a/internal/resources/hash_test.go
+++ b/internal/resources/hash_test.go
@@ -17,7 +17,8 @@ limitations under the License.
 package resources
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,113 +32,87 @@ func newConfigMap(data map[string]string) *corev1.ConfigMap {
 	}
 }
 
-func TestSpecHash_Stability(t *testing.T) {
-	cm := newConfigMap(map[string]string{"key": "val"})
-	h1 := SpecHash(cm)
-	h2 := SpecHash(cm)
-	if h1 != h2 {
-		t.Fatalf("expected stable hash, got %s != %s", h1, h2)
-	}
-	if h1 == "" {
-		t.Fatal("hash must not be empty")
-	}
-}
+var _ = Describe("SpecHash", func() {
+	It("is stable for the same spec", func() {
+		cm := newConfigMap(map[string]string{"key": "val"})
+		h1 := SpecHash(cm)
+		h2 := SpecHash(cm)
+		Expect(h1).To(Equal(h2))
+		Expect(h1).NotTo(BeEmpty())
+	})
 
-func TestSpecHash_Sensitivity(t *testing.T) {
-	cm1 := newConfigMap(map[string]string{"key": "val1"})
-	cm2 := newConfigMap(map[string]string{"key": "val2"})
-	if SpecHash(cm1) == SpecHash(cm2) {
-		t.Fatal("different data should produce different hashes")
-	}
-}
+	It("differs when data differs", func() {
+		cm1 := newConfigMap(map[string]string{"key": "val1"})
+		cm2 := newConfigMap(map[string]string{"key": "val2"})
+		Expect(SpecHash(cm1)).NotTo(Equal(SpecHash(cm2)))
+	})
 
-func TestSpecHash_IgnoresServerMetadata(t *testing.T) {
-	base := newConfigMap(map[string]string{"key": "val"})
-	baseHash := SpecHash(base)
+	It("ignores server metadata fields", func() {
+		base := newConfigMap(map[string]string{"key": "val"})
+		baseHash := SpecHash(base)
 
-	withRV := base.DeepCopy()
-	withRV.ResourceVersion = "12345"
-	if SpecHash(withRV) != baseHash {
-		t.Fatal("resourceVersion must not affect hash")
-	}
+		withRV := base.DeepCopy()
+		withRV.ResourceVersion = "12345"
+		Expect(SpecHash(withRV)).To(Equal(baseHash))
 
-	withUID := base.DeepCopy()
-	withUID.UID = types.UID("abc-123")
-	if SpecHash(withUID) != baseHash {
-		t.Fatal("UID must not affect hash")
-	}
+		withUID := base.DeepCopy()
+		withUID.UID = types.UID("abc-123")
+		Expect(SpecHash(withUID)).To(Equal(baseHash))
 
-	withGen := base.DeepCopy()
-	withGen.Generation = 42
-	if SpecHash(withGen) != baseHash {
-		t.Fatal("generation must not affect hash")
-	}
+		withGen := base.DeepCopy()
+		withGen.Generation = 42
+		Expect(SpecHash(withGen)).To(Equal(baseHash))
 
-	withMF := base.DeepCopy()
-	withMF.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "test"}}
-	if SpecHash(withMF) != baseHash {
-		t.Fatal("managedFields must not affect hash")
-	}
-}
+		withMF := base.DeepCopy()
+		withMF.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "test"}}
+		Expect(SpecHash(withMF)).To(Equal(baseHash))
+	})
 
-func TestSpecHash_IgnoresHashAnnotation(t *testing.T) {
-	base := newConfigMap(map[string]string{"key": "val"})
-	baseHash := SpecHash(base)
+	It("ignores the spec-hash annotation", func() {
+		base := newConfigMap(map[string]string{"key": "val"})
+		baseHash := SpecHash(base)
 
-	withAnnotation := base.DeepCopy()
-	withAnnotation.Annotations = map[string]string{AnnotationSpecHash: "old-hash"}
-	if SpecHash(withAnnotation) != baseHash {
-		t.Fatal("spec-hash annotation must not affect hash")
-	}
-}
+		withAnnotation := base.DeepCopy()
+		withAnnotation.Annotations = map[string]string{AnnotationSpecHash: "old-hash"}
+		Expect(SpecHash(withAnnotation)).To(Equal(baseHash))
+	})
 
-func TestSpecHash_PreservesOtherAnnotations(t *testing.T) {
-	cm1 := newConfigMap(map[string]string{"key": "val"})
+	It("includes non-spec-hash annotations in the hash", func() {
+		cm1 := newConfigMap(map[string]string{"key": "val"})
 
-	cm2 := cm1.DeepCopy()
-	cm2.Annotations = map[string]string{"custom-annotation": "value"}
+		cm2 := cm1.DeepCopy()
+		cm2.Annotations = map[string]string{"custom-annotation": "value"}
 
-	if SpecHash(cm1) == SpecHash(cm2) {
-		t.Fatal("non-spec-hash annotations should affect hash")
-	}
-}
+		Expect(SpecHash(cm1)).NotTo(Equal(SpecHash(cm2)))
+	})
 
-func TestSpecHash_OwnerRefChange(t *testing.T) {
-	cm1 := newConfigMap(map[string]string{"key": "val"})
+	It("changes when owner references change", func() {
+		cm1 := newConfigMap(map[string]string{"key": "val"})
 
-	cm2 := cm1.DeepCopy()
-	cm2.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: "kubernaut.ai/v1alpha1",
-			Kind:       "Kubernaut",
-			Name:       "my-kubernaut",
-			UID:        types.UID("new-uid"),
-		},
-	}
+		cm2 := cm1.DeepCopy()
+		cm2.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion: "kubernaut.ai/v1alpha1",
+				Kind:       "Kubernaut",
+				Name:       "my-kubernaut",
+				UID:        types.UID("new-uid"),
+			},
+		}
 
-	if SpecHash(cm1) == SpecHash(cm2) {
-		t.Fatal("ownerReference change must produce different hash for re-adoption")
-	}
-}
+		Expect(SpecHash(cm1)).NotTo(Equal(SpecHash(cm2)))
+	})
 
-func TestSpecHash_DoesNotMutateOriginal(t *testing.T) {
-	cm := newConfigMap(map[string]string{"key": "val"})
-	cm.ResourceVersion = "999"
-	cm.UID = "original-uid"
-	cm.Annotations = map[string]string{AnnotationSpecHash: "old", "keep": "this"}
+	It("does not mutate the original object", func() {
+		cm := newConfigMap(map[string]string{"key": "val"})
+		cm.ResourceVersion = "999"
+		cm.UID = "original-uid"
+		cm.Annotations = map[string]string{AnnotationSpecHash: "old", "keep": "this"}
 
-	_ = SpecHash(cm)
+		_ = SpecHash(cm)
 
-	if cm.ResourceVersion != "999" {
-		t.Fatal("SpecHash must not mutate the original ResourceVersion")
-	}
-	if cm.UID != "original-uid" {
-		t.Fatal("SpecHash must not mutate the original UID")
-	}
-	if cm.Annotations[AnnotationSpecHash] != "old" {
-		t.Fatal("SpecHash must not mutate the original annotations")
-	}
-	if cm.Annotations["keep"] != "this" {
-		t.Fatal("SpecHash must not lose other annotations from the original")
-	}
-}
+		Expect(cm.ResourceVersion).To(Equal("999"))
+		Expect(cm.UID).To(Equal(types.UID("original-uid")))
+		Expect(cm.Annotations[AnnotationSpecHash]).To(Equal("old"))
+		Expect(cm.Annotations["keep"]).To(Equal("this"))
+	})
+})

--- a/internal/resources/migration_test.go
+++ b/internal/resources/migration_test.go
@@ -18,174 +18,136 @@ package resources
 
 import (
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	batchv1 "k8s.io/api/batch/v1"
 
 	kubernautv1alpha1 "github.com/jordigilh/kubernaut-operator/api/v1alpha1"
 )
 
-func TestMigrationConfigMap_ContainsSQL(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := MigrationConfigMap(kn)
-	if err != nil {
-		t.Fatalf("MigrationConfigMap() error: %v", err)
-	}
-
-	if cm.Name != "kubernaut-migrations" {
-		t.Errorf("name = %q, want %q", cm.Name, "kubernaut-migrations")
-	}
-
-	if len(cm.Data) < 7 {
-		t.Fatalf("migration ConfigMap should contain at least 7 SQL files (v1.3.0), got %d", len(cm.Data))
-	}
-
-	for name, content := range cm.Data {
-		if !strings.HasSuffix(name, ".sql") {
-			t.Errorf("migration file %q should have .sql extension", name)
-		}
-		hasDDL := strings.Contains(content, "CREATE") ||
-			strings.Contains(content, "ALTER") ||
-			strings.Contains(content, "DROP")
-		if !hasDDL {
-			t.Errorf("migration file %q should contain SQL DDL, got %d bytes", name, len(content))
-		}
-	}
-}
-
-func TestMigrationConfigMap_Contains001Schema(t *testing.T) {
-	kn := testKubernaut()
-	cm, err := MigrationConfigMap(kn)
-	if err != nil {
-		t.Fatalf("MigrationConfigMap() error: %v", err)
-	}
-
-	if _, ok := cm.Data["001_v1_schema.sql"]; !ok {
-		t.Error("migration ConfigMap should contain 001_v1_schema.sql")
-	}
-}
-
-func mustMigrationJob(t *testing.T, kn *kubernautv1alpha1.Kubernaut) *batchv1.Job {
-	t.Helper()
+func mustMigrationJob(kn *kubernautv1alpha1.Kubernaut) *batchv1.Job {
 	job, err := MigrationJob(kn)
-	if err != nil {
-		t.Fatalf("MigrationJob() unexpected error: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	return job
 }
 
-func TestMigrationJob_Structure(t *testing.T) {
-	kn := testKubernaut()
-	job := mustMigrationJob(t, kn)
+var _ = Describe("MigrationConfigMap", func() {
+	It("contains SQL migration files", func() {
+		kn := testKubernaut()
+		cm, err := MigrationConfigMap(kn)
+		Expect(err).NotTo(HaveOccurred())
 
-	if job.Name != "kubernaut-db-migration" {
-		t.Errorf("name = %q, want %q", job.Name, "kubernaut-db-migration")
-	}
-	if job.Namespace != testSystemNamespace {
-		t.Errorf("namespace = %q, want %q", job.Namespace, testSystemNamespace)
-	}
+		Expect(cm.Name).To(Equal("kubernaut-migrations"), "name = %q, want %q", cm.Name, "kubernaut-migrations")
 
-	if job.Spec.BackoffLimit == nil || *job.Spec.BackoffLimit != 3 {
-		t.Error("Job should have backoffLimit=3")
-	}
-	if job.Spec.TTLSecondsAfterFinished == nil || *job.Spec.TTLSecondsAfterFinished != 300 {
-		t.Error("Job should have TTLSecondsAfterFinished=300")
-	}
-}
+		Expect(len(cm.Data)).To(BeNumerically(">=", 7), "migration ConfigMap should contain at least 7 SQL files (v1.3.0), got %d", len(cm.Data))
 
-func TestMigrationJob_Container(t *testing.T) {
-	kn := testKubernaut()
-	job := mustMigrationJob(t, kn)
-
-	if len(job.Spec.Template.Spec.Containers) != 1 {
-		t.Fatalf("Job should have 1 container, got %d", len(job.Spec.Template.Spec.Containers))
-	}
-
-	container := job.Spec.Template.Spec.Containers[0]
-	if container.Name != "db-migrate" {
-		t.Errorf("container name = %q, want %q", container.Name, "db-migrate")
-	}
-
-	wantImage := "quay.io/kubernaut-ai/db-migrate:v1.3.0"
-	if container.Image != wantImage {
-		t.Errorf("image = %q, want %q", container.Image, wantImage)
-	}
-
-	if len(container.Command) == 0 || container.Command[0] != "goose" {
-		t.Errorf("command should start with goose, got %v", container.Command)
-	}
-
-	if container.Resources.Requests == nil {
-		t.Error("migration container should have resource requests")
-	}
-}
-
-func TestMigrationJob_EnvFromPGSecret(t *testing.T) {
-	kn := testKubernaut()
-	job := mustMigrationJob(t, kn)
-
-	container := job.Spec.Template.Spec.Containers[0]
-	if len(container.EnvFrom) == 0 {
-		t.Fatal("container should have EnvFrom for PG secret")
-	}
-
-	ref := container.EnvFrom[0].SecretRef
-	if ref == nil || ref.Name != "postgresql-secret" {
-		t.Errorf("EnvFrom should reference postgresql-secret, got %v", ref)
-	}
-}
-
-func TestMigrationJob_MountsMigrationsCM(t *testing.T) {
-	kn := testKubernaut()
-	job := mustMigrationJob(t, kn)
-
-	container := job.Spec.Template.Spec.Containers[0]
-	found := false
-	for _, vm := range container.VolumeMounts {
-		if vm.Name == "migrations" && vm.MountPath == "/migrations" {
-			found = true
+		for name, content := range cm.Data {
+			Expect(strings.HasSuffix(name, ".sql")).To(BeTrue(), "migration file %q should have .sql extension", name)
+			hasDDL := strings.Contains(content, "CREATE") ||
+				strings.Contains(content, "ALTER") ||
+				strings.Contains(content, "DROP")
+			Expect(hasDDL).To(BeTrue(), "migration file %q should contain SQL DDL, got %d bytes", name, len(content))
 		}
-	}
-	if !found {
-		t.Error("container should mount migrations volume at /migrations")
-	}
+	})
 
-	volFound := false
-	for _, v := range job.Spec.Template.Spec.Volumes {
-		if v.Name == "migrations" && v.ConfigMap != nil && v.ConfigMap.Name == "kubernaut-migrations" {
-			volFound = true
+	It("contains 001_v1_schema.sql", func() {
+		kn := testKubernaut()
+		cm, err := MigrationConfigMap(kn)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, ok := cm.Data["001_v1_schema.sql"]
+		Expect(ok).To(BeTrue(), "migration ConfigMap should contain 001_v1_schema.sql")
+	})
+})
+
+var _ = Describe("MigrationJob", func() {
+	It("has expected Job metadata and lifecycle fields", func() {
+		kn := testKubernaut()
+		job := mustMigrationJob(kn)
+
+		Expect(job.Name).To(Equal("kubernaut-db-migration"), "name = %q, want %q", job.Name, "kubernaut-db-migration")
+		Expect(job.Namespace).To(Equal(testSystemNamespace), "namespace = %q, want %q", job.Namespace, testSystemNamespace)
+
+		Expect(job.Spec.BackoffLimit).NotTo(BeNil())
+		Expect(*job.Spec.BackoffLimit).To(Equal(int32(3)), "Job should have backoffLimit=3")
+		Expect(job.Spec.TTLSecondsAfterFinished).NotTo(BeNil())
+		Expect(*job.Spec.TTLSecondsAfterFinished).To(Equal(int32(300)), "Job should have TTLSecondsAfterFinished=300")
+	})
+
+	It("configures the db-migrate container", func() {
+		kn := testKubernaut()
+		job := mustMigrationJob(kn)
+
+		Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1), "Job should have 1 container, got %d", len(job.Spec.Template.Spec.Containers))
+
+		container := job.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("db-migrate"), "container name = %q, want %q", container.Name, "db-migrate")
+
+		wantImage := "quay.io/kubernaut-ai/db-migrate:v1.3.0"
+		Expect(container.Image).To(Equal(wantImage), "image = %q, want %q", container.Image, wantImage)
+
+		Expect(len(container.Command)).To(BeNumerically(">", 0))
+		Expect(container.Command[0]).To(Equal("goose"), "command should start with goose, got %v", container.Command)
+
+		Expect(container.Resources.Requests).NotTo(BeNil(), "migration container should have resource requests")
+	})
+
+	It("loads env from the PostgreSQL secret", func() {
+		kn := testKubernaut()
+		job := mustMigrationJob(kn)
+
+		container := job.Spec.Template.Spec.Containers[0]
+		Expect(container.EnvFrom).NotTo(BeEmpty(), "container should have EnvFrom for PG secret")
+
+		ref := container.EnvFrom[0].SecretRef
+		Expect(ref).NotTo(BeNil(), "EnvFrom should reference postgresql-secret, got %v", ref)
+		Expect(ref.Name).To(Equal("postgresql-secret"), "EnvFrom should reference postgresql-secret, got %v", ref)
+	})
+
+	It("mounts the migrations ConfigMap", func() {
+		kn := testKubernaut()
+		job := mustMigrationJob(kn)
+
+		container := job.Spec.Template.Spec.Containers[0]
+		found := false
+		for _, vm := range container.VolumeMounts {
+			if vm.Name == "migrations" && vm.MountPath == "/migrations" {
+				found = true
+			}
 		}
-	}
-	if !volFound {
-		t.Error("Job should have a migrations volume backed by kubernaut-migrations ConfigMap")
-	}
-}
+		Expect(found).To(BeTrue(), "container should mount migrations volume at /migrations")
 
-func TestMigrationJob_SecurityContext(t *testing.T) {
-	kn := testKubernaut()
-	job := mustMigrationJob(t, kn)
+		volFound := false
+		for _, v := range job.Spec.Template.Spec.Volumes {
+			if v.Name == "migrations" && v.ConfigMap != nil && v.ConfigMap.Name == "kubernaut-migrations" {
+				volFound = true
+			}
+		}
+		Expect(volFound).To(BeTrue(), "Job should have a migrations volume backed by kubernaut-migrations ConfigMap")
+	})
 
-	psc := job.Spec.Template.Spec.SecurityContext
-	if psc == nil || psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
-		t.Error("Job pod should have RunAsNonRoot=true")
-	}
+	It("sets security contexts", func() {
+		kn := testKubernaut()
+		job := mustMigrationJob(kn)
 
-	container := job.Spec.Template.Spec.Containers[0]
-	if container.SecurityContext == nil {
-		t.Error("Job container should have security context")
-	}
-}
+		psc := job.Spec.Template.Spec.SecurityContext
+		Expect(psc).NotTo(BeNil())
+		Expect(psc.RunAsNonRoot).NotTo(BeNil())
+		Expect(*psc.RunAsNonRoot).To(BeTrue(), "Job pod should have RunAsNonRoot=true")
 
-func TestMigrationJob_GooseCommand_ContainsPGHost(t *testing.T) {
-	kn := testKubernaut()
-	job := mustMigrationJob(t, kn)
+		container := job.Spec.Template.Spec.Containers[0]
+		Expect(container.SecurityContext).NotTo(BeNil(), "Job container should have security context")
+	})
 
-	container := job.Spec.Template.Spec.Containers[0]
-	cmdStr := strings.Join(container.Command, " ")
-	if !strings.Contains(cmdStr, "pg.example.com") {
-		t.Errorf("goose command should reference PG host, got:\n%s", cmdStr)
-	}
-	if !strings.Contains(cmdStr, "5432") {
-		t.Errorf("goose command should reference PG port, got:\n%s", cmdStr)
-	}
-}
+	It("runs goose with the PostgreSQL host and port", func() {
+		kn := testKubernaut()
+		job := mustMigrationJob(kn)
+
+		container := job.Spec.Template.Spec.Containers[0]
+		cmdStr := strings.Join(container.Command, " ")
+		Expect(cmdStr).To(ContainSubstring("pg.example.com"), "goose command should reference PG host, got:\n%s", cmdStr)
+		Expect(cmdStr).To(ContainSubstring("5432"), "goose command should reference PG port, got:\n%s", cmdStr)
+	})
+})

--- a/internal/resources/networkpolicies_test.go
+++ b/internal/resources/networkpolicies_test.go
@@ -18,285 +18,224 @@ package resources
 
 import (
 	"slices"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubernautv1alpha1 "github.com/jordigilh/kubernaut-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestNetworkPolicies_DisabledReturnsNil(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.NetworkPolicies.Enabled = &disabled
-	if got := NetworkPolicies(kn); got != nil {
-		t.Fatalf("NetworkPolicies() = %#v, want nil when enabled=false", got)
-	}
-}
+var _ = Describe("NetworkPolicies", func() {
+	Context("when disabled or default", func() {
+		It("returns nil when enabled is false", func() {
+			kn := testKubernaut()
+			disabled := false
+			kn.Spec.NetworkPolicies.Enabled = &disabled
+			Expect(NetworkPolicies(kn)).To(BeNil(), "NetworkPolicies() = %#v, want nil when enabled=false", NetworkPolicies(kn))
+		})
 
-func TestNetworkPolicies_DefaultDisabled(t *testing.T) {
-	kn := testKubernaut()
-	if got := NetworkPolicies(kn); got != nil {
-		t.Fatalf("NetworkPolicies() = %#v, want nil when enabled is not set (default false)", got)
-	}
-}
+		It("returns nil when enabled is unset", func() {
+			kn := testKubernaut()
+			Expect(NetworkPolicies(kn)).To(BeNil(), "NetworkPolicies() = %#v, want nil when enabled is not set (default false)", NetworkPolicies(kn))
+		})
+	})
 
-func TestNetworkPolicies_ExplicitEnabled(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	nps := NetworkPolicies(kn)
-	if len(nps) != 10 {
-		t.Fatalf("len(NetworkPolicies()) = %d, want 10", len(nps))
-	}
-}
+	Context("when enabled", func() {
+		var kn *kubernautv1alpha1.Kubernaut
 
-func TestNetworkPolicies_Names(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	nps := NetworkPolicies(kn)
-	wantNames := make(map[string]bool)
-	for _, c := range AllComponents() {
-		wantNames[c+"-netpol"] = true
-	}
-	if len(wantNames) != 10 {
-		t.Fatalf("internal: expected 10 component netpol names, got %d", len(wantNames))
-	}
-	for _, np := range nps {
-		if !wantNames[np.Name] {
-			t.Errorf("unexpected NetworkPolicy name %q", np.Name)
-			continue
-		}
-		delete(wantNames, np.Name)
-	}
-	for name := range wantNames {
-		t.Errorf("missing NetworkPolicy %q", name)
-	}
-}
+		BeforeEach(func() {
+			kn = testKubernaut()
+			enabled := true
+			kn.Spec.NetworkPolicies.Enabled = &enabled
+		})
 
-func TestNetworkPolicies_GatewayIngress(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	kn.Spec.NetworkPolicies.GatewayIngressNamespaces = []string{"ns1", "ns2"}
-	var gatewayNP *networkingv1.NetworkPolicy
-	for _, np := range NetworkPolicies(kn) {
-		if np.Name == ComponentGateway+"-netpol" {
-			gatewayNP = np
-			break
-		}
-	}
-	if gatewayNP == nil {
-		t.Fatal("gateway NetworkPolicy not found")
-	}
-	if len(gatewayNP.Spec.Ingress) != 1 {
-		t.Fatalf("gateway ingress rule count = %d, want 1", len(gatewayNP.Spec.Ingress))
-	}
-	nsSeen := ingressNamespaceNames(gatewayNP.Spec.Ingress[0])
-	if !nsSeen["ns1"] || !nsSeen["ns2"] {
-		t.Errorf("gateway ingress should allow namespaces ns1 and ns2, got %#v", nsSeen)
-	}
-	if len(nsSeen) != 2 {
-		t.Errorf("gateway ingress namespaces = %#v, want only ns1 and ns2", nsSeen)
-	}
-}
+		It("returns ten policies", func() {
+			nps := NetworkPolicies(kn)
+			Expect(nps).To(HaveLen(10), "len(NetworkPolicies()) = %d, want 10", len(nps))
+		})
 
-func TestNetworkPolicies_KubernautAgentIngressAndEgress(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	var agentNP *networkingv1.NetworkPolicy
-	for _, np := range NetworkPolicies(kn) {
-		if np.Name == ComponentKubernautAgent+"-netpol" {
-			agentNP = np
-			break
-		}
-	}
-	if agentNP == nil {
-		t.Fatal("kubernaut-agent NetworkPolicy not found")
-	}
-	wantTypes := []networkingv1.PolicyType{
-		networkingv1.PolicyTypeIngress,
-		networkingv1.PolicyTypeEgress,
-	}
-	if !slices.Equal(agentNP.Spec.PolicyTypes, wantTypes) {
-		t.Errorf("PolicyTypes = %v, want %v", agentNP.Spec.PolicyTypes, wantTypes)
-	}
-	if len(agentNP.Spec.Ingress) < 1 {
-		t.Fatalf("kubernaut-agent ingress rule count = %d, want at least 1", len(agentNP.Spec.Ingress))
-	}
-	// Without APIServerCIDR or MonitoringNamespace: DNS + data-storage egress only.
-	if want, got := 2, len(agentNP.Spec.Egress); got != want {
-		t.Errorf("kubernaut-agent egress rule count = %d, want %d", got, want)
-	}
-}
-
-func TestNetworkPolicies_KubernautAgentMonitoringEgress(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	kn.Spec.NetworkPolicies.MonitoringNamespace = OCPMonitoringNamespace
-	var agentNP *networkingv1.NetworkPolicy
-	for _, np := range NetworkPolicies(kn) {
-		if np.Name == ComponentKubernautAgent+"-netpol" {
-			agentNP = np
-			break
-		}
-	}
-	if agentNP == nil {
-		t.Fatal("kubernaut-agent NetworkPolicy not found")
-	}
-	// With MonitoringNamespace: DNS + data-storage + monitoring egress.
-	if want, got := 3, len(agentNP.Spec.Egress); got != want {
-		t.Fatalf("kubernaut-agent egress rule count = %d, want %d", got, want)
-	}
-	monRule := agentNP.Spec.Egress[2]
-	if len(monRule.To) != 1 {
-		t.Fatalf("monitoring egress peer count = %d, want 1", len(monRule.To))
-	}
-	ns := monRule.To[0].NamespaceSelector
-	if ns == nil || ns.MatchLabels["kubernetes.io/metadata.name"] != OCPMonitoringNamespace {
-		t.Errorf("monitoring egress namespace selector = %v, want %s", ns, OCPMonitoringNamespace)
-	}
-	if len(monRule.Ports) != 2 {
-		t.Fatalf("monitoring egress port count = %d, want 2", len(monRule.Ports))
-	}
-	if monRule.Ports[0].Port.IntValue() != 9091 {
-		t.Errorf("monitoring egress port[0] = %d, want 9091 (Thanos)", monRule.Ports[0].Port.IntValue())
-	}
-	if monRule.Ports[1].Port.IntValue() != 9094 {
-		t.Errorf("monitoring egress port[1] = %d, want 9094 (AlertManager)", monRule.Ports[1].Port.IntValue())
-	}
-}
-
-func TestNetworkPolicies_DataStorageIngressFromAllServices(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	var dsNP *networkingv1.NetworkPolicy
-	for _, np := range NetworkPolicies(kn) {
-		if np.Name == ComponentDataStorage+"-netpol" {
-			dsNP = np
-			break
-		}
-	}
-	if dsNP == nil {
-		t.Fatal("data-storage NetworkPolicy not found")
-	}
-	if len(dsNP.Spec.Ingress) < 1 {
-		t.Fatal("data-storage should have at least one ingress rule")
-	}
-	rule := dsNP.Spec.Ingress[0]
-	if len(rule.From) != 9 {
-		t.Fatalf("data-storage client ingress peers = %d, want 9", len(rule.From))
-	}
-	wantApps := map[string]struct{}{
-		ComponentGateway:                 {},
-		ComponentAIAnalysis:              {},
-		ComponentSignalProcessing:        {},
-		ComponentRemediationOrchestrator: {},
-		ComponentWorkflowExecution:       {},
-		ComponentNotification:            {},
-		ComponentEffectivenessMonitor:    {},
-		ComponentAuthWebhook:             {},
-		ComponentKubernautAgent:          {},
-	}
-	gotApps := make(map[string]struct{})
-	for _, peer := range rule.From {
-		if peer.PodSelector == nil || peer.PodSelector.MatchLabels == nil {
-			t.Fatalf("expected PodSelector peer, got %#v", peer)
-		}
-		app := peer.PodSelector.MatchLabels["app"]
-		if app == "" {
-			t.Fatalf("peer missing app label: %#v", peer.PodSelector.MatchLabels)
-		}
-		gotApps[app] = struct{}{}
-	}
-	for a := range wantApps {
-		if _, ok := gotApps[a]; !ok {
-			t.Errorf("missing ingress from client %q", a)
-		}
-	}
-	if len(gotApps) != 9 {
-		t.Errorf("unexpected peer count or duplicate apps: %#v", gotApps)
-	}
-}
-
-func TestNetworkPolicies_MetricsIngress(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	kn.Spec.NetworkPolicies.MonitoringNamespace = OCPMonitoringNamespace
-	var dsNP *networkingv1.NetworkPolicy
-	for _, np := range NetworkPolicies(kn) {
-		if np.Name == ComponentDataStorage+"-netpol" {
-			dsNP = np
-			break
-		}
-	}
-	if dsNP == nil {
-		t.Fatal("data-storage NetworkPolicy not found")
-	}
-	p9090 := intstr.FromInt32(PortMetrics)
-	proto := corev1.ProtocolTCP
-	found := false
-	for _, rule := range dsNP.Spec.Ingress {
-		nsOK := false
-		for _, peer := range rule.From {
-			if peer.NamespaceSelector != nil && peer.NamespaceSelector.MatchLabels != nil &&
-				peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == OCPMonitoringNamespace {
-				nsOK = true
-				break
+		It("names match component netpol names", func() {
+			nps := NetworkPolicies(kn)
+			wantNames := make(map[string]bool)
+			for _, c := range AllComponents() {
+				wantNames[c+"-netpol"] = true
 			}
-		}
-		if !nsOK {
-			continue
-		}
-		for _, port := range rule.Ports {
-			if port.Protocol != nil && *port.Protocol == proto && port.Port != nil && port.Port.String() == p9090.String() {
-				found = true
-				break
+			Expect(wantNames).To(HaveLen(10), "internal: expected 10 component netpol names, got %d", len(wantNames))
+			for _, np := range nps {
+				Expect(wantNames[np.Name]).To(BeTrue(), "unexpected NetworkPolicy name %q", np.Name)
+				delete(wantNames, np.Name)
 			}
-		}
-		if found {
-			break
-		}
-	}
-	if !found {
-		t.Errorf("data-storage NP should allow metrics scrape ingress from openshift-monitoring on port %d", PortMetrics)
-	}
-}
+			missing := make([]string, 0, len(wantNames))
+			for name := range wantNames {
+				missing = append(missing, name)
+			}
+			Expect(missing).To(BeEmpty(), "missing NetworkPolicy %v", missing)
+		})
 
-func TestNetworkPolicies_APIServerEgress(t *testing.T) {
-	kn := testKubernaut()
-	enabled := true
-	kn.Spec.NetworkPolicies.Enabled = &enabled
-	kn.Spec.NetworkPolicies.APIServerCIDR = "10.0.0.0/16"
-	nps := NetworkPolicies(kn)
-	p443 := intstr.FromInt32(443)
-	proto := corev1.ProtocolTCP
-	found := false
-outer:
-	for _, np := range nps {
-		for _, rule := range np.Spec.Egress {
-			for _, peer := range rule.To {
-				if peer.IPBlock == nil || peer.IPBlock.CIDR != "10.0.0.0/16" {
+		It("adds gateway ingress from configured namespaces", func() {
+			kn.Spec.NetworkPolicies.GatewayIngressNamespaces = []string{"ns1", "ns2"}
+			var gatewayNP *networkingv1.NetworkPolicy
+			for _, np := range NetworkPolicies(kn) {
+				if np.Name == ComponentGateway+"-netpol" {
+					gatewayNP = np
+					break
+				}
+			}
+			Expect(gatewayNP).NotTo(BeNil(), "gateway NetworkPolicy not found")
+			Expect(gatewayNP.Spec.Ingress).To(HaveLen(1), "gateway ingress rule count = %d, want 1", len(gatewayNP.Spec.Ingress))
+			nsSeen := ingressNamespaceNames(gatewayNP.Spec.Ingress[0])
+			Expect(nsSeen["ns1"] && nsSeen["ns2"]).To(BeTrue(), "gateway ingress should allow namespaces ns1 and ns2, got %#v", nsSeen)
+			Expect(nsSeen).To(HaveLen(2), "gateway ingress namespaces = %#v, want only ns1 and ns2", nsSeen)
+		})
+
+		It("gives kubernaut-agent ingress and egress with default egress count", func() {
+			var agentNP *networkingv1.NetworkPolicy
+			for _, np := range NetworkPolicies(kn) {
+				if np.Name == ComponentKubernautAgent+"-netpol" {
+					agentNP = np
+					break
+				}
+			}
+			Expect(agentNP).NotTo(BeNil(), "kubernaut-agent NetworkPolicy not found")
+			wantTypes := []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			}
+			Expect(slices.Equal(agentNP.Spec.PolicyTypes, wantTypes)).To(BeTrue(), "PolicyTypes = %v, want %v", agentNP.Spec.PolicyTypes, wantTypes)
+			Expect(len(agentNP.Spec.Ingress)).To(BeNumerically(">=", 1), "kubernaut-agent ingress rule count = %d, want at least 1", len(agentNP.Spec.Ingress))
+			Expect(len(agentNP.Spec.Egress)).To(Equal(2), "kubernaut-agent egress rule count = %d, want %d", len(agentNP.Spec.Egress), 2)
+		})
+
+		It("adds monitoring egress when MonitoringNamespace is set", func() {
+			kn.Spec.NetworkPolicies.MonitoringNamespace = OCPMonitoringNamespace
+			var agentNP *networkingv1.NetworkPolicy
+			for _, np := range NetworkPolicies(kn) {
+				if np.Name == ComponentKubernautAgent+"-netpol" {
+					agentNP = np
+					break
+				}
+			}
+			Expect(agentNP).NotTo(BeNil(), "kubernaut-agent NetworkPolicy not found")
+			Expect(len(agentNP.Spec.Egress)).To(Equal(3), "kubernaut-agent egress rule count = %d, want %d", len(agentNP.Spec.Egress), 3)
+			monRule := agentNP.Spec.Egress[2]
+			Expect(monRule.To).To(HaveLen(1), "monitoring egress peer count = %d, want 1", len(monRule.To))
+			ns := monRule.To[0].NamespaceSelector
+			Expect(ns != nil && ns.MatchLabels["kubernetes.io/metadata.name"] == OCPMonitoringNamespace).To(BeTrue(),
+				"monitoring egress namespace selector = %v, want %s", ns, OCPMonitoringNamespace)
+			Expect(monRule.Ports).To(HaveLen(2), "monitoring egress port count = %d, want 2", len(monRule.Ports))
+			Expect(monRule.Ports[0].Port.IntValue()).To(Equal(9091), "monitoring egress port[0] = %d, want 9091 (Thanos)", monRule.Ports[0].Port.IntValue())
+			Expect(monRule.Ports[1].Port.IntValue()).To(Equal(9094), "monitoring egress port[1] = %d, want 9094 (AlertManager)", monRule.Ports[1].Port.IntValue())
+		})
+
+		It("allows data-storage ingress from all client components", func() {
+			var dsNP *networkingv1.NetworkPolicy
+			for _, np := range NetworkPolicies(kn) {
+				if np.Name == ComponentDataStorage+"-netpol" {
+					dsNP = np
+					break
+				}
+			}
+			Expect(dsNP).NotTo(BeNil(), "data-storage NetworkPolicy not found")
+			Expect(len(dsNP.Spec.Ingress)).To(BeNumerically(">=", 1), "data-storage should have at least one ingress rule")
+			rule := dsNP.Spec.Ingress[0]
+			Expect(rule.From).To(HaveLen(9), "data-storage client ingress peers = %d, want 9", len(rule.From))
+			wantApps := map[string]struct{}{
+				ComponentGateway:                 {},
+				ComponentAIAnalysis:              {},
+				ComponentSignalProcessing:        {},
+				ComponentRemediationOrchestrator: {},
+				ComponentWorkflowExecution:       {},
+				ComponentNotification:            {},
+				ComponentEffectivenessMonitor:    {},
+				ComponentAuthWebhook:             {},
+				ComponentKubernautAgent:          {},
+			}
+			gotApps := make(map[string]struct{})
+			for _, peer := range rule.From {
+				Expect(peer.PodSelector).NotTo(BeNil(), "expected PodSelector peer, got %#v", peer)
+				Expect(peer.PodSelector.MatchLabels).NotTo(BeNil())
+				app := peer.PodSelector.MatchLabels["app"]
+				Expect(app).NotTo(BeEmpty(), "peer missing app label: %#v", peer.PodSelector.MatchLabels)
+				gotApps[app] = struct{}{}
+			}
+			for a := range wantApps {
+				_, ok := gotApps[a]
+				Expect(ok).To(BeTrue(), "missing ingress from client %q", a)
+			}
+			Expect(gotApps).To(HaveLen(9), "unexpected peer count or duplicate apps: %#v", gotApps)
+		})
+
+		It("allows metrics scrape ingress from openshift-monitoring", func() {
+			kn.Spec.NetworkPolicies.MonitoringNamespace = OCPMonitoringNamespace
+			var dsNP *networkingv1.NetworkPolicy
+			for _, np := range NetworkPolicies(kn) {
+				if np.Name == ComponentDataStorage+"-netpol" {
+					dsNP = np
+					break
+				}
+			}
+			Expect(dsNP).NotTo(BeNil(), "data-storage NetworkPolicy not found")
+			p9090 := intstr.FromInt32(PortMetrics)
+			proto := corev1.ProtocolTCP
+			found := false
+			for _, rule := range dsNP.Spec.Ingress {
+				nsOK := false
+				for _, peer := range rule.From {
+					if peer.NamespaceSelector != nil && peer.NamespaceSelector.MatchLabels != nil &&
+						peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == OCPMonitoringNamespace {
+						nsOK = true
+						break
+					}
+				}
+				if !nsOK {
 					continue
 				}
 				for _, port := range rule.Ports {
-					if port.Protocol != nil && *port.Protocol == proto && port.Port != nil && port.Port.String() == p443.String() {
+					if port.Protocol != nil && *port.Protocol == proto && port.Port != nil && port.Port.String() == p9090.String() {
 						found = true
-						break outer
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "data-storage NP should allow metrics scrape ingress from openshift-monitoring on port %d", PortMetrics)
+		})
+	})
+
+	It("adds API server egress when APIServerCIDR is set", func() {
+		kn := testKubernaut()
+		enabled := true
+		kn.Spec.NetworkPolicies.Enabled = &enabled
+		kn.Spec.NetworkPolicies.APIServerCIDR = "10.0.0.0/16"
+		nps := NetworkPolicies(kn)
+		p443 := intstr.FromInt32(443)
+		proto := corev1.ProtocolTCP
+		found := false
+	outer:
+		for _, np := range nps {
+			for _, rule := range np.Spec.Egress {
+				for _, peer := range rule.To {
+					if peer.IPBlock == nil || peer.IPBlock.CIDR != "10.0.0.0/16" {
+						continue
+					}
+					for _, port := range rule.Ports {
+						if port.Protocol != nil && *port.Protocol == proto && port.Port != nil && port.Port.String() == p443.String() {
+							found = true
+							break outer
+						}
 					}
 				}
 			}
 		}
-	}
-	if !found {
-		t.Error("expected at least one NetworkPolicy with API server egress (10.0.0.0/16:443)")
-	}
-}
+		Expect(found).To(BeTrue(), "expected at least one NetworkPolicy with API server egress (10.0.0.0/16:443)")
+	})
+})
 
 func ingressNamespaceNames(rule networkingv1.NetworkPolicyIngressRule) map[string]bool {
 	out := make(map[string]bool)

--- a/internal/resources/ocp_test.go
+++ b/internal/resources/ocp_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package resources
 
 import (
-	"strings"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,166 +30,124 @@ const (
 	testOperatorManagedByValue = "kubernaut-operator"
 )
 
-func TestGatewayRoute_EnabledByDefault(t *testing.T) {
-	kn := testKubernaut()
-	route := GatewayRoute(kn)
+var _ = Describe("GatewayRoute", func() {
+	It("is enabled by default with expected route settings", func() {
+		kn := testKubernaut()
+		route := GatewayRoute(kn)
 
-	if route == nil {
-		t.Fatal("GatewayRoute should not be nil when enabled by default")
-	}
-	if route.Name != "gateway-route" {
-		t.Errorf("name = %q, want %q", route.Name, "gateway-route")
-	}
-	if route.Namespace != testSystemNamespace {
-		t.Errorf("namespace = %q, want %q", route.Namespace, testSystemNamespace)
-	}
-	if route.Spec.To.Name != testGatewayServiceName {
-		t.Errorf("route target = %q, want %q", route.Spec.To.Name, testGatewayServiceName)
-	}
-	if route.Spec.TLS == nil {
-		t.Fatal("route should have TLS config")
-	}
-	if route.Spec.TLS.Termination != routev1.TLSTerminationEdge {
-		t.Errorf("TLS termination = %q, want %q", route.Spec.TLS.Termination, routev1.TLSTerminationEdge)
-	}
-	if route.Spec.TLS.InsecureEdgeTerminationPolicy != routev1.InsecureEdgeTerminationPolicyRedirect {
-		t.Errorf("insecure policy = %q, want Redirect", route.Spec.TLS.InsecureEdgeTerminationPolicy)
-	}
-}
+		Expect(route).NotTo(BeNil(), "GatewayRoute should not be nil when enabled by default")
+		Expect(route.Name).To(Equal("gateway-route"), "name = %q, want %q", route.Name, "gateway-route")
+		Expect(route.Namespace).To(Equal(testSystemNamespace), "namespace = %q, want %q", route.Namespace, testSystemNamespace)
+		Expect(route.Spec.To.Name).To(Equal(testGatewayServiceName), "route target = %q, want %q", route.Spec.To.Name, testGatewayServiceName)
+		Expect(route.Spec.TLS).NotTo(BeNil(), "route should have TLS config")
+		Expect(route.Spec.TLS.Termination).To(Equal(routev1.TLSTerminationEdge), "TLS termination = %q, want %q", route.Spec.TLS.Termination, routev1.TLSTerminationEdge)
+		Expect(route.Spec.TLS.InsecureEdgeTerminationPolicy).To(Equal(routev1.InsecureEdgeTerminationPolicyRedirect), "insecure policy = %q, want Redirect", route.Spec.TLS.InsecureEdgeTerminationPolicy)
+	})
 
-func TestGatewayRouteStub_MinimalMetadata(t *testing.T) {
-	kn := testKubernaut()
-	stub := GatewayRouteStub(kn)
+	It("returns nil when explicitly disabled", func() {
+		kn := testKubernaut()
+		disabled := false
+		kn.Spec.Gateway.Route.Enabled = &disabled
+		route := GatewayRoute(kn)
 
-	if stub.Name != "gateway-route" {
-		t.Errorf("Name = %q, want %q", stub.Name, "gateway-route")
-	}
-	if stub.Namespace != kn.Namespace {
-		t.Errorf("Namespace = %q, want %q", stub.Namespace, kn.Namespace)
-	}
-}
+		Expect(route).To(BeNil(), "GatewayRoute should be nil when explicitly disabled")
+	})
 
-func TestGatewayRoute_DisabledExplicitly(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.Gateway.Route.Enabled = &disabled
-	route := GatewayRoute(kn)
+	It("sets a custom hostname", func() {
+		kn := testKubernaut()
+		kn.Spec.Gateway.Route.Hostname = "kubernaut.example.com"
+		route := GatewayRoute(kn)
 
-	if route != nil {
-		t.Error("GatewayRoute should be nil when explicitly disabled")
-	}
-}
+		Expect(route.Spec.Host).To(Equal("kubernaut.example.com"), "route host = %q, want %q", route.Spec.Host, "kubernaut.example.com")
+	})
 
-func TestGatewayRoute_CustomHostname(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Gateway.Route.Hostname = "kubernaut.example.com"
-	route := GatewayRoute(kn)
+	It("has no hostname by default", func() {
+		kn := testKubernaut()
+		route := GatewayRoute(kn)
 
-	if route.Spec.Host != "kubernaut.example.com" {
-		t.Errorf("route host = %q, want %q", route.Spec.Host, "kubernaut.example.com")
-	}
-}
+		Expect(route.Spec.Host).To(BeEmpty(), "route host should be empty by default, got %q", route.Spec.Host)
+	})
+})
 
-func TestGatewayRoute_NoHostnameByDefault(t *testing.T) {
-	kn := testKubernaut()
-	route := GatewayRoute(kn)
+var _ = Describe("GatewayRouteStub", func() {
+	It("has minimal metadata", func() {
+		kn := testKubernaut()
+		stub := GatewayRouteStub(kn)
 
-	if route.Spec.Host != "" {
-		t.Errorf("route host should be empty by default, got %q", route.Spec.Host)
-	}
-}
+		Expect(stub.Name).To(Equal("gateway-route"), "Name = %q, want %q", stub.Name, "gateway-route")
+		Expect(stub.Namespace).To(Equal(kn.Namespace), "Namespace = %q, want %q", stub.Namespace, kn.Namespace)
+	})
+})
 
-func TestDataStorageDBSecret_DerivesFromPGSecret(t *testing.T) {
-	kn := testKubernaut()
-	pgSecret := &corev1.Secret{
-		Data: map[string][]byte{
-			"POSTGRES_USER":     []byte("kubernaut"),
-			"POSTGRES_PASSWORD": []byte("s3cret"),
-			"POSTGRES_DB":       []byte("action_history"),
-		},
-	}
+var _ = Describe("DataStorageDBSecret", func() {
+	It("derives from the PostgreSQL secret", func() {
+		kn := testKubernaut()
+		pgSecret := &corev1.Secret{
+			Data: map[string][]byte{
+				"POSTGRES_USER":     []byte("kubernaut"),
+				"POSTGRES_PASSWORD": []byte("s3cret"),
+				"POSTGRES_DB":       []byte("action_history"),
+			},
+		}
 
-	dsSecret, err := DataStorageDBSecret(kn, pgSecret)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+		dsSecret, err := DataStorageDBSecret(kn, pgSecret)
+		Expect(err).NotTo(HaveOccurred())
 
-	if dsSecret.Name != "datastorage-db-secret" {
-		t.Errorf("name = %q, want %q", dsSecret.Name, "datastorage-db-secret")
-	}
+		Expect(dsSecret.Name).To(Equal("datastorage-db-secret"), "name = %q, want %q", dsSecret.Name, "datastorage-db-secret")
 
-	yamlContent := string(dsSecret.Data["db-secrets.yaml"])
-	if !strings.Contains(yamlContent, "host: pg.example.com") {
-		t.Errorf("db-secrets.yaml should contain PG host, got:\n%s", yamlContent)
-	}
-	if !strings.Contains(yamlContent, "port: 5432") {
-		t.Errorf("db-secrets.yaml should contain PG port, got:\n%s", yamlContent)
-	}
-	if !strings.Contains(yamlContent, "dbname: action_history") {
-		t.Errorf("db-secrets.yaml should contain dbname, got:\n%s", yamlContent)
-	}
-	if !strings.Contains(yamlContent, "user: kubernaut") {
-		t.Errorf("db-secrets.yaml should contain user, got:\n%s", yamlContent)
-	}
-	if !strings.Contains(yamlContent, "password: s3cret") {
-		t.Errorf("db-secrets.yaml should contain password, got:\n%s", yamlContent)
-	}
-}
+		yamlContent := string(dsSecret.Data["db-secrets.yaml"])
+		Expect(yamlContent).To(ContainSubstring("host: pg.example.com"), "db-secrets.yaml should contain PG host, got:\n%s", yamlContent)
+		Expect(yamlContent).To(ContainSubstring("port: 5432"), "db-secrets.yaml should contain PG port, got:\n%s", yamlContent)
+		Expect(yamlContent).To(ContainSubstring("dbname: action_history"), "db-secrets.yaml should contain dbname, got:\n%s", yamlContent)
+		Expect(yamlContent).To(ContainSubstring("user: kubernaut"), "db-secrets.yaml should contain user, got:\n%s", yamlContent)
+		Expect(yamlContent).To(ContainSubstring("password: s3cret"), "db-secrets.yaml should contain password, got:\n%s", yamlContent)
+	})
 
-func TestDataStorageDBSecret_DefaultPort(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.PostgreSQL.Port = 0
-	pgSecret := &corev1.Secret{
-		Data: map[string][]byte{
-			"POSTGRES_USER":     []byte("u"),
-			"POSTGRES_PASSWORD": []byte("p"),
-			"POSTGRES_DB":       []byte("d"),
-		},
-	}
+	It("defaults the port to 5432", func() {
+		kn := testKubernaut()
+		kn.Spec.PostgreSQL.Port = 0
+		pgSecret := &corev1.Secret{
+			Data: map[string][]byte{
+				"POSTGRES_USER":     []byte("u"),
+				"POSTGRES_PASSWORD": []byte("p"),
+				"POSTGRES_DB":       []byte("d"),
+			},
+		}
 
-	dsSecret, err := DataStorageDBSecret(kn, pgSecret)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	yamlContent := string(dsSecret.Data["db-secrets.yaml"])
-	if !strings.Contains(yamlContent, "port: 5432") {
-		t.Errorf("should default to port 5432, got:\n%s", yamlContent)
-	}
-}
+		dsSecret, err := DataStorageDBSecret(kn, pgSecret)
+		Expect(err).NotTo(HaveOccurred())
+		yamlContent := string(dsSecret.Data["db-secrets.yaml"])
+		Expect(yamlContent).To(ContainSubstring("port: 5432"), "should default to port 5432, got:\n%s", yamlContent)
+	})
 
-func TestDataStorageDBSecret_MissingKey_ReturnsError(t *testing.T) {
-	kn := testKubernaut()
-	pgSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pg-secret"},
-		Data: map[string][]byte{
-			"POSTGRES_USER": []byte("u"),
-		},
-	}
+	It("returns an error when required keys are missing", func() {
+		kn := testKubernaut()
+		pgSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pg-secret"},
+			Data: map[string][]byte{
+				"POSTGRES_USER": []byte("u"),
+			},
+		}
 
-	_, err := DataStorageDBSecret(kn, pgSecret)
-	if err == nil {
-		t.Error("DataStorageDBSecret should return error when required keys are missing")
-	}
-}
+		_, err := DataStorageDBSecret(kn, pgSecret)
+		Expect(err).To(HaveOccurred(), "DataStorageDBSecret should return error when required keys are missing")
+	})
+})
 
-func TestWorkflowNamespace_DefaultName(t *testing.T) {
-	kn := testKubernaut()
-	ns := WorkflowNamespace(kn)
+var _ = Describe("WorkflowNamespace", func() {
+	It("uses the default name and labels", func() {
+		kn := testKubernaut()
+		ns := WorkflowNamespace(kn)
 
-	if ns.Name != DefaultWorkflowNamespace {
-		t.Errorf("name = %q, want %q", ns.Name, DefaultWorkflowNamespace)
-	}
-	if ns.Labels["app.kubernetes.io/managed-by"] != testOperatorManagedByValue {
-		t.Error("workflow namespace should have managed-by label")
-	}
-}
+		Expect(ns.Name).To(Equal(DefaultWorkflowNamespace), "name = %q, want %q", ns.Name, DefaultWorkflowNamespace)
+		Expect(ns.Labels["app.kubernetes.io/managed-by"]).To(Equal(testOperatorManagedByValue), "workflow namespace should have managed-by label")
+	})
 
-func TestWorkflowNamespace_CustomName(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.WorkflowExecution.WorkflowNamespace = "my-workflows"
-	ns := WorkflowNamespace(kn)
+	It("uses a custom name from the spec", func() {
+		kn := testKubernaut()
+		kn.Spec.WorkflowExecution.WorkflowNamespace = "my-workflows"
+		ns := WorkflowNamespace(kn)
 
-	if ns.Name != "my-workflows" {
-		t.Errorf("name = %q, want %q", ns.Name, "my-workflows")
-	}
-}
+		Expect(ns.Name).To(Equal("my-workflows"), "name = %q, want %q", ns.Name, "my-workflows")
+	})
+})

--- a/internal/resources/pdb_test.go
+++ b/internal/resources/pdb_test.go
@@ -17,88 +17,64 @@ limitations under the License.
 package resources
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestPodDisruptionBudgets_Count10(t *testing.T) {
-	kn := testKubernaut()
-	pdbs := PodDisruptionBudgets(kn)
-	if len(pdbs) != 10 {
-		t.Errorf("PodDisruptionBudgets() should return 10, got %d", len(pdbs))
-	}
-}
+var _ = Describe("PodDisruptionBudgets", func() {
+	It("returns 10 PDBs", func() {
+		kn := testKubernaut()
+		pdbs := PodDisruptionBudgets(kn)
+		Expect(len(pdbs)).To(Equal(10))
+	})
 
-func TestPodDisruptionBudgets_MaxUnavailable1(t *testing.T) {
-	kn := testKubernaut()
-	for _, pdb := range PodDisruptionBudgets(kn) {
-		if pdb.Spec.MaxUnavailable == nil {
-			t.Errorf("PDB %q should have MaxUnavailable set", pdb.Name)
-			continue
+	It("sets MaxUnavailable to 1 on every PDB", func() {
+		kn := testKubernaut()
+		for _, pdb := range PodDisruptionBudgets(kn) {
+			Expect(pdb.Spec.MaxUnavailable).NotTo(BeNil(), "PDB %q should have MaxUnavailable set", pdb.Name)
+			Expect(pdb.Spec.MaxUnavailable.IntValue()).To(Equal(1), "PDB %q MaxUnavailable = %d, want 1", pdb.Name, pdb.Spec.MaxUnavailable.IntValue())
 		}
-		if pdb.Spec.MaxUnavailable.IntValue() != 1 {
-			t.Errorf("PDB %q MaxUnavailable = %d, want 1", pdb.Name, pdb.Spec.MaxUnavailable.IntValue())
-		}
-	}
-}
+	})
 
-func TestPodDisruptionBudgets_SelectorsMatchComponentSelectorLabels(t *testing.T) {
-	kn := testKubernaut()
-	components := AllComponents()
-	pdbs := PodDisruptionBudgets(kn)
-	if len(pdbs) != len(components) {
-		t.Fatalf("PDB count = %d, component count = %d", len(pdbs), len(components))
-	}
-	for i, pdb := range pdbs {
-		component := components[i]
-		if pdb.Name != component {
-			t.Fatalf("PDB[%d] name = %q, want %q (index mismatch)", i, pdb.Name, component)
-		}
-		want := SelectorLabels(component)
-		if pdb.Spec.Selector == nil {
-			t.Errorf("PDB %q should have selector", pdb.Name)
-			continue
-		}
-		got := pdb.Spec.Selector.MatchLabels
-		if len(got) != len(want) {
-			t.Errorf("PDB %q selector len = %d, want %d (got %#v want %#v)", pdb.Name, len(got), len(want), got, want)
-			continue
-		}
-		for k, v := range want {
-			if got[k] != v {
-				t.Errorf("PDB %q selector %q = %q, want %q", pdb.Name, k, got[k], v)
+	It("aligns selectors with component selector labels by index", func() {
+		kn := testKubernaut()
+		components := AllComponents()
+		pdbs := PodDisruptionBudgets(kn)
+		Expect(len(pdbs)).To(Equal(len(components)), "PDB count = %d, component count = %d", len(pdbs), len(components))
+		for i, pdb := range pdbs {
+			component := components[i]
+			Expect(pdb.Name).To(Equal(component), "PDB[%d] name = %q, want %q (index mismatch)", i, pdb.Name, component)
+			want := SelectorLabels(component)
+			Expect(pdb.Spec.Selector).NotTo(BeNil(), "PDB %q should have selector", pdb.Name)
+			got := pdb.Spec.Selector.MatchLabels
+			Expect(len(got)).To(Equal(len(want)), "PDB %q selector len = %d, want %d (got %#v want %#v)", pdb.Name, len(got), len(want), got, want)
+			for k, v := range want {
+				Expect(got[k]).To(Equal(v), "PDB %q selector %q = %q, want %q", pdb.Name, k, got[k], v)
 			}
 		}
-	}
-}
+	})
 
-func TestPodDisruptionBudgets_LabelsIncludeManagedBy(t *testing.T) {
-	kn := testKubernaut()
-	for _, pdb := range PodDisruptionBudgets(kn) {
-		if pdb.Labels["app.kubernetes.io/managed-by"] != "kubernaut-operator" {
-			t.Errorf("PDB %q labels missing app.kubernetes.io/managed-by=kubernaut-operator, got %#v", pdb.Name, pdb.Labels)
+	It("labels every PDB with managed-by kubernaut-operator", func() {
+		kn := testKubernaut()
+		for _, pdb := range PodDisruptionBudgets(kn) {
+			Expect(pdb.Labels["app.kubernetes.io/managed-by"]).To(Equal("kubernaut-operator"), "PDB %q labels missing app.kubernetes.io/managed-by=kubernaut-operator, got %#v", pdb.Name, pdb.Labels)
 		}
-	}
-}
+	})
 
-func TestPodDisruptionBudgets_CorrectNamespace(t *testing.T) {
-	kn := testKubernaut()
-	for _, pdb := range PodDisruptionBudgets(kn) {
-		if pdb.Namespace != testSystemNamespace {
-			t.Errorf("PDB %q namespace = %q, want %q", pdb.Name, pdb.Namespace, testSystemNamespace)
+	It("places every PDB in the system namespace", func() {
+		kn := testKubernaut()
+		for _, pdb := range PodDisruptionBudgets(kn) {
+			Expect(pdb.Namespace).To(Equal(testSystemNamespace), "PDB %q namespace = %q, want %q", pdb.Name, pdb.Namespace, testSystemNamespace)
 		}
-	}
-}
+	})
 
-func TestPodDisruptionBudgets_NamesMatchComponents(t *testing.T) {
-	kn := testKubernaut()
-	pdbs := PodDisruptionBudgets(kn)
-	components := AllComponents()
-	if len(pdbs) != len(components) {
-		t.Fatalf("PDB count = %d, component count = %d", len(pdbs), len(components))
-	}
-	for i, pdb := range pdbs {
-		if pdb.Name != components[i] {
-			t.Errorf("PDB[%d] name = %q, want %q (no -pdb suffix)", i, pdb.Name, components[i])
+	It("names PDBs after components without a -pdb suffix", func() {
+		kn := testKubernaut()
+		pdbs := PodDisruptionBudgets(kn)
+		components := AllComponents()
+		Expect(len(pdbs)).To(Equal(len(components)), "PDB count = %d, component count = %d", len(pdbs), len(components))
+		for i, pdb := range pdbs {
+			Expect(pdb.Name).To(Equal(components[i]), "PDB[%d] name = %q, want %q (no -pdb suffix)", i, pdb.Name, components[i])
 		}
-	}
-}
+	})
+})

--- a/internal/resources/rbac_test.go
+++ b/internal/resources/rbac_test.go
@@ -18,7 +18,9 @@ package resources
 
 import (
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -29,676 +31,586 @@ const (
 	testClusterRoleKind      = "ClusterRole"
 )
 
-func TestClusterRoles_Count(t *testing.T) {
-	kn := testKubernaut()
-	roles := ClusterRoles(kn)
-	if len(roles) != 15 {
-		t.Errorf("ClusterRoles() should return exactly 15 roles (13 base + 2 monitoring), got %d", len(roles))
-	}
-}
+var _ = Describe("ClusterRoles", func() {
+	It("returns exactly 15 roles (13 base + 2 monitoring)", func() {
+		kn := testKubernaut()
+		roles := ClusterRoles(kn)
+		Expect(len(roles)).To(Equal(15), "ClusterRoles() should return exactly 15 roles (13 base + 2 monitoring), got %d", len(roles))
+	})
 
-func TestClusterRoles_MonitoringDisabledReducesCount(t *testing.T) {
-	kn := testKubernaut()
-	enabled := false
-	kn.Spec.Monitoring.Enabled = &enabled
+	It("reduces count when monitoring is disabled", func() {
+		kn := testKubernaut()
+		enabled := false
+		kn.Spec.Monitoring.Enabled = &enabled
 
-	withMonitoring := ClusterRoles(testKubernaut())
-	withoutMonitoring := ClusterRoles(kn)
+		withMonitoring := ClusterRoles(testKubernaut())
+		withoutMonitoring := ClusterRoles(kn)
 
-	if len(withoutMonitoring) >= len(withMonitoring) {
-		t.Errorf("disabling monitoring should reduce ClusterRole count: %d vs %d",
+		Expect(len(withoutMonitoring) < len(withMonitoring)).To(BeTrue(),
+			"disabling monitoring should reduce ClusterRole count: %d vs %d",
 			len(withoutMonitoring), len(withMonitoring))
-	}
-}
+	})
 
-func TestClusterRoles_ContainsExpectedNames(t *testing.T) {
-	kn := testKubernaut()
-	roles := ClusterRoles(kn)
-	names := make(map[string]bool, len(roles))
-	for _, r := range roles {
-		names[r.Name] = true
-	}
-
-	ns := kn.Namespace
-	expectedNames := []string{
-		ns + "-gateway-role",
-		ns + "-aianalysis-controller",
-		ns + "-kubernaut-agent-client",
-		ns + "-kubernaut-agent-investigator",
-		ns + "-signalprocessing-controller",
-		ns + "-remediationorchestrator-controller",
-		ns + "-workflowexecution-controller",
-		ns + "-workflow-runner",
-		ns + "-effectivenessmonitor-controller",
-		ns + "-notification-controller",
-		ns + "-data-storage-auth-middleware",
-		ns + "-data-storage-client",
-		ns + "-authwebhook-role",
-		ns + "-alertmanager-view",
-		ns + "-gateway-signal-source",
-	}
-
-	for _, name := range expectedNames {
-		if !names[name] {
-			t.Errorf("ClusterRoles() missing expected role %q", name)
+	It("contains expected role names", func() {
+		kn := testKubernaut()
+		roles := ClusterRoles(kn)
+		names := make(map[string]bool, len(roles))
+		for _, r := range roles {
+			names[r.Name] = true
 		}
-	}
-}
 
-func TestClusterRoleBindings_SubjectNamespace(t *testing.T) {
-	kn := testKubernaut()
-	crbs := ClusterRoleBindings(kn)
-
-	allowedNamespaces := map[string]bool{
-		kn.Namespace:             true,
-		DefaultWorkflowNamespace: true,
-		OCPMonitoringNamespace:   true,
-	}
-
-	for _, crb := range crbs {
-		if len(crb.Subjects) == 0 {
-			t.Errorf("CRB %q has no subjects", crb.Name)
-			continue
+		ns := kn.Namespace
+		expectedNames := []string{
+			ns + "-gateway-role",
+			ns + "-aianalysis-controller",
+			ns + "-kubernaut-agent-client",
+			ns + "-kubernaut-agent-investigator",
+			ns + "-signalprocessing-controller",
+			ns + "-remediationorchestrator-controller",
+			ns + "-workflowexecution-controller",
+			ns + "-workflow-runner",
+			ns + "-effectivenessmonitor-controller",
+			ns + "-notification-controller",
+			ns + "-data-storage-auth-middleware",
+			ns + "-data-storage-client",
+			ns + "-authwebhook-role",
+			ns + "-alertmanager-view",
+			ns + "-gateway-signal-source",
 		}
-		for _, subj := range crb.Subjects {
-			if !allowedNamespaces[subj.Namespace] {
-				t.Errorf("CRB %q subject %q has namespace %q, want one of %v",
+
+		for _, name := range expectedNames {
+			Expect(names[name]).To(BeTrue(), "ClusterRoles() missing expected role %q", name)
+		}
+	})
+
+	It("include common managed-by labels", func() {
+		kn := testKubernaut()
+		for _, cr := range ClusterRoles(kn) {
+			Expect(cr.Labels["app.kubernetes.io/managed-by"]).To(Equal(testOperatorManagedByValue),
+				"ClusterRole %q missing managed-by label", cr.Name)
+		}
+	})
+
+	Describe("GatewayClusterRole", func() {
+		It("has PVC and HPA rules", func() {
+			kn := testKubernaut()
+			roles := ClusterRoles(kn)
+			var gw *rbacv1.ClusterRole
+			for _, r := range roles {
+				if r.Name == kn.Namespace+"-gateway-role" {
+					gw = r
+					break
+				}
+			}
+			Expect(gw).NotTo(BeNil(), "gateway-role ClusterRole not found")
+
+			type resourceCheck struct {
+				apiGroup string
+				resource string
+			}
+			want := []resourceCheck{
+				{"", "persistentvolumeclaims"},
+				{"autoscaling", "horizontalpodautoscalers"},
+			}
+
+			for _, w := range want {
+				found := false
+				for _, rule := range gw.Rules {
+					for _, g := range rule.APIGroups {
+						if g != w.apiGroup {
+							continue
+						}
+						for _, r := range rule.Resources {
+							if r == w.resource {
+								found = true
+							}
+						}
+					}
+				}
+				Expect(found).To(BeTrue(), "gateway-role missing %s/%s", w.apiGroup, w.resource)
+			}
+		})
+	})
+
+	Describe("KubernautAgent investigator", func() {
+		It("has service mesh and GitOps rules", func() {
+			kn := testKubernaut()
+			roles := ClusterRoles(kn)
+			var investigator *rbacv1.ClusterRole
+			for _, r := range roles {
+				if r.Name == kn.Namespace+"-kubernaut-agent-investigator" {
+					investigator = r
+					break
+				}
+			}
+			Expect(investigator).NotTo(BeNil(), "kubernaut-agent-investigator ClusterRole not found")
+
+			wantGroups := []string{
+				"cert-manager.io",
+				"argoproj.io",
+				"policy.linkerd.io",
+				"security.istio.io",
+				"networking.istio.io",
+			}
+			foundGroups := make(map[string]bool)
+			for _, rule := range investigator.Rules {
+				for _, g := range rule.APIGroups {
+					foundGroups[g] = true
+				}
+			}
+			for _, g := range wantGroups {
+				Expect(foundGroups[g]).To(BeTrue(), "kubernaut-agent-investigator missing API group %q", g)
+			}
+		})
+
+		It("has OCP and core Kubernetes rules", func() {
+			kn := testKubernaut()
+			roles := ClusterRoles(kn)
+			var investigator *rbacv1.ClusterRole
+			for _, r := range roles {
+				if r.Name == kn.Namespace+"-kubernaut-agent-investigator" {
+					investigator = r
+					break
+				}
+			}
+			Expect(investigator).NotTo(BeNil(), "kubernaut-agent-investigator ClusterRole not found")
+
+			wantGroups := []string{
+				"operators.coreos.com",
+				"packages.operators.coreos.com",
+				"route.openshift.io",
+				"apps.openshift.io",
+				"security.openshift.io",
+				"image.openshift.io",
+				"build.openshift.io",
+				"machine.openshift.io",
+				"machineconfiguration.openshift.io",
+				"quota.openshift.io",
+				"network.operator.openshift.io",
+				"rbac.authorization.k8s.io",
+				"admissionregistration.k8s.io",
+				"apiextensions.k8s.io",
+				"scheduling.k8s.io",
+			}
+			foundGroups := make(map[string]bool)
+			for _, rule := range investigator.Rules {
+				for _, g := range rule.APIGroups {
+					foundGroups[g] = true
+				}
+			}
+			for _, g := range wantGroups {
+				Expect(foundGroups[g]).To(BeTrue(), "kubernaut-agent-investigator missing API group %q", g)
+			}
+		})
+	})
+
+	Describe("Workflow runner", func() {
+		It("has mesh and GitOps rules", func() {
+			kn := testKubernaut()
+			roles := ClusterRoles(kn)
+			var runner *rbacv1.ClusterRole
+			for _, r := range roles {
+				if r.Name == kn.Namespace+"-workflow-runner" {
+					runner = r
+					break
+				}
+			}
+			Expect(runner).NotTo(BeNil(), "workflow-runner ClusterRole not found")
+
+			wantGroups := []string{
+				"argoproj.io",
+				"cert-manager.io",
+				"policy.linkerd.io",
+				"security.istio.io",
+				"networking.istio.io",
+			}
+			foundGroups := make(map[string]bool)
+			for _, rule := range runner.Rules {
+				for _, g := range rule.APIGroups {
+					foundGroups[g] = true
+				}
+			}
+			for _, g := range wantGroups {
+				Expect(foundGroups[g]).To(BeTrue(), "workflow-runner missing API group %q", g)
+			}
+		})
+	})
+
+	Describe("Data storage client", func() {
+		It("has expanded verbs", func() {
+			kn := testKubernaut()
+			roles := ClusterRoles(kn)
+			var dsClient *rbacv1.ClusterRole
+			for _, r := range roles {
+				if r.Name == kn.Namespace+"-data-storage-client" {
+					dsClient = r
+					break
+				}
+			}
+			Expect(dsClient).NotTo(BeNil(), "data-storage-client ClusterRole not found")
+			Expect(len(dsClient.Rules)).NotTo(BeZero(), "data-storage-client has no rules")
+			rule := dsClient.Rules[0]
+			wantVerbs := []string{"create", "get", "list", "update", "delete"}
+			verbs := make(map[string]bool)
+			for _, v := range rule.Verbs {
+				verbs[v] = true
+			}
+			for _, v := range wantVerbs {
+				Expect(verbs[v]).To(BeTrue(), "data-storage-client missing verb %q", v)
+			}
+		})
+	})
+})
+
+var _ = Describe("ClusterRoleBindings", func() {
+	It("restricts subject namespaces", func() {
+		kn := testKubernaut()
+		crbs := ClusterRoleBindings(kn)
+
+		allowedNamespaces := map[string]bool{
+			kn.Namespace:             true,
+			DefaultWorkflowNamespace: true,
+			OCPMonitoringNamespace:   true,
+		}
+
+		for _, crb := range crbs {
+			Expect(crb.Subjects).NotTo(BeEmpty(), "CRB %q has no subjects", crb.Name)
+			for _, subj := range crb.Subjects {
+				Expect(allowedNamespaces[subj.Namespace]).To(BeTrue(),
+					"CRB %q subject %q has namespace %q, want one of %v",
 					crb.Name, subj.Name, subj.Namespace, allowedNamespaces)
 			}
 		}
-	}
-}
-
-func TestClusterRoleBindings_WorkflowRunnerBinding(t *testing.T) {
-	kn := testKubernaut()
-	crbs := ClusterRoleBindings(kn)
-	ns := kn.Namespace
-
-	wantName := ns + "-workflow-runner-binding"
-	wantRef := ns + "-workflow-runner"
-
-	found := false
-	for _, crb := range crbs {
-		if crb.Name == wantName {
-			found = true
-			if crb.RoleRef.Name != wantRef {
-				t.Errorf("workflow-runner CRB roleRef = %q, want %q", crb.RoleRef.Name, wantRef)
-			}
-			if len(crb.Subjects) == 0 {
-				t.Fatal("workflow-runner CRB has no subjects")
-			}
-			if crb.Subjects[0].Name != testWorkflowRunnerSAName {
-				t.Errorf("workflow-runner CRB subject = %q, want %q", crb.Subjects[0].Name, testWorkflowRunnerSAName)
-			}
-			if crb.Subjects[0].Namespace != DefaultWorkflowNamespace {
-				t.Errorf("workflow-runner CRB subject namespace = %q, want %q", crb.Subjects[0].Namespace, DefaultWorkflowNamespace)
-			}
-		}
-	}
-	if !found {
-		t.Errorf("ClusterRoleBindings() should include %q", wantName)
-	}
-}
-
-func TestDataStorageClientRoleBindings_Count10(t *testing.T) {
-	kn := testKubernaut()
-	rbs := DataStorageClientRoleBindings(kn)
-	if len(rbs) != 10 {
-		t.Errorf("DataStorageClientRoleBindings() should return 10, got %d", len(rbs))
-	}
-}
-
-func TestDataStorageClientRoleBindings_AllRefClusterRole(t *testing.T) {
-	kn := testKubernaut()
-	rbs := DataStorageClientRoleBindings(kn)
-	wantRef := kn.Namespace + "-data-storage-client"
-	for _, rb := range rbs {
-		if rb.RoleRef.Name != wantRef {
-			t.Errorf("RoleBinding %q should reference %q, got %q", rb.Name, wantRef, rb.RoleRef.Name)
-		}
-		if rb.RoleRef.Kind != testClusterRoleKind {
-			t.Errorf("RoleBinding %q should reference kind ClusterRole, got %q", rb.Name, rb.RoleRef.Kind)
-		}
-	}
-}
-
-func TestNamespaceRoles_AllHaveSecretsConfigmapsAccess(t *testing.T) {
-	kn := testKubernaut()
-	roles := NamespaceRoles(kn)
-
-	if len(roles) != 10 {
-		t.Errorf("NamespaceRoles() should return 10, got %d", len(roles))
-	}
-
-	for _, role := range roles {
-		if len(role.Rules) != 1 {
-			t.Errorf("Role %q should have exactly 1 rule, got %d", role.Name, len(role.Rules))
-			continue
-		}
-		rule := role.Rules[0]
-		hasConfigmaps := false
-		hasSecrets := false
-		for _, r := range rule.Resources {
-			if r == "configmaps" {
-				hasConfigmaps = true
-			}
-			if r == "secrets" {
-				hasSecrets = true
-			}
-		}
-		if !hasConfigmaps || !hasSecrets {
-			t.Errorf("Role %q should grant configmaps+secrets access", role.Name)
-		}
-	}
-}
-
-func TestNamespaceRoleBindings_MatchRoles(t *testing.T) {
-	kn := testKubernaut()
-	roles := NamespaceRoles(kn)
-	rbs := NamespaceRoleBindings(kn)
-
-	if len(rbs) != len(roles) {
-		t.Errorf("NamespaceRoleBindings count %d != NamespaceRoles count %d", len(rbs), len(roles))
-	}
-
-	roleNames := make(map[string]bool)
-	for _, r := range roles {
-		roleNames[r.Name] = true
-	}
-	for _, rb := range rbs {
-		if !roleNames[rb.RoleRef.Name] {
-			t.Errorf("RoleBinding %q references non-existent role %q", rb.Name, rb.RoleRef.Name)
-		}
-	}
-}
-
-func TestWorkflowNamespaceRBAC_UsesDefaultNamespace(t *testing.T) {
-	kn := testKubernaut()
-	roles, rbs := WorkflowNamespaceRBAC(kn)
-
-	for _, r := range roles {
-		if r.Namespace != DefaultWorkflowNamespace {
-			t.Errorf("workflow Role %q should be in kubernaut-workflows, got %q", r.Name, r.Namespace)
-		}
-	}
-	for _, rb := range rbs {
-		if rb.Namespace != DefaultWorkflowNamespace {
-			t.Errorf("workflow RoleBinding %q should be in kubernaut-workflows, got %q", rb.Name, rb.Namespace)
-		}
-	}
-}
-
-func TestWorkflowNamespaceRBAC_UsesCustomNamespace(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.WorkflowExecution.WorkflowNamespace = testCustomWorkflowNS
-	roles, rbs := WorkflowNamespaceRBAC(kn)
-
-	for _, r := range roles {
-		if r.Namespace != testCustomWorkflowNS {
-			t.Errorf("workflow Role %q should be in my-wf-ns, got %q", r.Name, r.Namespace)
-		}
-	}
-	for _, rb := range rbs {
-		if rb.Namespace != testCustomWorkflowNS {
-			t.Errorf("workflow RoleBinding %q should be in my-wf-ns, got %q", rb.Name, rb.Namespace)
-		}
-	}
-}
-
-func TestAnsibleRBAC_AwxJobsPermission(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.Ansible.Enabled = true
-	ns := kn.Namespace
-	cr, crb := AnsibleRBAC(kn)
-
-	wantCR := ns + "-workflowexecution-awx"
-	if cr.Name != wantCR {
-		t.Errorf("AWX ClusterRole name = %q, want %q", cr.Name, wantCR)
-	}
-
-	found := false
-	for _, rule := range cr.Rules {
-		for _, res := range rule.Resources {
-			if res == "awxjobs" {
-				found = true
-			}
-		}
-	}
-	if !found {
-		t.Error("AWX ClusterRole should grant access to awxjobs resources")
-	}
-
-	if crb.RoleRef.Name != wantCR {
-		t.Errorf("AWX CRB roleRef = %q, want %q", crb.RoleRef.Name, wantCR)
-	}
-}
-
-func TestClusterRoleBindings_MonitoringCRBs(t *testing.T) {
-	kn := testKubernaut()
-	crbs := ClusterRoleBindings(kn)
-	ns := kn.Namespace
-
-	crbMap := make(map[string]*rbacv1.ClusterRoleBinding, len(crbs))
-	for _, crb := range crbs {
-		crbMap[crb.Name] = crb
-	}
-
-	t.Run("cluster-monitoring-view for EM", func(t *testing.T) {
-		crb, ok := crbMap[ns+"-effectivenessmonitor-monitoring-view"]
-		if !ok {
-			t.Fatalf("missing %s-effectivenessmonitor-monitoring-view CRB", ns)
-		}
-		if crb.RoleRef.Name != "cluster-monitoring-view" {
-			t.Errorf("roleRef = %q, want %q", crb.RoleRef.Name, "cluster-monitoring-view")
-		}
 	})
 
-	t.Run("cluster-monitoring-view for KA", func(t *testing.T) {
-		crb, ok := crbMap[ns+"-kubernaut-agent-monitoring-view"]
-		if !ok {
-			t.Fatalf("missing %s-kubernaut-agent-monitoring-view CRB", ns)
-		}
-		if crb.RoleRef.Name != "cluster-monitoring-view" {
-			t.Errorf("roleRef = %q, want %q", crb.RoleRef.Name, "cluster-monitoring-view")
-		}
-	})
+	It("binds workflow runner to the workflow namespace", func() {
+		kn := testKubernaut()
+		crbs := ClusterRoleBindings(kn)
+		ns := kn.Namespace
 
-	t.Run("alertmanager signal source binds OCP SA", func(t *testing.T) {
-		crb, ok := crbMap[ns+"-alertmanager-gateway-signal-source"]
-		if !ok {
-			t.Fatalf("missing %s-alertmanager-gateway-signal-source CRB", ns)
-		}
-		if crb.RoleRef.Name != ns+"-gateway-signal-source" {
-			t.Errorf("roleRef = %q, want %q", crb.RoleRef.Name, ns+"-gateway-signal-source")
-		}
-		if len(crb.Subjects) == 0 {
-			t.Fatal("CRB has no subjects")
-		}
-		subj := crb.Subjects[0]
-		if subj.Name != OCPAlertManagerSAName {
-			t.Errorf("subject name = %q, want %q", subj.Name, OCPAlertManagerSAName)
-		}
-		if subj.Namespace != OCPMonitoringNamespace {
-			t.Errorf("subject namespace = %q, want %q", subj.Namespace, OCPMonitoringNamespace)
-		}
-	})
-}
+		wantName := ns + "-workflow-runner-binding"
+		wantRef := ns + "-workflow-runner"
 
-func TestClusterRoleBindings_MonitoringDisabled_NoMonitoringCRBs(t *testing.T) {
-	kn := testKubernaut()
-	disabled := false
-	kn.Spec.Monitoring.Enabled = &disabled
-	ns := kn.Namespace
-
-	crbs := ClusterRoleBindings(kn)
-	monitoringNames := map[string]bool{
-		ns + "-effectivenessmonitor-alertmanager-view-binding": true,
-		ns + "-effectivenessmonitor-monitoring-view":           true,
-		ns + "-kubernaut-agent-monitoring-view":                true,
-		ns + "-alertmanager-gateway-signal-source":             true,
-	}
-
-	for _, crb := range crbs {
-		if monitoringNames[crb.Name] {
-			t.Errorf("monitoring CRB %q should not exist when monitoring is disabled", crb.Name)
-		}
-	}
-}
-
-func TestKubernautAgentClientRoleBinding_GrantsAIAnalysisAccess(t *testing.T) {
-	kn := testKubernaut()
-	rb := KubernautAgentClientRoleBinding(kn)
-
-	if rb.Name != "kubernaut-agent-client-aianalysis" {
-		t.Errorf("Name = %q, want %q", rb.Name, "kubernaut-agent-client-aianalysis")
-	}
-	if rb.Namespace != kn.Namespace {
-		t.Errorf("Namespace = %q, want %q", rb.Namespace, kn.Namespace)
-	}
-	wantRoleRef := kn.Namespace + "-kubernaut-agent-client"
-	if rb.RoleRef.Name != wantRoleRef {
-		t.Errorf("RoleRef.Name = %q, want %q", rb.RoleRef.Name, wantRoleRef)
-	}
-	if rb.RoleRef.Kind != testClusterRoleKind {
-		t.Errorf("RoleRef.Kind = %q, want ClusterRole", rb.RoleRef.Kind)
-	}
-	if len(rb.Subjects) == 0 {
-		t.Fatal("RoleBinding has no subjects")
-	}
-	subj := rb.Subjects[0]
-	if subj.Name != ServiceAccountName(ComponentAIAnalysis) {
-		t.Errorf("Subject.Name = %q, want %q", subj.Name, ServiceAccountName(ComponentAIAnalysis))
-	}
-	if subj.Namespace != kn.Namespace {
-		t.Errorf("Subject.Namespace = %q, want %q", subj.Namespace, kn.Namespace)
-	}
-}
-
-func TestMonitoringCRBNames_ReturnsAll4(t *testing.T) {
-	kn := testKubernaut()
-	names := MonitoringCRBNames(kn)
-	if len(names) != 4 {
-		t.Fatalf("MonitoringCRBNames() count = %d, want 4", len(names))
-	}
-	ns := kn.Namespace
-	for _, name := range names {
-		if len(name) <= len(ns) || name[:len(ns)] != ns {
-			t.Errorf("MonitoringCRBNames entry %q should be namespace-prefixed with %q", name, ns)
-		}
-	}
-}
-
-func TestMonitoringClusterRoleNames_ReturnsAll2(t *testing.T) {
-	kn := testKubernaut()
-	names := MonitoringClusterRoleNames(kn)
-	if len(names) != 2 {
-		t.Fatalf("MonitoringClusterRoleNames() count = %d, want 2", len(names))
-	}
-	ns := kn.Namespace
-	for _, name := range names {
-		if len(name) <= len(ns) || name[:len(ns)] != ns {
-			t.Errorf("MonitoringClusterRoleNames entry %q should be namespace-prefixed with %q", name, ns)
-		}
-	}
-}
-
-func TestClusterRoles_HaveCommonLabels(t *testing.T) {
-	kn := testKubernaut()
-	for _, cr := range ClusterRoles(kn) {
-		if cr.Labels["app.kubernetes.io/managed-by"] != testOperatorManagedByValue {
-			t.Errorf("ClusterRole %q missing managed-by label", cr.Name)
-		}
-	}
-}
-
-func TestGatewayClusterRole_HasPVCAndHPARules(t *testing.T) {
-	kn := testKubernaut()
-	roles := ClusterRoles(kn)
-	var gw *rbacv1.ClusterRole
-	for _, r := range roles {
-		if r.Name == kn.Namespace+"-gateway-role" {
-			gw = r
-			break
-		}
-	}
-	if gw == nil {
-		t.Fatal("gateway-role ClusterRole not found")
-	}
-
-	type resourceCheck struct {
-		apiGroup string
-		resource string
-	}
-	want := []resourceCheck{
-		{"", "persistentvolumeclaims"},
-		{"autoscaling", "horizontalpodautoscalers"},
-	}
-
-	for _, w := range want {
 		found := false
-		for _, rule := range gw.Rules {
-			for _, g := range rule.APIGroups {
-				if g != w.apiGroup {
-					continue
+		for _, crb := range crbs {
+			if crb.Name == wantName {
+				found = true
+				Expect(crb.RoleRef.Name).To(Equal(wantRef),
+					"workflow-runner CRB roleRef = %q, want %q", crb.RoleRef.Name, wantRef)
+				Expect(crb.Subjects).NotTo(BeEmpty(), "workflow-runner CRB has no subjects")
+				Expect(crb.Subjects[0].Name).To(Equal(testWorkflowRunnerSAName),
+					"workflow-runner CRB subject = %q, want %q", crb.Subjects[0].Name, testWorkflowRunnerSAName)
+				Expect(crb.Subjects[0].Namespace).To(Equal(DefaultWorkflowNamespace),
+					"workflow-runner CRB subject namespace = %q, want %q", crb.Subjects[0].Namespace, DefaultWorkflowNamespace)
+			}
+		}
+		Expect(found).To(BeTrue(), "ClusterRoleBindings() should include %q", wantName)
+	})
+
+	Context("when monitoring is enabled", func() {
+		var crbMap map[string]*rbacv1.ClusterRoleBinding
+		var ns string
+
+		BeforeEach(func() {
+			kn := testKubernaut()
+			crbs := ClusterRoleBindings(kn)
+			ns = kn.Namespace
+			crbMap = make(map[string]*rbacv1.ClusterRoleBinding, len(crbs))
+			for _, crb := range crbs {
+				crbMap[crb.Name] = crb
+			}
+		})
+
+		It("binds cluster-monitoring-view for effectiveness monitor", func() {
+			crb, ok := crbMap[ns+"-effectivenessmonitor-monitoring-view"]
+			Expect(ok).To(BeTrue(), "missing %s-effectivenessmonitor-monitoring-view CRB", ns)
+			Expect(crb.RoleRef.Name).To(Equal("cluster-monitoring-view"),
+				"roleRef = %q, want %q", crb.RoleRef.Name, "cluster-monitoring-view")
+		})
+
+		It("binds cluster-monitoring-view for kubernaut agent", func() {
+			crb, ok := crbMap[ns+"-kubernaut-agent-monitoring-view"]
+			Expect(ok).To(BeTrue(), "missing %s-kubernaut-agent-monitoring-view CRB", ns)
+			Expect(crb.RoleRef.Name).To(Equal("cluster-monitoring-view"),
+				"roleRef = %q, want %q", crb.RoleRef.Name, "cluster-monitoring-view")
+		})
+
+		It("binds alertmanager gateway signal source to the OCP SA", func() {
+			crb, ok := crbMap[ns+"-alertmanager-gateway-signal-source"]
+			Expect(ok).To(BeTrue(), "missing %s-alertmanager-gateway-signal-source CRB", ns)
+			Expect(crb.RoleRef.Name).To(Equal(ns+"-gateway-signal-source"),
+				"roleRef = %q, want %q", crb.RoleRef.Name, ns+"-gateway-signal-source")
+			Expect(crb.Subjects).NotTo(BeEmpty(), "CRB has no subjects")
+			subj := crb.Subjects[0]
+			Expect(subj.Name).To(Equal(OCPAlertManagerSAName),
+				"subject name = %q, want %q", subj.Name, OCPAlertManagerSAName)
+			Expect(subj.Namespace).To(Equal(OCPMonitoringNamespace),
+				"subject namespace = %q, want %q", subj.Namespace, OCPMonitoringNamespace)
+		})
+	})
+
+	It("omits monitoring CRBs when monitoring is disabled", func() {
+		kn := testKubernaut()
+		disabled := false
+		kn.Spec.Monitoring.Enabled = &disabled
+		ns := kn.Namespace
+
+		crbs := ClusterRoleBindings(kn)
+		monitoringNames := map[string]bool{
+			ns + "-effectivenessmonitor-alertmanager-view-binding": true,
+			ns + "-effectivenessmonitor-monitoring-view":           true,
+			ns + "-kubernaut-agent-monitoring-view":                true,
+			ns + "-alertmanager-gateway-signal-source":             true,
+		}
+
+		for _, crb := range crbs {
+			Expect(monitoringNames[crb.Name]).To(BeFalse(), "monitoring CRB %q should not exist when monitoring is disabled", crb.Name)
+		}
+	})
+})
+
+var _ = Describe("DataStorageClientRoleBindings", func() {
+	It("returns ten bindings", func() {
+		kn := testKubernaut()
+		rbs := DataStorageClientRoleBindings(kn)
+		Expect(len(rbs)).To(Equal(10), "DataStorageClientRoleBindings() should return 10, got %d", len(rbs))
+	})
+
+	It("all reference the data-storage-client ClusterRole", func() {
+		kn := testKubernaut()
+		rbs := DataStorageClientRoleBindings(kn)
+		wantRef := kn.Namespace + "-data-storage-client"
+		for _, rb := range rbs {
+			Expect(rb.RoleRef.Name).To(Equal(wantRef),
+				"RoleBinding %q should reference %q, got %q", rb.Name, wantRef, rb.RoleRef.Name)
+			Expect(rb.RoleRef.Kind).To(Equal(testClusterRoleKind),
+				"RoleBinding %q should reference kind ClusterRole, got %q", rb.Name, rb.RoleRef.Kind)
+		}
+	})
+})
+
+var _ = Describe("NamespaceRoles", func() {
+	It("all grant secrets and configmaps access", func() {
+		kn := testKubernaut()
+		roles := NamespaceRoles(kn)
+
+		Expect(len(roles)).To(Equal(10), "NamespaceRoles() should return 10, got %d", len(roles))
+
+		for _, role := range roles {
+			Expect(role.Rules).To(HaveLen(1), "Role %q should have exactly 1 rule, got %d", role.Name, len(role.Rules))
+			rule := role.Rules[0]
+			hasConfigmaps := false
+			hasSecrets := false
+			for _, r := range rule.Resources {
+				if r == "configmaps" {
+					hasConfigmaps = true
 				}
-				for _, r := range rule.Resources {
-					if r == w.resource {
-						found = true
-					}
+				if r == "secrets" {
+					hasSecrets = true
+				}
+			}
+			Expect(hasConfigmaps && hasSecrets).To(BeTrue(), "Role %q should grant configmaps+secrets access", role.Name)
+		}
+	})
+})
+
+var _ = Describe("NamespaceRoleBindings", func() {
+	It("match NamespaceRoles by name", func() {
+		kn := testKubernaut()
+		roles := NamespaceRoles(kn)
+		rbs := NamespaceRoleBindings(kn)
+
+		Expect(len(rbs)).To(Equal(len(roles)),
+			"NamespaceRoleBindings count %d != NamespaceRoles count %d", len(rbs), len(roles))
+
+		roleNames := make(map[string]bool)
+		for _, r := range roles {
+			roleNames[r.Name] = true
+		}
+		for _, rb := range rbs {
+			Expect(roleNames[rb.RoleRef.Name]).To(BeTrue(),
+				"RoleBinding %q references non-existent role %q", rb.Name, rb.RoleRef.Name)
+		}
+	})
+})
+
+var _ = Describe("WorkflowNamespaceRBAC", func() {
+	It("uses the default workflow namespace", func() {
+		kn := testKubernaut()
+		roles, rbs := WorkflowNamespaceRBAC(kn)
+
+		for _, r := range roles {
+			Expect(r.Namespace).To(Equal(DefaultWorkflowNamespace),
+				"workflow Role %q should be in kubernaut-workflows, got %q", r.Name, r.Namespace)
+		}
+		for _, rb := range rbs {
+			Expect(rb.Namespace).To(Equal(DefaultWorkflowNamespace),
+				"workflow RoleBinding %q should be in kubernaut-workflows, got %q", rb.Name, rb.Namespace)
+		}
+	})
+
+	It("uses a custom workflow namespace when set", func() {
+		kn := testKubernaut()
+		kn.Spec.WorkflowExecution.WorkflowNamespace = testCustomWorkflowNS
+		roles, rbs := WorkflowNamespaceRBAC(kn)
+
+		for _, r := range roles {
+			Expect(r.Namespace).To(Equal(testCustomWorkflowNS),
+				"workflow Role %q should be in my-wf-ns, got %q", r.Name, r.Namespace)
+		}
+		for _, rb := range rbs {
+			Expect(rb.Namespace).To(Equal(testCustomWorkflowNS),
+				"workflow RoleBinding %q should be in my-wf-ns, got %q", rb.Name, rb.Namespace)
+		}
+	})
+})
+
+var _ = Describe("AnsibleRBAC", func() {
+	It("grants AWX jobs permission", func() {
+		kn := testKubernaut()
+		kn.Spec.Ansible.Enabled = true
+		ns := kn.Namespace
+		cr, crb := AnsibleRBAC(kn)
+
+		wantCR := ns + "-workflowexecution-awx"
+		Expect(cr.Name).To(Equal(wantCR), "AWX ClusterRole name = %q, want %q", cr.Name, wantCR)
+
+		found := false
+		for _, rule := range cr.Rules {
+			for _, res := range rule.Resources {
+				if res == "awxjobs" {
+					found = true
 				}
 			}
 		}
-		if !found {
-			t.Errorf("gateway-role missing %s/%s", w.apiGroup, w.resource)
+		Expect(found).To(BeTrue(), "AWX ClusterRole should grant access to awxjobs resources")
+
+		Expect(crb.RoleRef.Name).To(Equal(wantCR), "AWX CRB roleRef = %q, want %q", crb.RoleRef.Name, wantCR)
+	})
+})
+
+var _ = Describe("KubernautAgentClientRoleBinding", func() {
+	It("grants AI analysis access", func() {
+		kn := testKubernaut()
+		rb := KubernautAgentClientRoleBinding(kn)
+
+		Expect(rb.Name).To(Equal("kubernaut-agent-client-aianalysis"), "Name = %q, want %q", rb.Name, "kubernaut-agent-client-aianalysis")
+		Expect(rb.Namespace).To(Equal(kn.Namespace), "Namespace = %q, want %q", rb.Namespace, kn.Namespace)
+		wantRoleRef := kn.Namespace + "-kubernaut-agent-client"
+		Expect(rb.RoleRef.Name).To(Equal(wantRoleRef), "RoleRef.Name = %q, want %q", rb.RoleRef.Name, wantRoleRef)
+		Expect(rb.RoleRef.Kind).To(Equal(testClusterRoleKind), "RoleRef.Kind = %q, want ClusterRole", rb.RoleRef.Kind)
+		Expect(rb.Subjects).NotTo(BeEmpty(), "RoleBinding has no subjects")
+		subj := rb.Subjects[0]
+		Expect(subj.Name).To(Equal(ServiceAccountName(ComponentAIAnalysis)),
+			"Subject.Name = %q, want %q", subj.Name, ServiceAccountName(ComponentAIAnalysis))
+		Expect(subj.Namespace).To(Equal(kn.Namespace),
+			"Subject.Namespace = %q, want %q", subj.Namespace, kn.Namespace)
+	})
+})
+
+var _ = Describe("MonitoringCRBNames", func() {
+	It("returns all four namespace-prefixed names", func() {
+		kn := testKubernaut()
+		names := MonitoringCRBNames(kn)
+		Expect(names).To(HaveLen(4), "MonitoringCRBNames() count = %d, want 4", len(names))
+		ns := kn.Namespace
+		for _, name := range names {
+			Expect(len(name) > len(ns) && name[:len(ns)] == ns).To(BeTrue(),
+				"MonitoringCRBNames entry %q should be namespace-prefixed with %q", name, ns)
 		}
-	}
-}
+	})
+})
 
-func TestKAInvestigator_HasServiceMeshAndGitOpsRules(t *testing.T) {
-	kn := testKubernaut()
-	roles := ClusterRoles(kn)
-	var investigator *rbacv1.ClusterRole
-	for _, r := range roles {
-		if r.Name == kn.Namespace+"-kubernaut-agent-investigator" {
-			investigator = r
-			break
+var _ = Describe("MonitoringClusterRoleNames", func() {
+	It("returns two namespace-prefixed names", func() {
+		kn := testKubernaut()
+		names := MonitoringClusterRoleNames(kn)
+		Expect(names).To(HaveLen(2), "MonitoringClusterRoleNames() count = %d, want 2", len(names))
+		ns := kn.Namespace
+		for _, name := range names {
+			Expect(len(name) > len(ns) && name[:len(ns)] == ns).To(BeTrue(),
+				"MonitoringClusterRoleNames entry %q should be namespace-prefixed with %q", name, ns)
 		}
-	}
-	if investigator == nil {
-		t.Fatal("kubernaut-agent-investigator ClusterRole not found")
-	}
+	})
+})
 
-	wantGroups := []string{
-		"cert-manager.io",
-		"argoproj.io",
-		"policy.linkerd.io",
-		"security.istio.io",
-		"networking.istio.io",
-	}
-	foundGroups := make(map[string]bool)
-	for _, rule := range investigator.Rules {
-		for _, g := range rule.APIGroups {
-			foundGroups[g] = true
-		}
-	}
-	for _, g := range wantGroups {
-		if !foundGroups[g] {
-			t.Errorf("kubernaut-agent-investigator missing API group %q", g)
-		}
-	}
-}
+var _ = Describe("AdditionalAgentCRB", func() {
+	Describe("AdditionalAgentCRBName", func() {
+		It("returns the short form", func() {
+			kn := testKubernaut()
+			name := AdditionalAgentCRBName(kn, "my-kafka-reader")
+			want := "kubernaut-system-kubernaut-agent-ext-my-kafka-reader"
+			Expect(name).To(Equal(want), "got %q, want %q", name, want)
+		})
 
-func TestKAInvestigator_HasOCPAndCoreK8sRules(t *testing.T) {
-	kn := testKubernaut()
-	roles := ClusterRoles(kn)
-	var investigator *rbacv1.ClusterRole
-	for _, r := range roles {
-		if r.Name == kn.Namespace+"-kubernaut-agent-investigator" {
-			investigator = r
-			break
-		}
-	}
-	if investigator == nil {
-		t.Fatal("kubernaut-agent-investigator ClusterRole not found")
-	}
+		It("does not truncate when exactly at the limit", func() {
+			kn := testKubernaut()
+			prefix := kn.Namespace + "-kubernaut-agent-ext-"
+			roleName := strings.Repeat("a", maxK8sNameLen-len(prefix))
+			name := AdditionalAgentCRBName(kn, roleName)
+			Expect(len(name)).To(Equal(maxK8sNameLen), "expected name length %d, got %d", maxK8sNameLen, len(name))
+			Expect(name).To(Equal(prefix+roleName), "name should not be truncated when exactly at limit")
+		})
 
-	wantGroups := []string{
-		"operators.coreos.com",
-		"packages.operators.coreos.com",
-		"route.openshift.io",
-		"apps.openshift.io",
-		"security.openshift.io",
-		"image.openshift.io",
-		"build.openshift.io",
-		"machine.openshift.io",
-		"machineconfiguration.openshift.io",
-		"quota.openshift.io",
-		"network.operator.openshift.io",
-		"rbac.authorization.k8s.io",
-		"admissionregistration.k8s.io",
-		"apiextensions.k8s.io",
-		"scheduling.k8s.io",
-	}
-	foundGroups := make(map[string]bool)
-	for _, rule := range investigator.Rules {
-		for _, g := range rule.APIGroups {
-			foundGroups[g] = true
-		}
-	}
-	for _, g := range wantGroups {
-		if !foundGroups[g] {
-			t.Errorf("kubernaut-agent-investigator missing API group %q", g)
-		}
-	}
-}
+		It("truncates long names", func() {
+			kn := testKubernaut()
+			prefix := kn.Namespace + "-kubernaut-agent-ext-"
+			roleName := strings.Repeat("x", maxK8sNameLen-len(prefix)+50)
+			name := AdditionalAgentCRBName(kn, roleName)
 
-func TestWorkflowRunner_HasMeshAndGitOpsRules(t *testing.T) {
-	kn := testKubernaut()
-	roles := ClusterRoles(kn)
-	var runner *rbacv1.ClusterRole
-	for _, r := range roles {
-		if r.Name == kn.Namespace+"-workflow-runner" {
-			runner = r
-			break
-		}
-	}
-	if runner == nil {
-		t.Fatal("workflow-runner ClusterRole not found")
-	}
+			Expect(len(name)).To(BeNumerically("<=", maxK8sNameLen), "name exceeds 253 chars: len=%d", len(name))
+			Expect(strings.HasPrefix(name, prefix)).To(BeTrue(), "name should start with %q, got %q", prefix, name)
+		})
 
-	wantGroups := []string{
-		"argoproj.io",
-		"cert-manager.io",
-		"policy.linkerd.io",
-		"security.istio.io",
-		"networking.istio.io",
-	}
-	foundGroups := make(map[string]bool)
-	for _, rule := range runner.Rules {
-		for _, g := range rule.APIGroups {
-			foundGroups[g] = true
-		}
-	}
-	for _, g := range wantGroups {
-		if !foundGroups[g] {
-			t.Errorf("workflow-runner missing API group %q", g)
-		}
-	}
-}
+		It("maps different long names to different hashes", func() {
+			kn := testKubernaut()
+			prefix := kn.Namespace + "-kubernaut-agent-ext-"
+			base := strings.Repeat("a", maxK8sNameLen-len(prefix)+10)
 
-func TestDataStorageClient_HasExpandedVerbs(t *testing.T) {
-	kn := testKubernaut()
-	roles := ClusterRoles(kn)
-	var dsClient *rbacv1.ClusterRole
-	for _, r := range roles {
-		if r.Name == kn.Namespace+"-data-storage-client" {
-			dsClient = r
-			break
-		}
-	}
-	if dsClient == nil {
-		t.Fatal("data-storage-client ClusterRole not found")
-	}
-	if len(dsClient.Rules) == 0 {
-		t.Fatal("data-storage-client has no rules")
-	}
-	rule := dsClient.Rules[0]
-	wantVerbs := []string{"create", "get", "list", "update", "delete"}
-	verbs := make(map[string]bool)
-	for _, v := range rule.Verbs {
-		verbs[v] = true
-	}
-	for _, v := range wantVerbs {
-		if !verbs[v] {
-			t.Errorf("data-storage-client missing verb %q", v)
-		}
-	}
-}
+			name1 := AdditionalAgentCRBName(kn, base+"1")
+			name2 := AdditionalAgentCRBName(kn, base+"2")
+			Expect(name1).NotTo(Equal(name2), "different long role names should produce different CRB names")
+		})
 
-// --- Additional Agent RBAC tests ---
+		It("is stable for the same role name", func() {
+			kn := testKubernaut()
+			name1 := AdditionalAgentCRBName(kn, "role-a")
+			name2 := AdditionalAgentCRBName(kn, "role-b")
 
-func TestAdditionalAgentCRBName_Short(t *testing.T) {
-	kn := testKubernaut()
-	name := AdditionalAgentCRBName(kn, "my-kafka-reader")
-	want := "kubernaut-system-kubernaut-agent-ext-my-kafka-reader"
-	if name != want {
-		t.Errorf("got %q, want %q", name, want)
-	}
-}
+			name1Again := AdditionalAgentCRBName(kn, "role-a")
+			name2Again := AdditionalAgentCRBName(kn, "role-b")
 
-func TestAdditionalAgentCRBName_ExactlyAtLimit(t *testing.T) {
-	kn := testKubernaut()
-	prefix := kn.Namespace + "-kubernaut-agent-ext-"
-	roleName := strings.Repeat("a", maxK8sNameLen-len(prefix))
-	name := AdditionalAgentCRBName(kn, roleName)
-	if len(name) != maxK8sNameLen {
-		t.Errorf("expected name length %d, got %d", maxK8sNameLen, len(name))
-	}
-	if name != prefix+roleName {
-		t.Error("name should not be truncated when exactly at limit")
-	}
-}
+			Expect(name1 == name1Again && name2 == name2Again).To(BeTrue(),
+				"reordering should not change CRB names (names are per-role, not positional)")
+		})
+	})
 
-func TestAdditionalAgentCRBName_Truncation(t *testing.T) {
-	kn := testKubernaut()
-	prefix := kn.Namespace + "-kubernaut-agent-ext-"
-	roleName := strings.Repeat("x", maxK8sNameLen-len(prefix)+50)
-	name := AdditionalAgentCRBName(kn, roleName)
+	It("has the expected structure", func() {
+		kn := testKubernaut()
+		crName := "strimzi-kafka-reader"
+		crb := AdditionalAgentCRB(kn, crName)
 
-	if len(name) > maxK8sNameLen {
-		t.Errorf("name exceeds 253 chars: len=%d", len(name))
-	}
-	if !strings.HasPrefix(name, prefix) {
-		t.Errorf("name should start with %q, got %q", prefix, name)
-	}
-}
+		Expect(crb.RoleRef.Kind).To(Equal(testClusterRoleKind), "RoleRef.Kind = %q, want ClusterRole", crb.RoleRef.Kind)
+		Expect(crb.RoleRef.Name).To(Equal(crName), "RoleRef.Name = %q, want %q", crb.RoleRef.Name, crName)
+		Expect(crb.Subjects).To(HaveLen(1), "expected 1 subject, got %d", len(crb.Subjects))
+		Expect(crb.Subjects[0].Name).To(Equal(ServiceAccountName(ComponentKubernautAgent)),
+			"subject SA = %q, want %q", crb.Subjects[0].Name, ServiceAccountName(ComponentKubernautAgent))
+		Expect(crb.Subjects[0].Namespace).To(Equal(kn.Namespace),
+			"subject namespace = %q, want %q", crb.Subjects[0].Namespace, kn.Namespace)
+	})
 
-func TestAdditionalAgentCRBName_DifferentLongNamesProduceDifferentHashes(t *testing.T) {
-	kn := testKubernaut()
-	prefix := kn.Namespace + "-kubernaut-agent-ext-"
-	base := strings.Repeat("a", maxK8sNameLen-len(prefix)+10)
+	It("sets expected labels", func() {
+		kn := testKubernaut()
+		crb := AdditionalAgentCRB(kn, "test-role")
 
-	name1 := AdditionalAgentCRBName(kn, base+"1")
-	name2 := AdditionalAgentCRBName(kn, base+"2")
-	if name1 == name2 {
-		t.Error("different long role names should produce different CRB names")
-	}
-}
+		Expect(crb.Labels["app.kubernetes.io/managed-by"]).To(Equal(testOperatorManagedByValue), "missing managed-by label")
+		Expect(crb.Labels["app.kubernetes.io/instance"]).To(Equal(kn.Name), "missing instance label")
+		Expect(crb.Labels[LabelAdditionalAgentRBAC]).To(Equal(LabelValueTrue), "missing additional-agent-rbac label")
+	})
 
-func TestAdditionalAgentCRB_Structure(t *testing.T) {
-	kn := testKubernaut()
-	crName := "strimzi-kafka-reader"
-	crb := AdditionalAgentCRB(kn, crName)
-
-	if crb.RoleRef.Kind != testClusterRoleKind {
-		t.Errorf("RoleRef.Kind = %q, want ClusterRole", crb.RoleRef.Kind)
-	}
-	if crb.RoleRef.Name != crName {
-		t.Errorf("RoleRef.Name = %q, want %q", crb.RoleRef.Name, crName)
-	}
-	if len(crb.Subjects) != 1 {
-		t.Fatalf("expected 1 subject, got %d", len(crb.Subjects))
-	}
-	if crb.Subjects[0].Name != ServiceAccountName(ComponentKubernautAgent) {
-		t.Errorf("subject SA = %q, want %q", crb.Subjects[0].Name, ServiceAccountName(ComponentKubernautAgent))
-	}
-	if crb.Subjects[0].Namespace != kn.Namespace {
-		t.Errorf("subject namespace = %q, want %q", crb.Subjects[0].Namespace, kn.Namespace)
-	}
-}
-
-func TestAdditionalAgentCRB_Labels(t *testing.T) {
-	kn := testKubernaut()
-	crb := AdditionalAgentCRB(kn, "test-role")
-
-	if crb.Labels["app.kubernetes.io/managed-by"] != testOperatorManagedByValue {
-		t.Error("missing managed-by label")
-	}
-	if crb.Labels["app.kubernetes.io/instance"] != kn.Name {
-		t.Error("missing instance label")
-	}
-	if crb.Labels[LabelAdditionalAgentRBAC] != LabelValueTrue {
-		t.Error("missing additional-agent-rbac label")
-	}
-}
-
-func TestAdditionalAgentCRB_EmptyList(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.KubernautAgent.AdditionalClusterRoleBindings = nil
-	if len(kn.Spec.KubernautAgent.AdditionalClusterRoleBindings) != 0 {
-		t.Error("empty additional list should have length 0")
-	}
-}
-
-func TestAdditionalAgentCRB_ReorderProducesSameNames(t *testing.T) {
-	kn := testKubernaut()
-	name1 := AdditionalAgentCRBName(kn, "role-a")
-	name2 := AdditionalAgentCRBName(kn, "role-b")
-
-	name1Again := AdditionalAgentCRBName(kn, "role-a")
-	name2Again := AdditionalAgentCRBName(kn, "role-b")
-
-	if name1 != name1Again || name2 != name2Again {
-		t.Error("reordering should not change CRB names (names are per-role, not positional)")
-	}
-}
+	It("has no entries when the spec list is nil", func() {
+		kn := testKubernaut()
+		kn.Spec.KubernautAgent.AdditionalClusterRoleBindings = nil
+		Expect(kn.Spec.KubernautAgent.AdditionalClusterRoleBindings).To(HaveLen(0), "empty additional list should have length 0")
+	})
+})

--- a/internal/resources/serviceaccounts_test.go
+++ b/internal/resources/serviceaccounts_test.go
@@ -17,47 +17,40 @@ limitations under the License.
 package resources
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestServiceAccount_PerComponent(t *testing.T) {
-	kn := testKubernaut()
-	for _, component := range AllComponents() {
-		sa := ServiceAccount(kn, component)
-		wantName := ServiceAccountName(component)
-		if sa.Name != wantName {
-			t.Errorf("ServiceAccount(%q).Name = %q, want %q", component, sa.Name, wantName)
-		}
-		if sa.Namespace != kn.Namespace {
-			t.Errorf("ServiceAccount(%q).Namespace = %q, want %q", component, sa.Namespace, kn.Namespace)
-		}
-		if got := sa.Labels["app"]; got != component {
-			t.Errorf("ServiceAccount(%q).Labels[app] = %q, want %q", component, got, component)
-		}
-	}
-}
+var _ = Describe("ServiceAccount", func() {
+	Context("per component", func() {
+		It("names, namespaces, and labels each service account", func() {
+			kn := testKubernaut()
+			for _, component := range AllComponents() {
+				sa := ServiceAccount(kn, component)
+				wantName := ServiceAccountName(component)
+				Expect(sa.Name).To(Equal(wantName), "ServiceAccount(%q).Name = %q, want %q", component, sa.Name, wantName)
+				Expect(sa.Namespace).To(Equal(kn.Namespace), "ServiceAccount(%q).Namespace = %q, want %q", component, sa.Namespace, kn.Namespace)
+				Expect(sa.Labels["app"]).To(Equal(component), "ServiceAccount(%q).Labels[app] = %q, want %q", component, sa.Labels["app"], component)
+			}
+		})
+	})
 
-func TestWorkflowRunnerServiceAccount_DefaultNamespace(t *testing.T) {
-	kn := testKubernaut()
-	sa := WorkflowRunnerServiceAccount(kn)
+	Context("WorkflowRunnerServiceAccount", func() {
+		It("uses default workflow namespace", func() {
+			kn := testKubernaut()
+			sa := WorkflowRunnerServiceAccount(kn)
 
-	if sa.Name != "kubernaut-workflow-runner" {
-		t.Errorf("Name = %q, want %q", sa.Name, "kubernaut-workflow-runner")
-	}
-	if sa.Namespace != "kubernaut-workflows" {
-		t.Errorf("Namespace = %q, want %q", sa.Namespace, "kubernaut-workflows")
-	}
-}
+			Expect(sa.Name).To(Equal("kubernaut-workflow-runner"))
+			Expect(sa.Namespace).To(Equal("kubernaut-workflows"))
+		})
 
-func TestWorkflowRunnerServiceAccount_CustomNamespace(t *testing.T) {
-	kn := testKubernaut()
-	kn.Spec.WorkflowExecution.WorkflowNamespace = "custom-wf-ns"
-	sa := WorkflowRunnerServiceAccount(kn)
+		It("uses custom workflow namespace from spec", func() {
+			kn := testKubernaut()
+			kn.Spec.WorkflowExecution.WorkflowNamespace = "custom-wf-ns"
+			sa := WorkflowRunnerServiceAccount(kn)
 
-	if sa.Name != "kubernaut-workflow-runner" {
-		t.Errorf("Name = %q, want %q", sa.Name, "kubernaut-workflow-runner")
-	}
-	if sa.Namespace != "custom-wf-ns" {
-		t.Errorf("Namespace = %q, want %q", sa.Namespace, "custom-wf-ns")
-	}
-}
+			Expect(sa.Name).To(Equal("kubernaut-workflow-runner"))
+			Expect(sa.Namespace).To(Equal("custom-wf-ns"))
+		})
+	})
+})

--- a/internal/resources/services_test.go
+++ b/internal/resources/services_test.go
@@ -17,218 +17,201 @@ limitations under the License.
 package resources
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 const testAuthWebhookServiceName = "authwebhook-service"
 
-func TestServices_APIServiceCount(t *testing.T) {
-	kn := testKubernaut()
-	svcs := Services(kn)
-	// 4 API services + 1 authwebhook = 5
-	if len(svcs) != 5 {
-		t.Errorf("Services() should return 5, got %d", len(svcs))
-	}
-}
+var _ = Describe("Services", func() {
+	Context("Services()", func() {
+		It("returns 5 API services", func() {
+			kn := testKubernaut()
+			svcs := Services(kn)
+			Expect(len(svcs)).To(Equal(5))
+		})
 
-func TestServices_MetricsServiceCount(t *testing.T) {
-	kn := testKubernaut()
-	svcs := MetricsServices(kn)
-	if len(svcs) != 5 {
-		t.Errorf("MetricsServices() should return 5, got %d", len(svcs))
-	}
-}
-
-func TestServices_AllInCorrectNamespace(t *testing.T) {
-	kn := testKubernaut()
-	all := append(Services(kn), MetricsServices(kn)...)
-	for _, svc := range all {
-		if svc.Namespace != testSystemNamespace {
-			t.Errorf("Service %q namespace = %q, want %q", svc.Name, svc.Namespace, testSystemNamespace)
-		}
-	}
-}
-
-func TestServices_AuthWebhookOn443(t *testing.T) {
-	kn := testKubernaut()
-	for _, svc := range Services(kn) {
-		if svc.Name == testAuthWebhookServiceName {
-			if len(svc.Spec.Ports) == 0 || svc.Spec.Ports[0].Port != 443 {
-				t.Errorf("authwebhook-service port should be 443, got %v", svc.Spec.Ports)
+		It("places all services in the system namespace", func() {
+			kn := testKubernaut()
+			for _, svc := range Services(kn) {
+				Expect(svc.Namespace).To(Equal(testSystemNamespace), "Service %q namespace = %q, want %q", svc.Name, svc.Namespace, testSystemNamespace)
 			}
-			if svc.Annotations[OCPServingCertAnnotation] != "authwebhook-tls" {
-				t.Errorf("authwebhook-service should have serving-cert annotation, got %v", svc.Annotations)
-			}
-			return
-		}
-	}
-	t.Error("Services() should contain authwebhook-service")
-}
+		})
 
-func TestServices_APIServicesHaveHTTPPort(t *testing.T) {
-	kn := testKubernaut()
-	for _, svc := range Services(kn) {
-		if svc.Name == testAuthWebhookServiceName {
-			continue
-		}
-		found := false
-		for _, p := range svc.Spec.Ports {
-			if p.Port == 8080 {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Service %q should have port 8080", svc.Name)
-		}
-	}
-}
-
-func TestServices_ExpectedAPIServiceNames(t *testing.T) {
-	kn := testKubernaut()
-	svcs := Services(kn)
-	names := make(map[string]bool, len(svcs))
-	for _, svc := range svcs {
-		names[svc.Name] = true
-	}
-
-	expected := []string{
-		"gateway-service",
-		"data-storage-service",
-		"aianalysis-service",
-		"kubernaut-agent",
-		testAuthWebhookServiceName,
-	}
-	for _, name := range expected {
-		if !names[name] {
-			t.Errorf("Services() missing expected service %q", name)
-		}
-	}
-}
-
-func TestServices_ExpectedMetricsServiceNames(t *testing.T) {
-	kn := testKubernaut()
-	svcs := MetricsServices(kn)
-	names := make(map[string]bool, len(svcs))
-	for _, svc := range svcs {
-		names[svc.Name] = true
-	}
-
-	expected := []string{
-		"signalprocessing-controller-metrics",
-		"remediationorchestrator-controller",
-		"workflowexecution-controller-metrics",
-		"effectivenessmonitor-metrics",
-		"notification-metrics",
-	}
-	for _, name := range expected {
-		if !names[name] {
-			t.Errorf("MetricsServices() missing expected service %q", name)
-		}
-	}
-}
-
-func TestServices_SelectorsMatchComponents(t *testing.T) {
-	kn := testKubernaut()
-	all := append(Services(kn), MetricsServices(kn)...)
-
-	knownComponents := make(map[string]bool)
-	for _, c := range AllComponents() {
-		knownComponents[c] = true
-	}
-
-	for _, svc := range all {
-		app, ok := svc.Spec.Selector["app"]
-		if !ok {
-			t.Errorf("Service %q missing 'app' selector", svc.Name)
-			continue
-		}
-		if !knownComponents[app] {
-			t.Errorf("Service %q selector app=%q is not a known component", svc.Name, app)
-		}
-	}
-}
-
-func TestServices_GatewayMultiPort(t *testing.T) {
-	kn := testKubernaut()
-	for _, svc := range Services(kn) {
-		if svc.Name == "gateway-service" {
-			wantPorts := map[string]int32{"http": 8080, "health": 8081, "metrics": 9090}
-			gotPorts := make(map[string]int32)
-			for _, p := range svc.Spec.Ports {
-				gotPorts[p.Name] = p.Port
-			}
-			for name, port := range wantPorts {
-				if gotPorts[name] != port {
-					t.Errorf("gateway-service port %q = %d, want %d", name, gotPorts[name], port)
+		It("exposes authwebhook on 443 with serving cert annotation", func() {
+			kn := testKubernaut()
+			found := false
+			for _, svc := range Services(kn) {
+				if svc.Name == testAuthWebhookServiceName {
+					found = true
+					Expect(svc.Spec.Ports).NotTo(BeEmpty())
+					Expect(svc.Spec.Ports[0].Port).To(Equal(int32(443)))
+					Expect(svc.Annotations[OCPServingCertAnnotation]).To(Equal("authwebhook-tls"))
+					break
 				}
 			}
-			return
-		}
-	}
-	t.Fatal("gateway-service not found")
-}
+			Expect(found).To(BeTrue(), "Services() should contain authwebhook-service")
+		})
 
-func TestServices_KubernautAgentServingCert(t *testing.T) {
-	kn := testKubernaut()
-	for _, svc := range Services(kn) {
-		if svc.Name == "kubernaut-agent" {
-			v, ok := svc.Annotations[OCPServingCertAnnotation]
-			if !ok {
-				t.Fatal("kubernaut-agent missing serving-cert-secret-name annotation")
+		It("gives non-authwebhook API services port 8080", func() {
+			kn := testKubernaut()
+			for _, svc := range Services(kn) {
+				if svc.Name == testAuthWebhookServiceName {
+					continue
+				}
+				found := false
+				for _, p := range svc.Spec.Ports {
+					if p.Port == 8080 {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "Service %q should have port 8080", svc.Name)
 			}
-			if v != KubernautAgentTLSSecretName {
-				t.Errorf("kubernaut-agent annotation = %q, want %q", v, KubernautAgentTLSSecretName)
-			}
-			return
-		}
-	}
-	t.Fatal("kubernaut-agent service not found")
-}
+		})
 
-func TestServices_GatewayHasServingCertAnnotation(t *testing.T) {
-	kn := testKubernaut()
-	for _, svc := range Services(kn) {
-		if svc.Name == "gateway-service" {
-			v, ok := svc.Annotations[OCPServingCertAnnotation]
-			if !ok {
-				t.Fatal("gateway-service missing serving-cert-secret-name annotation")
+		It("includes expected service names", func() {
+			kn := testKubernaut()
+			svcs := Services(kn)
+			names := make(map[string]bool, len(svcs))
+			for _, svc := range svcs {
+				names[svc.Name] = true
 			}
-			if v != GatewayTLSSecretName {
-				t.Errorf("gateway-service annotation = %q, want %q", v, GatewayTLSSecretName)
+			expected := []string{
+				"gateway-service",
+				"data-storage-service",
+				"aianalysis-service",
+				"kubernaut-agent",
+				testAuthWebhookServiceName,
 			}
-			return
-		}
-	}
-	t.Fatal("gateway-service not found")
-}
+			for _, name := range expected {
+				Expect(names[name]).To(BeTrue(), "Services() missing expected service %q", name)
+			}
+		})
 
-func TestServices_DataStorageHasServingCertAnnotation(t *testing.T) {
-	kn := testKubernaut()
-	for _, svc := range Services(kn) {
-		if svc.Name == "data-storage-service" {
-			v, ok := svc.Annotations[OCPServingCertAnnotation]
-			if !ok {
-				t.Fatal("data-storage-service missing serving-cert-secret-name annotation")
+		It("maps gateway-service to multi-port spec", func() {
+			kn := testKubernaut()
+			found := false
+			for _, svc := range Services(kn) {
+				if svc.Name == "gateway-service" {
+					found = true
+					wantPorts := map[string]int32{"http": 8080, "health": 8081, "metrics": 9090}
+					gotPorts := make(map[string]int32)
+					for _, p := range svc.Spec.Ports {
+						gotPorts[p.Name] = p.Port
+					}
+					for name, port := range wantPorts {
+						Expect(gotPorts[name]).To(Equal(port), "gateway-service port %q = %d, want %d", name, gotPorts[name], port)
+					}
+					break
+				}
 			}
-			if v != DataStorageTLSSecretName {
-				t.Errorf("data-storage-service annotation = %q, want %q", v, DataStorageTLSSecretName)
-			}
-			return
-		}
-	}
-	t.Fatal("data-storage-service not found")
-}
+			Expect(found).To(BeTrue(), "gateway-service not found")
+		})
 
-func TestServices_MetricsServicesOnlyExposePort9090(t *testing.T) {
-	kn := testKubernaut()
-	for _, svc := range MetricsServices(kn) {
-		if len(svc.Spec.Ports) != 1 {
-			t.Errorf("metrics service %q should have exactly 1 port, got %d", svc.Name, len(svc.Spec.Ports))
-			continue
-		}
-		if svc.Spec.Ports[0].Port != 9090 {
-			t.Errorf("metrics service %q port = %d, want 9090", svc.Name, svc.Spec.Ports[0].Port)
-		}
-	}
-}
+		It("annotates kubernaut-agent with serving cert secret name", func() {
+			kn := testKubernaut()
+			found := false
+			for _, svc := range Services(kn) {
+				if svc.Name == "kubernaut-agent" {
+					found = true
+					v, ok := svc.Annotations[OCPServingCertAnnotation]
+					Expect(ok).To(BeTrue(), "kubernaut-agent missing serving-cert-secret-name annotation")
+					Expect(v).To(Equal(KubernautAgentTLSSecretName))
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "kubernaut-agent service not found")
+		})
+
+		It("annotates gateway-service with serving cert secret name", func() {
+			kn := testKubernaut()
+			found := false
+			for _, svc := range Services(kn) {
+				if svc.Name == "gateway-service" {
+					found = true
+					v, ok := svc.Annotations[OCPServingCertAnnotation]
+					Expect(ok).To(BeTrue(), "gateway-service missing serving-cert-secret-name annotation")
+					Expect(v).To(Equal(GatewayTLSSecretName))
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "gateway-service not found")
+		})
+
+		It("annotates data-storage-service with serving cert secret name", func() {
+			kn := testKubernaut()
+			found := false
+			for _, svc := range Services(kn) {
+				if svc.Name == "data-storage-service" {
+					found = true
+					v, ok := svc.Annotations[OCPServingCertAnnotation]
+					Expect(ok).To(BeTrue(), "data-storage-service missing serving-cert-secret-name annotation")
+					Expect(v).To(Equal(DataStorageTLSSecretName))
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "data-storage-service not found")
+		})
+	})
+
+	Context("MetricsServices()", func() {
+		It("returns 5 metrics services", func() {
+			kn := testKubernaut()
+			svcs := MetricsServices(kn)
+			Expect(len(svcs)).To(Equal(5))
+		})
+
+		It("places all metrics services in the system namespace", func() {
+			kn := testKubernaut()
+			for _, svc := range MetricsServices(kn) {
+				Expect(svc.Namespace).To(Equal(testSystemNamespace), "Service %q namespace = %q, want %q", svc.Name, svc.Namespace, testSystemNamespace)
+			}
+		})
+
+		It("includes expected metrics service names", func() {
+			kn := testKubernaut()
+			svcs := MetricsServices(kn)
+			names := make(map[string]bool, len(svcs))
+			for _, svc := range svcs {
+				names[svc.Name] = true
+			}
+			expected := []string{
+				"signalprocessing-controller-metrics",
+				"remediationorchestrator-controller",
+				"workflowexecution-controller-metrics",
+				"effectivenessmonitor-metrics",
+				"notification-metrics",
+			}
+			for _, name := range expected {
+				Expect(names[name]).To(BeTrue(), "MetricsServices() missing expected service %q", name)
+			}
+		})
+
+		It("exposes only port 9090 on each metrics service", func() {
+			kn := testKubernaut()
+			for _, svc := range MetricsServices(kn) {
+				Expect(len(svc.Spec.Ports)).To(Equal(1), "metrics service %q should have exactly 1 port, got %d", svc.Name, len(svc.Spec.Ports))
+				Expect(svc.Spec.Ports[0].Port).To(Equal(int32(9090)), "metrics service %q port = %d, want 9090", svc.Name, svc.Spec.Ports[0].Port)
+			}
+		})
+	})
+
+	Context("selectors", func() {
+		It("use app labels that match known components", func() {
+			kn := testKubernaut()
+			all := append(Services(kn), MetricsServices(kn)...)
+
+			knownComponents := make(map[string]bool)
+			for _, c := range AllComponents() {
+				knownComponents[c] = true
+			}
+
+			for _, svc := range all {
+				app, ok := svc.Spec.Selector["app"]
+				Expect(ok).To(BeTrue(), "Service %q missing 'app' selector", svc.Name)
+				Expect(knownComponents[app]).To(BeTrue(), "Service %q selector app=%q is not a known component", svc.Name, app)
+			}
+		})
+	})
+})

--- a/internal/resources/suite_test.go
+++ b/internal/resources/suite_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resources Suite")
+}
+
+var _ = BeforeSuite(func() {
+	for k, v := range map[string]string{
+		"RELATED_IMAGE_GATEWAY":                 "quay.io/kubernaut-ai/gateway:v1.3.0",
+		"RELATED_IMAGE_DATA_STORAGE":            "quay.io/kubernaut-ai/datastorage:v1.3.0",
+		"RELATED_IMAGE_AIANALYSIS":              "quay.io/kubernaut-ai/aianalysis:v1.3.0",
+		"RELATED_IMAGE_SIGNALPROCESSING":        "quay.io/kubernaut-ai/signalprocessing:v1.3.0",
+		"RELATED_IMAGE_REMEDIATIONORCHESTRATOR": "quay.io/kubernaut-ai/remediationorchestrator:v1.3.0",
+		"RELATED_IMAGE_WORKFLOWEXECUTION":       "quay.io/kubernaut-ai/workflowexecution:v1.3.0",
+		"RELATED_IMAGE_EFFECTIVENESSMONITOR":    "quay.io/kubernaut-ai/effectivenessmonitor:v1.3.0",
+		"RELATED_IMAGE_NOTIFICATION":            "quay.io/kubernaut-ai/notification:v1.3.0",
+		"RELATED_IMAGE_KUBERNAUT_AGENT":         "quay.io/kubernaut-ai/kubernautagent:v1.3.0",
+		"RELATED_IMAGE_AUTHWEBHOOK":             "quay.io/kubernaut-ai/authwebhook:v1.3.0",
+		"RELATED_IMAGE_DB_MIGRATE":              "quay.io/kubernaut-ai/db-migrate:v1.3.0",
+	} {
+		Expect(os.Setenv(k, v)).To(Succeed())
+	}
+})
+
+var _ = AfterSuite(func() {
+	for _, k := range []string{
+		"RELATED_IMAGE_GATEWAY",
+		"RELATED_IMAGE_DATA_STORAGE",
+		"RELATED_IMAGE_AIANALYSIS",
+		"RELATED_IMAGE_SIGNALPROCESSING",
+		"RELATED_IMAGE_REMEDIATIONORCHESTRATOR",
+		"RELATED_IMAGE_WORKFLOWEXECUTION",
+		"RELATED_IMAGE_EFFECTIVENESSMONITOR",
+		"RELATED_IMAGE_NOTIFICATION",
+		"RELATED_IMAGE_KUBERNAUT_AGENT",
+		"RELATED_IMAGE_AUTHWEBHOOK",
+		"RELATED_IMAGE_DB_MIGRATE",
+	} {
+		Expect(os.Unsetenv(k)).To(Succeed())
+	}
+})

--- a/internal/resources/tlsprofile_test.go
+++ b/internal/resources/tlsprofile_test.go
@@ -17,107 +17,90 @@ limitations under the License.
 package resources
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
 
-func TestMapTLSProfile_Nil(t *testing.T) {
-	if got := MapTLSProfile(nil); got != "" {
-		t.Fatalf("nil profile should return empty string, got %q", got)
-	}
-}
+var _ = Describe("MapTLSProfile", func() {
+	It("returns empty when profile is nil", func() {
+		Expect(MapTLSProfile(nil)).To(BeEmpty())
+	})
 
-func TestMapTLSProfile_Old(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType}
-	if got := MapTLSProfile(p); got != TLSProfileNameOld {
-		t.Fatalf("expected Old, got %q", got)
-	}
-}
+	It("maps Old type to TLSProfileNameOld", func() {
+		p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameOld))
+	})
 
-func TestMapTLSProfile_Intermediate(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
-	if got := MapTLSProfile(p); got != TLSProfileNameIntermediate {
-		t.Fatalf("expected Intermediate, got %q", got)
-	}
-}
+	It("maps Intermediate type to TLSProfileNameIntermediate", func() {
+		p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameIntermediate))
+	})
 
-func TestMapTLSProfile_Modern(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType}
-	if got := MapTLSProfile(p); got != TLSProfileNameModern {
-		t.Fatalf("expected Modern, got %q", got)
-	}
-}
+	It("maps Modern type to TLSProfileNameModern", func() {
+		p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameModern))
+	})
 
-func TestMapTLSProfile_CustomTLS13(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{
-		Type: configv1.TLSProfileCustomType,
-		Custom: &configv1.CustomTLSProfile{
-			TLSProfileSpec: configv1.TLSProfileSpec{
-				MinTLSVersion: configv1.VersionTLS13,
-				Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+	It("maps Custom with TLS 1.3 minimum to Modern", func() {
+		p := &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileCustomType,
+			Custom: &configv1.CustomTLSProfile{
+				TLSProfileSpec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS13,
+					Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+				},
 			},
-		},
-	}
-	if got := MapTLSProfile(p); got != TLSProfileNameModern {
-		t.Fatalf("Custom with TLS 1.3 should map to Modern, got %q", got)
-	}
-}
+		}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameModern))
+	})
 
-func TestMapTLSProfile_CustomTLS12(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{
-		Type: configv1.TLSProfileCustomType,
-		Custom: &configv1.CustomTLSProfile{
-			TLSProfileSpec: configv1.TLSProfileSpec{
-				MinTLSVersion: configv1.VersionTLS12,
-				Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+	It("maps Custom with TLS 1.2 minimum to Intermediate", func() {
+		p := &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileCustomType,
+			Custom: &configv1.CustomTLSProfile{
+				TLSProfileSpec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS12,
+					Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+				},
 			},
-		},
-	}
-	if got := MapTLSProfile(p); got != TLSProfileNameIntermediate {
-		t.Fatalf("Custom with TLS 1.2 should map to Intermediate, got %q", got)
-	}
-}
+		}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameIntermediate))
+	})
 
-func TestMapTLSProfile_CustomTLS10(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{
-		Type: configv1.TLSProfileCustomType,
-		Custom: &configv1.CustomTLSProfile{
-			TLSProfileSpec: configv1.TLSProfileSpec{
-				MinTLSVersion: configv1.VersionTLS10,
-				Ciphers:       []string{"AES128-SHA"},
+	It("maps Custom with TLS 1.0 minimum to Old", func() {
+		p := &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileCustomType,
+			Custom: &configv1.CustomTLSProfile{
+				TLSProfileSpec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS10,
+					Ciphers:       []string{"AES128-SHA"},
+				},
 			},
-		},
-	}
-	if got := MapTLSProfile(p); got != TLSProfileNameOld {
-		t.Fatalf("Custom with TLS 1.0 should map to Old, got %q", got)
-	}
-}
+		}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameOld))
+	})
 
-func TestMapTLSProfile_CustomTLS11(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{
-		Type: configv1.TLSProfileCustomType,
-		Custom: &configv1.CustomTLSProfile{
-			TLSProfileSpec: configv1.TLSProfileSpec{
-				MinTLSVersion: configv1.VersionTLS11,
+	It("maps Custom with TLS 1.1 minimum to Old", func() {
+		p := &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileCustomType,
+			Custom: &configv1.CustomTLSProfile{
+				TLSProfileSpec: configv1.TLSProfileSpec{
+					MinTLSVersion: configv1.VersionTLS11,
+				},
 			},
-		},
-	}
-	if got := MapTLSProfile(p); got != TLSProfileNameOld {
-		t.Fatalf("Custom with TLS 1.1 should map to Old, got %q", got)
-	}
-}
+		}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameOld))
+	})
 
-func TestMapTLSProfile_CustomNilCustomField(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType}
-	if got := MapTLSProfile(p); got != TLSProfileNameIntermediate {
-		t.Fatalf("Custom with nil custom field should default to Intermediate, got %q", got)
-	}
-}
+	It("defaults Custom with nil custom field to Intermediate", func() {
+		p := &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType}
+		Expect(MapTLSProfile(p)).To(Equal(TLSProfileNameIntermediate))
+	})
 
-func TestMapTLSProfile_UnknownType(t *testing.T) {
-	p := &configv1.TLSSecurityProfile{Type: "FutureProfile"}
-	if got := MapTLSProfile(p); got != "" {
-		t.Fatalf("unknown type should return empty string, got %q", got)
-	}
-}
+	It("returns empty for an unknown type", func() {
+		p := &configv1.TLSSecurityProfile{Type: "FutureProfile"}
+		Expect(MapTLSProfile(p)).To(BeEmpty())
+	})
+})

--- a/internal/resources/webhooks_test.go
+++ b/internal/resources/webhooks_test.go
@@ -17,283 +17,222 @@ limitations under the License.
 package resources
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
 
-func TestMutatingWebhookConfiguration_Basic(t *testing.T) {
-	kn := testKubernaut()
-	mwc := MutatingWebhookConfiguration(kn)
+var _ = Describe("MutatingWebhookConfiguration", func() {
+	It("has expected name, annotation, and webhook count", func() {
+		kn := testKubernaut()
+		mwc := MutatingWebhookConfiguration(kn)
 
-	if mwc.Name != "kubernaut-system-authwebhook-mutating" {
-		t.Errorf("name = %q, want %q", mwc.Name, "kubernaut-system-authwebhook-mutating")
-	}
-	if mwc.Annotations[OCPServiceCAInjectAnnotation] != "true" {
-		t.Error("MWC should have OCP service-CA inject annotation")
-	}
-	if len(mwc.Webhooks) != 3 {
-		t.Fatalf("should have 3 webhooks, got %d", len(mwc.Webhooks))
-	}
-}
+		Expect(mwc.Name).To(Equal("kubernaut-system-authwebhook-mutating"), "name = %q, want %q", mwc.Name, "kubernaut-system-authwebhook-mutating")
+		Expect(mwc.Annotations[OCPServiceCAInjectAnnotation]).To(Equal("true"), "MWC should have OCP service-CA inject annotation")
+		Expect(mwc.Webhooks).To(HaveLen(3), "should have 3 webhooks, got %d", len(mwc.Webhooks))
+	})
 
-func TestMutatingWebhookConfiguration_WebhookNames(t *testing.T) {
-	kn := testKubernaut()
-	mwc := MutatingWebhookConfiguration(kn)
+	It("uses the expected webhook names", func() {
+		kn := testKubernaut()
+		mwc := MutatingWebhookConfiguration(kn)
 
-	wantNames := []string{
-		"workflowexecution.mutate.kubernaut.ai",
-		"remediationapprovalrequest.mutate.kubernaut.ai",
-		"remediationrequest.mutate.kubernaut.ai",
-	}
-
-	for i, wh := range mwc.Webhooks {
-		if wh.Name != wantNames[i] {
-			t.Errorf("webhook[%d] name = %q, want %q", i, wh.Name, wantNames[i])
-		}
-	}
-}
-
-func TestMutatingWebhookConfiguration_Paths(t *testing.T) {
-	kn := testKubernaut()
-	mwc := MutatingWebhookConfiguration(kn)
-
-	wantPaths := []string{
-		"/mutate-workflowexecution",
-		"/mutate-remediationapprovalrequest",
-		"/mutate-remediationrequest",
-	}
-
-	for i, wh := range mwc.Webhooks {
-		if wh.ClientConfig.Service == nil {
-			t.Fatalf("webhook[%d] should use service reference", i)
-		}
-		if wh.ClientConfig.Service.Path == nil || *wh.ClientConfig.Service.Path != wantPaths[i] {
-			t.Errorf("webhook[%d] path = %v, want %q", i, wh.ClientConfig.Service.Path, wantPaths[i])
-		}
-	}
-}
-
-func TestMutatingWebhookConfiguration_Rules(t *testing.T) {
-	kn := testKubernaut()
-	mwc := MutatingWebhookConfiguration(kn)
-
-	wantResources := []string{
-		"workflowexecutions/status",
-		"remediationapprovalrequests/status",
-		"remediationrequests/status",
-	}
-
-	for i, wh := range mwc.Webhooks {
-		if len(wh.Rules) != 1 {
-			t.Fatalf("webhook[%d] should have 1 rule, got %d", i, len(wh.Rules))
-		}
-		rule := wh.Rules[0]
-
-		if len(rule.Operations) != 1 || rule.Operations[0] != admissionregistrationv1.Update {
-			t.Errorf("webhook[%d] should only have UPDATE operation, got %v", i, rule.Operations)
+		wantNames := []string{
+			"workflowexecution.mutate.kubernaut.ai",
+			"remediationapprovalrequest.mutate.kubernaut.ai",
+			"remediationrequest.mutate.kubernaut.ai",
 		}
 
-		if len(rule.APIGroups) == 0 || rule.APIGroups[0] != "kubernaut.ai" {
-			t.Errorf("webhook[%d] apiGroups = %v, want [kubernaut.ai]", i, rule.APIGroups)
+		for i, wh := range mwc.Webhooks {
+			Expect(wh.Name).To(Equal(wantNames[i]), "webhook[%d] name = %q, want %q", i, wh.Name, wantNames[i])
 		}
-		if len(rule.Resources) == 0 || rule.Resources[0] != wantResources[i] {
-			t.Errorf("webhook[%d] resources = %v, want [%s]", i, rule.Resources, wantResources[i])
+	})
+
+	It("sets client paths", func() {
+		kn := testKubernaut()
+		mwc := MutatingWebhookConfiguration(kn)
+
+		wantPaths := []string{
+			"/mutate-workflowexecution",
+			"/mutate-remediationapprovalrequest",
+			"/mutate-remediationrequest",
 		}
-	}
-}
 
-func TestMutatingWebhookConfiguration_ServiceReference(t *testing.T) {
-	kn := testKubernaut()
-	mwc := MutatingWebhookConfiguration(kn)
-
-	for i, wh := range mwc.Webhooks {
-		svc := wh.ClientConfig.Service
-		if svc == nil {
-			t.Fatalf("webhook[%d] should use service reference", i)
+		for i, wh := range mwc.Webhooks {
+			Expect(wh.ClientConfig.Service).NotTo(BeNil(), "webhook[%d] should use service reference", i)
+			Expect(wh.ClientConfig.Service.Path).NotTo(BeNil())
+			Expect(*wh.ClientConfig.Service.Path).To(Equal(wantPaths[i]), "webhook[%d] path = %v, want %q", i, wh.ClientConfig.Service.Path, wantPaths[i])
 		}
-		if svc.Namespace != "kubernaut-system" {
-			t.Errorf("webhook[%d] service namespace = %q, want %q", i, svc.Namespace, "kubernaut-system")
+	})
+
+	It("defines admission rules", func() {
+		kn := testKubernaut()
+		mwc := MutatingWebhookConfiguration(kn)
+
+		wantResources := []string{
+			"workflowexecutions/status",
+			"remediationapprovalrequests/status",
+			"remediationrequests/status",
 		}
-		if svc.Name != "authwebhook-service" {
-			t.Errorf("webhook[%d] service name = %q, want %q", i, svc.Name, "authwebhook-service")
+
+		for i, wh := range mwc.Webhooks {
+			Expect(wh.Rules).To(HaveLen(1), "webhook[%d] should have 1 rule, got %d", i, len(wh.Rules))
+			rule := wh.Rules[0]
+
+			Expect(rule.Operations).To(HaveLen(1))
+			Expect(rule.Operations[0]).To(Equal(admissionregistrationv1.Update), "webhook[%d] should only have UPDATE operation, got %v", i, rule.Operations)
+
+			Expect(rule.APIGroups).NotTo(BeEmpty())
+			Expect(rule.APIGroups[0]).To(Equal("kubernaut.ai"), "webhook[%d] apiGroups = %v, want [kubernaut.ai]", i, rule.APIGroups)
+			Expect(rule.Resources).NotTo(BeEmpty())
+			Expect(rule.Resources[0]).To(Equal(wantResources[i]), "webhook[%d] resources = %v, want [%s]", i, rule.Resources, wantResources[i])
 		}
-		if *svc.Port != PortAuthWebhookService {
-			t.Errorf("webhook[%d] service port = %d, want %d", i, *svc.Port, PortAuthWebhookService)
+	})
+
+	It("references the authwebhook service", func() {
+		kn := testKubernaut()
+		mwc := MutatingWebhookConfiguration(kn)
+
+		for i, wh := range mwc.Webhooks {
+			svc := wh.ClientConfig.Service
+			Expect(svc).NotTo(BeNil(), "webhook[%d] should use service reference", i)
+			Expect(svc.Namespace).To(Equal("kubernaut-system"), "webhook[%d] service namespace = %q, want %q", i, svc.Namespace, "kubernaut-system")
+			Expect(svc.Name).To(Equal("authwebhook-service"), "webhook[%d] service name = %q, want %q", i, svc.Name, "authwebhook-service")
+			Expect(*svc.Port).To(Equal(PortAuthWebhookService), "webhook[%d] service port = %d, want %d", i, *svc.Port, PortAuthWebhookService)
 		}
-	}
-}
+	})
+})
 
-func TestValidatingWebhookConfiguration_Basic(t *testing.T) {
-	kn := testKubernaut()
-	vwc := ValidatingWebhookConfiguration(kn)
+var _ = Describe("ValidatingWebhookConfiguration", func() {
+	It("has expected name, annotation, and webhook count", func() {
+		kn := testKubernaut()
+		vwc := ValidatingWebhookConfiguration(kn)
 
-	if vwc.Name != "kubernaut-system-authwebhook-validating" {
-		t.Errorf("name = %q, want %q", vwc.Name, "kubernaut-system-authwebhook-validating")
-	}
-	if vwc.Annotations[OCPServiceCAInjectAnnotation] != "true" {
-		t.Error("VWC should have OCP service-CA inject annotation")
-	}
-	if len(vwc.Webhooks) != 3 {
-		t.Fatalf("should have 3 webhooks, got %d", len(vwc.Webhooks))
-	}
-}
+		Expect(vwc.Name).To(Equal("kubernaut-system-authwebhook-validating"), "name = %q, want %q", vwc.Name, "kubernaut-system-authwebhook-validating")
+		Expect(vwc.Annotations[OCPServiceCAInjectAnnotation]).To(Equal("true"), "VWC should have OCP service-CA inject annotation")
+		Expect(vwc.Webhooks).To(HaveLen(3), "should have 3 webhooks, got %d", len(vwc.Webhooks))
+	})
 
-func TestValidatingWebhookConfiguration_WebhookNames(t *testing.T) {
-	kn := testKubernaut()
-	vwc := ValidatingWebhookConfiguration(kn)
+	It("uses the expected webhook names", func() {
+		kn := testKubernaut()
+		vwc := ValidatingWebhookConfiguration(kn)
 
-	wantNames := []string{
-		"notificationrequest.validate.kubernaut.ai",
-		"remediationworkflow.validate.kubernaut.ai",
-		"actiontype.validate.kubernaut.ai",
-	}
-
-	for i, wh := range vwc.Webhooks {
-		if wh.Name != wantNames[i] {
-			t.Errorf("webhook[%d] name = %q, want %q", i, wh.Name, wantNames[i])
+		wantNames := []string{
+			"notificationrequest.validate.kubernaut.ai",
+			"remediationworkflow.validate.kubernaut.ai",
+			"actiontype.validate.kubernaut.ai",
 		}
-	}
-}
 
-func TestValidatingWebhookConfiguration_Paths(t *testing.T) {
-	kn := testKubernaut()
-	vwc := ValidatingWebhookConfiguration(kn)
-
-	wantPaths := []string{
-		"/validate-notificationrequest-delete",
-		"/validate-remediationworkflow",
-		"/validate-actiontype",
-	}
-
-	for i, wh := range vwc.Webhooks {
-		if wh.ClientConfig.Service == nil {
-			t.Fatalf("webhook[%d] should use service reference", i)
+		for i, wh := range vwc.Webhooks {
+			Expect(wh.Name).To(Equal(wantNames[i]), "webhook[%d] name = %q, want %q", i, wh.Name, wantNames[i])
 		}
-		if wh.ClientConfig.Service.Path == nil || *wh.ClientConfig.Service.Path != wantPaths[i] {
-			t.Errorf("webhook[%d] path = %v, want %q", i, wh.ClientConfig.Service.Path, wantPaths[i])
+	})
+
+	It("sets client paths", func() {
+		kn := testKubernaut()
+		vwc := ValidatingWebhookConfiguration(kn)
+
+		wantPaths := []string{
+			"/validate-notificationrequest-delete",
+			"/validate-remediationworkflow",
+			"/validate-actiontype",
 		}
-	}
-}
 
-func TestValidatingWebhookConfiguration_Rules(t *testing.T) {
-	kn := testKubernaut()
-	vwc := ValidatingWebhookConfiguration(kn)
-
-	wantResources := []string{
-		"notificationrequests",
-		"remediationworkflows",
-		"actiontypes",
-	}
-
-	// notificationrequest: DELETE only; others: CREATE, UPDATE, DELETE
-	for i, wh := range vwc.Webhooks {
-		if len(wh.Rules) != 1 {
-			t.Fatalf("webhook[%d] should have 1 rule, got %d", i, len(wh.Rules))
+		for i, wh := range vwc.Webhooks {
+			Expect(wh.ClientConfig.Service).NotTo(BeNil(), "webhook[%d] should use service reference", i)
+			Expect(wh.ClientConfig.Service.Path).NotTo(BeNil())
+			Expect(*wh.ClientConfig.Service.Path).To(Equal(wantPaths[i]), "webhook[%d] path = %v, want %q", i, wh.ClientConfig.Service.Path, wantPaths[i])
 		}
-		rule := wh.Rules[0]
+	})
 
-		if i == 0 {
-			if len(rule.Operations) != 1 || rule.Operations[0] != admissionregistrationv1.Delete {
-				t.Errorf("webhook[%d] should only have DELETE, got %v", i, rule.Operations)
+	It("defines admission rules", func() {
+		kn := testKubernaut()
+		vwc := ValidatingWebhookConfiguration(kn)
+
+		wantResources := []string{
+			"notificationrequests",
+			"remediationworkflows",
+			"actiontypes",
+		}
+
+		for i, wh := range vwc.Webhooks {
+			Expect(wh.Rules).To(HaveLen(1), "webhook[%d] should have 1 rule, got %d", i, len(wh.Rules))
+			rule := wh.Rules[0]
+
+			if i == 0 {
+				Expect(rule.Operations).To(HaveLen(1))
+				Expect(rule.Operations[0]).To(Equal(admissionregistrationv1.Delete), "webhook[%d] should only have DELETE, got %v", i, rule.Operations)
+			} else {
+				Expect(len(rule.Operations)).To(Equal(3), "webhook[%d] should have CREATE, UPDATE, DELETE, got %v", i, rule.Operations)
 			}
-		} else {
-			if len(rule.Operations) != 3 {
-				t.Errorf("webhook[%d] should have CREATE, UPDATE, DELETE, got %v", i, rule.Operations)
-			}
+
+			Expect(rule.Resources).NotTo(BeEmpty())
+			Expect(rule.Resources[0]).To(Equal(wantResources[i]), "webhook[%d] resources = %v, want [%s]", i, rule.Resources, wantResources[i])
 		}
+	})
 
-		if len(rule.Resources) == 0 || rule.Resources[0] != wantResources[i] {
-			t.Errorf("webhook[%d] resources = %v, want [%s]", i, rule.Resources, wantResources[i])
+	It("applies namespace selectors as expected", func() {
+		kn := testKubernaut()
+		vwc := ValidatingWebhookConfiguration(kn)
+
+		Expect(vwc.Webhooks[0].NamespaceSelector).To(BeNil(), "notificationrequest validating webhook should not have namespaceSelector")
+
+		for _, i := range []int{1, 2} {
+			wh := vwc.Webhooks[i]
+			Expect(wh.NamespaceSelector).NotTo(BeNil(), "webhook[%d] should have namespaceSelector", i)
+			ns, ok := wh.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]
+			Expect(ok && ns == "kubernaut-system").To(BeTrue(), "webhook[%d] namespaceSelector should match %q, got %v", i, "kubernaut-system", wh.NamespaceSelector.MatchLabels)
 		}
-	}
-}
+	})
 
-func TestValidatingWebhookConfiguration_NamespaceSelector(t *testing.T) {
-	kn := testKubernaut()
-	vwc := ValidatingWebhookConfiguration(kn)
+	It("sets side effects", func() {
+		kn := testKubernaut()
+		vwc := ValidatingWebhookConfiguration(kn)
 
-	// notificationrequest (index 0) has no namespaceSelector
-	if vwc.Webhooks[0].NamespaceSelector != nil {
-		t.Error("notificationrequest validating webhook should not have namespaceSelector")
-	}
-
-	// remediationworkflow and actiontype should have namespaceSelector
-	for _, i := range []int{1, 2} {
-		wh := vwc.Webhooks[i]
-		if wh.NamespaceSelector == nil {
-			t.Errorf("webhook[%d] should have namespaceSelector", i)
-			continue
+		Expect(*vwc.Webhooks[0].SideEffects).To(Equal(admissionregistrationv1.SideEffectClassNone), "notificationrequest webhook should have SideEffects=None")
+		for _, i := range []int{1, 2} {
+			Expect(*vwc.Webhooks[i].SideEffects).To(Equal(admissionregistrationv1.SideEffectClassNoneOnDryRun), "webhook[%d] should have SideEffects=NoneOnDryRun", i)
 		}
-		ns, ok := wh.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]
-		if !ok || ns != "kubernaut-system" {
-			t.Errorf("webhook[%d] namespaceSelector should match %q, got %v", i, "kubernaut-system", wh.NamespaceSelector.MatchLabels)
+	})
+
+	It("sets timeouts", func() {
+		kn := testKubernaut()
+		vwc := ValidatingWebhookConfiguration(kn)
+
+		Expect(*vwc.Webhooks[0].TimeoutSeconds).To(Equal(int32(10)), "notificationrequest timeout = %d, want 10", *vwc.Webhooks[0].TimeoutSeconds)
+		for _, i := range []int{1, 2} {
+			Expect(*vwc.Webhooks[i].TimeoutSeconds).To(Equal(int32(15)), "webhook[%d] timeout = %d, want 15", i, *vwc.Webhooks[i].TimeoutSeconds)
 		}
-	}
-}
+	})
+})
 
-func TestValidatingWebhookConfiguration_SideEffects(t *testing.T) {
-	kn := testKubernaut()
-	vwc := ValidatingWebhookConfiguration(kn)
+var _ = Describe("WebhookConfigurations", func() {
+	It("use FailurePolicy=Fail", func() {
+		kn := testKubernaut()
+		mwc := MutatingWebhookConfiguration(kn)
+		vwc := ValidatingWebhookConfiguration(kn)
 
-	// notificationrequest: SideEffects=None
-	if *vwc.Webhooks[0].SideEffects != admissionregistrationv1.SideEffectClassNone {
-		t.Error("notificationrequest webhook should have SideEffects=None")
-	}
-	// remediationworkflow and actiontype: SideEffects=NoneOnDryRun
-	for _, i := range []int{1, 2} {
-		if *vwc.Webhooks[i].SideEffects != admissionregistrationv1.SideEffectClassNoneOnDryRun {
-			t.Errorf("webhook[%d] should have SideEffects=NoneOnDryRun", i)
+		for i, wh := range mwc.Webhooks {
+			Expect(*wh.FailurePolicy).To(Equal(admissionregistrationv1.Fail), "mutating webhook[%d] should have FailurePolicy=Fail", i)
 		}
-	}
-}
-
-func TestValidatingWebhookConfiguration_Timeouts(t *testing.T) {
-	kn := testKubernaut()
-	vwc := ValidatingWebhookConfiguration(kn)
-
-	// notificationrequest: 10s; others: 15s
-	if *vwc.Webhooks[0].TimeoutSeconds != 10 {
-		t.Errorf("notificationrequest timeout = %d, want 10", *vwc.Webhooks[0].TimeoutSeconds)
-	}
-	for _, i := range []int{1, 2} {
-		if *vwc.Webhooks[i].TimeoutSeconds != 15 {
-			t.Errorf("webhook[%d] timeout = %d, want 15", i, *vwc.Webhooks[i].TimeoutSeconds)
+		for i, wh := range vwc.Webhooks {
+			Expect(*wh.FailurePolicy).To(Equal(admissionregistrationv1.Fail), "validating webhook[%d] should have FailurePolicy=Fail", i)
 		}
-	}
-}
+	})
 
-func TestWebhookConfigurations_FailurePolicy(t *testing.T) {
-	kn := testKubernaut()
-	mwc := MutatingWebhookConfiguration(kn)
-	vwc := ValidatingWebhookConfiguration(kn)
+	It("have managed-by labels", func() {
+		kn := testKubernaut()
+		mwc := MutatingWebhookConfiguration(kn)
+		vwc := ValidatingWebhookConfiguration(kn)
 
-	for i, wh := range mwc.Webhooks {
-		if *wh.FailurePolicy != admissionregistrationv1.Fail {
-			t.Errorf("mutating webhook[%d] should have FailurePolicy=Fail", i)
+		for _, obj := range []struct {
+			name   string
+			labels map[string]string
+		}{
+			{"mutating", mwc.Labels},
+			{"validating", vwc.Labels},
+		} {
+			Expect(obj.labels["app.kubernetes.io/managed-by"]).To(Equal("kubernaut-operator"), "%s webhook missing managed-by label", obj.name)
 		}
-	}
-	for i, wh := range vwc.Webhooks {
-		if *wh.FailurePolicy != admissionregistrationv1.Fail {
-			t.Errorf("validating webhook[%d] should have FailurePolicy=Fail", i)
-		}
-	}
-}
-
-func TestWebhookConfigurations_HaveCommonLabels(t *testing.T) {
-	kn := testKubernaut()
-	mwc := MutatingWebhookConfiguration(kn)
-	vwc := ValidatingWebhookConfiguration(kn)
-
-	for _, obj := range []struct {
-		name   string
-		labels map[string]string
-	}{
-		{"mutating", mwc.Labels},
-		{"validating", vwc.Labels},
-	} {
-		if obj.labels["app.kubernetes.io/managed-by"] != "kubernaut-operator" {
-			t.Errorf("%s webhook missing managed-by label", obj.name)
-		}
-	}
-}
+	})
+})


### PR DESCRIPTION
## Summary
- Convert all 14 test files in `internal/resources/` from standard Go `testing` to BDD-style Ginkgo v2 / Gomega
- Add `suite_test.go` with `BeforeSuite`/`AfterSuite` for `RELATED_IMAGE_*` env var management
- All 269 specs pass

## Test plan
- [x] `go test ./internal/resources/... -count=1` passes (269/269 specs)
- [ ] CI lint + test + coverage gate passes

Closes #106

Made with [Cursor](https://cursor.com)