### PR TITLE
fix(deps): bump kubernaut to v1.5.0-rc3 to resolve duplicate migration 009

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jordigilh/kubernaut-operator
 go 1.25.10
 
 require (
-	github.com/jordigilh/kubernaut v1.5.0-rc1.0.20260521022301-c72e31f17a98
+	github.com/jordigilh/kubernaut v1.5.0-rc3
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/openshift/api v0.0.0-20260327162646-993e604705e3

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jordigilh/kubernaut v1.5.0-rc1.0.20260521022301-c72e31f17a98 h1:zt5iV1Cl1e7pVDAzXDKm5qm4XGo1XEbRgKqpxQe6owk=
-github.com/jordigilh/kubernaut v1.5.0-rc1.0.20260521022301-c72e31f17a98/go.mod h1:JleM8Fxg67weMHBgNJkEBpJZaBSN00dNN+ZILOOOAEQ=
+github.com/jordigilh/kubernaut v1.5.0-rc3 h1:ktiuV+Z1w+pmeidCFDTl+3gaA+28K4mMalh9u1e3ypc=
+github.com/jordigilh/kubernaut v1.5.0-rc3/go.mod h1:JleM8Fxg67weMHBgNJkEBpJZaBSN00dNN+ZILOOOAEQ=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
## Summary
- Bumps `github.com/jordigilh/kubernaut` from pseudo-version `c72e31f17` to `v1.5.0-rc3`
- The previous pin contained two `009_*.sql` files in the embedded migrations, causing goose to panic with `duplicate version 9 detected` on every fresh deployment

## Root Cause
The operator's `go.mod` was pinned to commit `c72e31f17` (PR #1214 merge in kubernaut), which predated the migration renumber fix (PR #1219). The embedded `pkg/shared/assets/migrations/` at that commit contained both `009_drop_resource_action_traces.sql` and `009_retention_default_alignment.sql`.

## Verification
Module cache at `v1.5.0-rc3` confirms correct numbering: single `009`, `010`, `011` — no duplicates.

## Test plan
- [ ] Operator builds cleanly
- [ ] Deploy on OCP with fresh PostgreSQL — db-migrate job succeeds without panic

Fixes jordigilh/kubernaut#1218

Made with [Cursor](https://cursor.com)