### PR TITLE
fix: make webhook registration conditional on TLS cert availability

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,11 +156,17 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Kubernaut")
 		os.Exit(1)
 	}
-	mgr.GetWebhookServer().Register("/validate-kubernaut-singleton", &admission.Webhook{
-		Handler: &webhook.SingletonValidator{
-			Client: mgr.GetClient(),
-		},
-	})
+	webhookCertDir := filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs")
+	if _, err := os.Stat(filepath.Join(webhookCertDir, "tls.crt")); err == nil {
+		setupLog.Info("webhook TLS certs found, registering singleton validating webhook")
+		mgr.GetWebhookServer().Register("/validate-kubernaut-singleton", &admission.Webhook{
+			Handler: &webhook.SingletonValidator{
+				Client: mgr.GetClient(),
+			},
+		})
+	} else {
+		setupLog.Info("webhook TLS certs not found, skipping singleton webhook registration — singleton constraint enforced at reconcile time")
+	}
 	// +kubebuilder:scaffold:builder
 
 	if metricsCertWatcher != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -165,7 +165,7 @@ func main() {
 			},
 		})
 	} else {
-		setupLog.Info("webhook TLS certs not found, skipping singleton webhook registration — singleton constraint enforced at reconcile time")
+		setupLog.Info("webhook TLS certs not found, skipping singleton webhook registration")
 	}
 	// +kubebuilder:scaffold:builder
 


### PR DESCRIPTION
## Summary
- Makes the singleton validating webhook registration conditional on the presence of TLS cert files at startup
- If certs are absent (e.g. OLM doesn't provision them), the operator starts normally and logs a warning
- The singleton constraint remains enforced at the controller reconcile level

## Context
OLM on OCP 4.21 strips `spec.webhookdefinitions` from the CSV during bundle unpacking, preventing automatic TLS cert provisioning. This caused the operator to crash on startup with `open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory`.

Rather than relying on a manual CSV patch, this makes the operator resilient to missing webhook certs.

## Test plan
- [ ] Operator starts without webhook certs (OLM deploy without webhookdefinitions)
- [ ] Operator registers webhook when certs are present (manual deploy with cert-manager)
- [ ] Singleton constraint is enforced at reconcile time when webhook is skipped

Made with [Cursor](https://cursor.com)