### PR TITLE
fix: airgap imageset for oc-mirror v2, add Valkey

### DIFF
--- a/hack/airgap/generate-imageset.sh
+++ b/hack/airgap/generate-imageset.sh
@@ -32,14 +32,11 @@ cat > "$OUT" <<HEADER
 # Version: v${VERSION}
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
-storageConfig:
-  local:
-    path: ./kubernaut-mirror
 mirror:
   additionalImages:
-    # Operator
-    - name: quay.io/kubernaut-ai/kubernaut-operator:v${VERSION}
-    # Operator bundle
+    # Operator (quay.io tag omits the v prefix)
+    - name: quay.io/kubernaut-ai/kubernaut-operator:${VERSION}
+    # Operator bundle (quay.io tag keeps the v prefix)
     - name: quay.io/kubernaut-ai/kubernaut-operator-bundle:v${VERSION}
     # Operand and infrastructure images
 HEADER
@@ -48,5 +45,18 @@ for img in "${images[@]}"; do
   echo "    - name: ${img}" >> "$OUT"
 done
 
+# Infrastructure images not managed by the operator but required for deployment.
+# Update digests when upgrading to newer RHEL/UBI releases.
+INFRA_IMAGES=(
+  "registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e"
+  "registry.redhat.io/rhel10/valkey-8@sha256:7b478930b2d186a61c3af408c3228f3da5104c759b8bd52d62c683e33bdb9ee2"
+)
+
+echo "    # Infrastructure dependencies (PostgreSQL, Valkey)" >> "$OUT"
+for img in "${INFRA_IMAGES[@]}"; do
+  echo "    - name: ${img}" >> "$OUT"
+done
+
+total=$(( ${#images[@]} + 2 + ${#INFRA_IMAGES[@]} ))
 echo ""
-echo "Generated ${OUT} with $((${#images[@]} + 2)) images for v${VERSION}"
+echo "Generated ${OUT} with ${total} images for v${VERSION}"

--- a/hack/airgap/imageset-config.yaml
+++ b/hack/airgap/imageset-config.yaml
@@ -11,14 +11,11 @@
 # Version: v1.5.0-rc11
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
-storageConfig:
-  local:
-    path: ./kubernaut-mirror
 mirror:
   additionalImages:
-    # Operator
-    - name: quay.io/kubernaut-ai/kubernaut-operator:v1.5.0-rc11
-    # Operator bundle
+    # Operator (quay.io tag omits the v prefix)
+    - name: quay.io/kubernaut-ai/kubernaut-operator:1.5.0-rc11
+    # Operator bundle (quay.io tag keeps the v prefix)
     - name: quay.io/kubernaut-ai/kubernaut-operator-bundle:v1.5.0-rc11
     # Operand and infrastructure images
     - name: quay.io/kubernaut-ai/aianalysis@sha256:68e59eca46935aa98530f36644365e31b70f5461fa6ef6d31e39274bdc422f91
@@ -35,3 +32,4 @@ mirror:
     - name: quay.io/kubernaut-ai/workflowexecution@sha256:5db71118a4ee8e18e2e357a9713e48299df08bcaa9aa96d705d4dc83376a3483
     - name: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
     - name: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
+    - name: registry.redhat.io/rhel10/valkey-8@sha256:7b478930b2d186a61c3af408c3228f3da5104c759b8bd52d62c683e33bdb9ee2


### PR DESCRIPTION
## Summary
- Remove `storageConfig` from `ImageSetConfiguration` (unsupported by oc-mirror v2)
- Fix operator image tag to omit `v` prefix (`1.5.0-rc11`) while keeping the `v` prefix for the bundle (`v1.5.0-rc11`) — quay.io convention mismatch
- Add `registry.redhat.io/rhel10/valkey-8` to infrastructure images alongside PostgreSQL — both are required for airgapped deployments but not managed by the operator
- Update `generate-imageset.sh` to include infrastructure dependencies automatically

## Test plan
- [x] Validated with `oc-mirror v2` (4.21) on helios08 — 17/17 images mirrored successfully to local filesystem
- [ ] Verify `oc-mirror` disk-to-mirror push to a disconnected registry


Made with [Cursor](https://cursor.com)