### PR TITLE
feat: add KubeVirt/CDI read RBAC for KA, AF, GW, and EM

### DIFF
--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -621,6 +621,9 @@ func ownerChainResolutionRules() []rbacv1.PolicyRule {
 		{APIGroups: []string{"cert-manager.io"}, Resources: []string{"certificates", "clusterissuers", "certificaterequests"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"route.openshift.io"}, Resources: []string{"routes"}, Verbs: []string{"get", "list", "watch"}},
+		// KubeVirt / CDI: VM workload correlation and investigation
+		{APIGroups: []string{"kubevirt.io"}, Resources: []string{"virtualmachines", "virtualmachineinstances", "virtualmachineinstancemigrations"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"cdi.kubevirt.io"}, Resources: []string{"datavolumes"}, Verbs: []string{"get", "list", "watch"}},
 	}
 }
 
@@ -737,6 +740,9 @@ func kubernautAgentInvestigatorClusterRole(kn *kubernautv1alpha1.Kubernaut, labe
 		}, Verbs: []string{"get", "list", "watch"}},
 		// Interactive session locking via Leases (v1.5+); list needed for ReconcileOrphanedLeases
 		{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "create", "update", "delete", "list"}},
+		// KubeVirt / CDI: VM investigation and enrichment
+		{APIGroups: []string{"kubevirt.io"}, Resources: []string{"virtualmachines", "virtualmachineinstances", "virtualmachineinstancemigrations"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"cdi.kubevirt.io"}, Resources: []string{"datavolumes"}, Verbs: []string{"get", "list", "watch"}},
 	}
 
 	return &rbacv1.ClusterRole{
@@ -940,6 +946,9 @@ func apifrontendClusterRole(kn *kubernautv1alpha1.Kubernaut, labels map[string]s
 			{APIGroups: []string{"autoscaling"}, Resources: []string{"horizontalpodautoscalers"}, Verbs: []string{"get", "list"}},
 			{APIGroups: []string{"policy"}, Resources: []string{"poddisruptionbudgets"}, Verbs: []string{"get", "list"}},
 			{APIGroups: []string{"cert-manager.io"}, Resources: []string{"certificates"}, Verbs: []string{"get", "list"}},
+			// KubeVirt / CDI: VM triage and investigation
+			{APIGroups: []string{"kubevirt.io"}, Resources: []string{"virtualmachines", "virtualmachineinstances", "virtualmachineinstancemigrations"}, Verbs: []string{"get", "list"}},
+			{APIGroups: []string{"cdi.kubevirt.io"}, Resources: []string{"datavolumes"}, Verbs: []string{"get", "list"}},
 		},
 	}
 }

--- a/internal/resources/rbac_test.go
+++ b/internal/resources/rbac_test.go
@@ -154,6 +154,8 @@ var _ = Describe("ClusterRoles", func() {
 				"cert-manager.io",
 				"argoproj.io",
 				"route.openshift.io",
+				"kubevirt.io",
+				"cdi.kubevirt.io",
 			}
 			foundGroups := make(map[string]bool)
 			for _, rule := range gw.Rules {
@@ -187,6 +189,8 @@ var _ = Describe("ClusterRoles", func() {
 				"security.istio.io",
 				"networking.istio.io",
 				kubernautAPIGroup,
+				"kubevirt.io",
+				"cdi.kubevirt.io",
 			}
 			foundGroups := make(map[string]bool)
 			for _, rule := range investigator.Rules {
@@ -319,6 +323,8 @@ var _ = Describe("ClusterRoles", func() {
 				"cert-manager.io",
 				"argoproj.io",
 				"route.openshift.io",
+				"kubevirt.io",
+				"cdi.kubevirt.io",
 			}
 			foundGroups := make(map[string]bool)
 			for _, rule := range em.Rules {
@@ -1240,6 +1246,28 @@ var _ = Describe("APIFrontend ClusterRole", func() {
 			}
 		}
 		Expect(found).To(BeTrue(), "apifrontend ClusterRole should include tokenreviews/create")
+	})
+
+	It("grants KubeVirt and CDI read access for VM triage", func() {
+		kn := testKubernautWithAF()
+		roles := ClusterRoles(kn)
+		var afRole *rbacv1.ClusterRole
+		for _, r := range roles {
+			if r.Name == clusterRoleName(kn, "apifrontend-role") {
+				afRole = r
+				break
+			}
+		}
+		Expect(afRole).NotTo(BeNil())
+
+		foundGroups := make(map[string]bool)
+		for _, rule := range afRole.Rules {
+			for _, g := range rule.APIGroups {
+				foundGroups[g] = true
+			}
+		}
+		Expect(foundGroups["kubevirt.io"]).To(BeTrue(), "apifrontend ClusterRole missing kubevirt.io API group")
+		Expect(foundGroups["cdi.kubevirt.io"]).To(BeTrue(), "apifrontend ClusterRole missing cdi.kubevirt.io API group")
 	})
 
 	It("includes services/kubernaut-agent create for KA SAR gate (#137)", func() {


### PR DESCRIPTION
## Summary
- Grant read access to `kubevirt.io` (virtualmachines, virtualmachineinstances, virtualmachineinstancemigrations) and `cdi.kubevirt.io` (datavolumes) for investigation and enrichment
- **KA investigator**: VM investigation and enrichment (fixes `datavolumes.cdi.kubevirt.io is forbidden` during enrichment)
- **AF**: VM triage via kubectl_get/kubectl_list tools
- **GW + EM**: owner-chain resolution via `ownerChainResolutionRules()`
- Workflow runner is excluded — each remediation workflow brings its own ServiceAccount and RBAC

## Test plan
- [x] All 518 resource tests pass with new KubeVirt/CDI assertions
- [x] ClusterRoles patched on dev cluster and verified


Made with [Cursor](https://cursor.com)