### PR TITLE
refactor(rbac): align AF RBAC and tool personas with unified security model (#117, #121, #122)

### DIFF
--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -400,56 +400,64 @@ type toolPersona struct {
 }
 
 // toolPersonas lists the 6 upstream persona-based tool roles and their allowed tools,
-// matching the merged kubernaut PR#1222 values.yaml definitions.
+// aligned with the kubernaut Helm chart values.yaml after PRs #1231, #1233, #1236.
 var toolPersonas = []toolPersona{
 	{
 		name: "tool-sre",
 		resourceNames: []string{
-			"list_investigations", "get_investigation", "start_investigation",
-			"search_signals", "get_signal_details", "get_remediation_details",
-			"list_remediations", "get_investigation_history", "search_knowledge_base",
-			"get_cluster_health", "list_nodes", "get_node_details",
-			"list_pods", "get_pod_details", "get_pod_logs",
-			"list_deployments", "get_deployment_details",
-			"list_namespaces", "get_namespace_details",
+			"kubernaut_list_remediations", "kubernaut_get_remediation",
+			"kubernaut_cancel_remediation", "kubernaut_watch",
+			"kubernaut_start_investigation", "kubernaut_poll_investigation",
+			"kubernaut_discover_workflows", "kubernaut_select_workflow", "kubernaut_present_decision",
+			"kubernaut_list_workflows", "kubernaut_get_remediation_history",
+			"kubernaut_get_effectiveness", "kubernaut_get_audit_trail",
+			"kubernaut_takeover", "kubernaut_message", "kubernaut_complete",
+			"kubernaut_cancel", "kubernaut_status", "kubernaut_reconnect",
+			"kubernaut_stream_investigation",
+			"kubectl_get", "kubectl_list", "kubectl_list_events",
+			"af_check_existing_rr", "af_create_rr",
 		},
 	},
 	{
 		name: "tool-ai-orchestrator",
 		resourceNames: []string{
-			"list_investigations", "get_investigation", "start_investigation",
-			"search_signals", "get_signal_details", "get_remediation_details",
-			"list_remediations", "get_investigation_history", "search_knowledge_base",
-			"get_cluster_health", "list_nodes", "get_node_details",
-			"list_pods", "get_pod_details", "get_pod_logs",
+			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_watch",
+			"kubernaut_start_investigation", "kubernaut_poll_investigation",
+			"kubernaut_discover_workflows", "kubernaut_select_workflow", "kubernaut_present_decision",
+			"kubernaut_takeover", "kubernaut_message", "kubernaut_complete",
+			"kubernaut_cancel", "kubernaut_status", "kubernaut_reconnect",
+			"kubernaut_stream_investigation",
+			"kubectl_get", "kubectl_list", "kubectl_list_events",
+			"af_check_existing_rr", "af_create_rr",
 		},
 	},
 	{
 		name: "tool-cicd",
 		resourceNames: []string{
-			"list_investigations", "get_investigation", "get_investigation_history",
+			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_watch",
 		},
 	},
 	{
 		name: "tool-observability",
 		resourceNames: []string{
-			"search_signals", "get_signal_details", "get_cluster_health",
-			"list_nodes", "get_node_details",
-			"list_pods", "get_pod_details", "get_pod_logs",
+			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_watch",
+			"kubernaut_get_effectiveness", "kubernaut_list_workflows",
 		},
 	},
 	{
 		name: "tool-l3-audit",
 		resourceNames: []string{
-			"list_investigations", "get_investigation", "get_investigation_history",
-			"search_signals", "get_signal_details", "get_remediation_details",
+			"kubernaut_list_remediations", "kubernaut_get_remediation",
+			"kubernaut_list_workflows", "kubernaut_get_remediation_history",
+			"kubernaut_get_effectiveness", "kubernaut_get_audit_trail",
 		},
 	},
 	{
 		name: "tool-remediation-approver",
 		resourceNames: []string{
-			"list_remediations", "get_remediation_details",
-			"list_investigations", "get_investigation",
+			"kubernaut_approve", "kubernaut_list_approval_requests",
+			"kubernaut_get_approval_request",
+			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_watch",
 		},
 	},
 }
@@ -821,12 +829,16 @@ func apifrontendClusterRole(kn *kubernautv1alpha1.Kubernaut, labels map[string]s
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName(kn, "apifrontend-role"), Labels: labels},
 		Rules: []rbacv1.PolicyRule{
-			{APIGroups: []string{"apifrontend.kubernaut.ai"}, Resources: []string{"investigationsessions"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
-			{APIGroups: []string{"apifrontend.kubernaut.ai"}, Resources: []string{"investigationsessions/status"}, Verbs: []string{"get", "update", "patch"}},
-			{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create", "patch"}},
-			{APIGroups: []string{""}, Resources: []string{"users", "groups", "serviceaccounts"}, Verbs: []string{"impersonate"}},
+			{APIGroups: []string{"kubernaut.ai"}, Resources: []string{"investigationsessions"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
+			{APIGroups: []string{"kubernaut.ai"}, Resources: []string{"investigationsessions/status"}, Verbs: []string{"get", "update", "patch"}},
+			{APIGroups: []string{"kubernaut.ai"}, Resources: []string{"remediationrequests"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch"}},
+			{APIGroups: []string{"kubernaut.ai"}, Resources: []string{"remediationapprovalrequests"}, Verbs: []string{"get", "list", "create", "update", "patch"}},
+			{APIGroups: []string{"kubernaut.ai"}, Resources: []string{"remediationapprovalrequests/status"}, Verbs: []string{"get", "update", "patch"}},
+			{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"get", "list", "create", "patch"}},
+			{APIGroups: []string{""}, Resources: []string{"pods", "replicationcontrollers"}, Verbs: []string{"get", "list"}},
+			{APIGroups: []string{"apps"}, Resources: []string{"deployments", "replicasets", "statefulsets", "daemonsets"}, Verbs: []string{"get", "list"}},
+			{APIGroups: []string{"batch"}, Resources: []string{"jobs", "cronjobs"}, Verbs: []string{"get"}},
 			{APIGroups: []string{"authorization.k8s.io"}, Resources: []string{"subjectaccessreviews"}, Verbs: []string{"create"}},
-			{APIGroups: []string{"kubernaut.ai"}, Resources: []string{"remediationrequests"}, Verbs: []string{"get", "list", "create"}},
 		},
 	}
 }

--- a/internal/resources/rbac_test.go
+++ b/internal/resources/rbac_test.go
@@ -662,12 +662,12 @@ var _ = Describe("ToolClusterRoles", func() {
 				"tool ClusterRole %q should have %d resourceNames, got %d",
 				found.Name, expectedCount, len(found.Rules[0].ResourceNames))
 		},
-		Entry("SRE", "tool-sre", 19),
-		Entry("AI-orchestrator", "tool-ai-orchestrator", 15),
+		Entry("SRE", "tool-sre", 25),
+		Entry("AI-orchestrator", "tool-ai-orchestrator", 20),
 		Entry("CICD", "tool-cicd", 3),
-		Entry("Observability", "tool-observability", 8),
+		Entry("Observability", "tool-observability", 5),
 		Entry("L3-audit", "tool-l3-audit", 6),
-		Entry("Remediation-approver", "tool-remediation-approver", 4),
+		Entry("Remediation-approver", "tool-remediation-approver", 6),
 	)
 
 	It("tool ClusterRole names are namespace-prefixed", func() {
@@ -789,7 +789,7 @@ var _ = Describe("APIFrontend ClusterRole", func() {
 		Expect(found).To(BeTrue(), "apifrontend ClusterRole should be present when AF is enabled")
 	})
 
-	It("grants InvestigationSession CRUD and impersonation", func() {
+	It("grants InvestigationSession CRUD under kubernaut.ai API group", func() {
 		kn := testKubernautWithAF()
 		roles := ClusterRoles(kn)
 		var afRole *rbacv1.ClusterRole
@@ -809,12 +809,82 @@ var _ = Describe("APIFrontend ClusterRole", func() {
 			}
 		}
 
-		Expect(ruleMap).To(HaveKey("apifrontend.kubernaut.ai/investigationsessions"))
-		Expect(ruleMap["apifrontend.kubernaut.ai/investigationsessions"]).To(ContainElements("get", "list", "watch", "create", "update", "patch", "delete"))
+		Expect(ruleMap).To(HaveKey("kubernaut.ai/investigationsessions"))
+		Expect(ruleMap["kubernaut.ai/investigationsessions"]).To(ContainElements("get", "list", "watch", "create", "update", "patch", "delete"))
 
-		Expect(ruleMap).To(HaveKey("/users"))
-		impersonateVerbs := ruleMap["/users"]
-		Expect(impersonateVerbs).To(ContainElement("impersonate"))
+		Expect(ruleMap).NotTo(HaveKey("apifrontend.kubernaut.ai/investigationsessions"),
+			"old apifrontend.kubernaut.ai API group must not be present")
+
+		Expect(ruleMap).NotTo(HaveKey("/users"),
+			"impersonate verb removed per unified security model (ADR-022)")
+	})
+
+	It("grants expanded remediationrequests and remediationapprovalrequests permissions", func() {
+		kn := testKubernautWithAF()
+		roles := ClusterRoles(kn)
+		var afRole *rbacv1.ClusterRole
+		for _, r := range roles {
+			if r.Name == clusterRoleName(kn, "apifrontend-role") {
+				afRole = r
+				break
+			}
+		}
+		Expect(afRole).NotTo(BeNil())
+
+		ruleMap := map[string][]string{}
+		for _, rule := range afRole.Rules {
+			for _, res := range rule.Resources {
+				key := rule.APIGroups[0] + "/" + res
+				ruleMap[key] = rule.Verbs
+			}
+		}
+
+		Expect(ruleMap).To(HaveKey("kubernaut.ai/remediationrequests"))
+		Expect(ruleMap["kubernaut.ai/remediationrequests"]).To(ContainElements("get", "list", "watch", "create", "update", "patch"))
+
+		Expect(ruleMap).To(HaveKey("kubernaut.ai/remediationapprovalrequests"))
+		Expect(ruleMap["kubernaut.ai/remediationapprovalrequests"]).To(ContainElements("get", "list", "create", "update", "patch"))
+
+		Expect(ruleMap).To(HaveKey("kubernaut.ai/remediationapprovalrequests/status"))
+		Expect(ruleMap["kubernaut.ai/remediationapprovalrequests/status"]).To(ContainElements("get", "update", "patch"))
+	})
+
+	It("grants core resource read access for kubectl_get/kubectl_list tools", func() {
+		kn := testKubernautWithAF()
+		roles := ClusterRoles(kn)
+		var afRole *rbacv1.ClusterRole
+		for _, r := range roles {
+			if r.Name == clusterRoleName(kn, "apifrontend-role") {
+				afRole = r
+				break
+			}
+		}
+		Expect(afRole).NotTo(BeNil())
+
+		ruleMap := map[string][]string{}
+		for _, rule := range afRole.Rules {
+			for _, res := range rule.Resources {
+				key := rule.APIGroups[0] + "/" + res
+				ruleMap[key] = rule.Verbs
+			}
+		}
+
+		Expect(ruleMap).To(HaveKey("/pods"))
+		Expect(ruleMap["/pods"]).To(ContainElements("get", "list"))
+		Expect(ruleMap).To(HaveKey("/replicationcontrollers"))
+		Expect(ruleMap["/replicationcontrollers"]).To(ContainElements("get", "list"))
+		Expect(ruleMap).To(HaveKey("/events"))
+		Expect(ruleMap["/events"]).To(ContainElements("get", "list", "create", "patch"))
+
+		Expect(ruleMap).To(HaveKey("apps/deployments"))
+		Expect(ruleMap["apps/deployments"]).To(ContainElements("get", "list"))
+		Expect(ruleMap).To(HaveKey("apps/replicasets"))
+		Expect(ruleMap).To(HaveKey("apps/statefulsets"))
+		Expect(ruleMap).To(HaveKey("apps/daemonsets"))
+
+		Expect(ruleMap).To(HaveKey("batch/jobs"))
+		Expect(ruleMap["batch/jobs"]).To(ContainElements("get"))
+		Expect(ruleMap).To(HaveKey("batch/cronjobs"))
 	})
 
 	It("has a matching ClusterRoleBinding when AF is enabled", func() {
@@ -878,7 +948,7 @@ var _ = Describe("APIFrontend ClusterRole", func() {
 		Expect(found).To(BeTrue(), "apifrontend ClusterRole should include subjectaccessreviews/create")
 	})
 
-	It("includes remediationrequests get/list/create permission", func() {
+	It("includes remediationrequests with full CRUD+watch verbs", func() {
 		kn := testKubernautWithAF()
 		roles := ClusterRoles(kn)
 		var afRole *rbacv1.ClusterRole
@@ -898,12 +968,12 @@ var _ = Describe("APIFrontend ClusterRole", func() {
 				}
 				for _, res := range rule.Resources {
 					if res == "remediationrequests" {
-						Expect(rule.Verbs).To(ContainElements("get", "list", "create"))
+						Expect(rule.Verbs).To(ContainElements("get", "list", "watch", "create", "update", "patch"))
 						found = true
 					}
 				}
 			}
 		}
-		Expect(found).To(BeTrue(), "apifrontend ClusterRole should include remediationrequests get/list/create")
+		Expect(found).To(BeTrue(), "apifrontend ClusterRole should include remediationrequests with full CRUD+watch verbs")
 	})
 })


### PR DESCRIPTION
## Summary

Aligns the operator's AF ServiceAccount RBAC rules and tool persona ClusterRoles with the upstream kubernaut unified security model after PRs #1224, #1231, #1233, and #1236 merged.

### Changes

**AF ClusterRole (`apifrontendClusterRole`):**
- **#117**: Migrate InvestigationSession API group from `apifrontend.kubernaut.ai` to `kubernaut.ai`
- **#121**: Remove `impersonate` verb on `users`/`groups`/`serviceaccounts` per ADR-022
- **#121**: Expand `remediationrequests` verbs to include `watch`, `update`, `patch`
- **#121**: Add `remediationapprovalrequests` and `/status` permissions
- **#121**: Add core resource read access (`pods`, `replicationcontrollers`, `events`, `apps/*`, `batch/*`) for `kubectl_get`/`kubectl_list` tools

**Tool Personas (`toolPersonas`):**
- **#121/#122**: Replace deprecated `af_*` and narrow triage tool names with `kubernaut_*`/`kubectl_*` names matching upstream Helm chart
- **#122**: Add 7 interactive session tools (`kubernaut_takeover`, `kubernaut_message`, `kubernaut_complete`, `kubernaut_cancel`, `kubernaut_status`, `kubernaut_reconnect`, `kubernaut_stream_investigation`) to `sre` and `ai-orchestrator` personas
- Updated all 6 persona tool lists to match upstream `values.yaml`

**NetworkPolicy (#122):**
- KA MCP ingress restriction to AF pods is already covered by the existing `kubernautAgentNetworkPolicy` (AF pods are in the ingress peers on port 8443). No additional NetworkPolicy needed since MCP runs on the same HTTPS port.

## Test plan

- [x] All 391 resource unit tests pass (0 failures)
- [x] All controller integration tests pass (68s runtime)
- [x] `golangci-lint` clean (0 issues)
- [x] `go build ./...` clean

Closes #117
Closes #121
Closes #122