### PR TITLE
feat: create AgentRuntime CR for apifrontend to trigger kagenti namespace provisioning

### DIFF
--- a/internal/controller/agentruntime_test.go
+++ b/internal/controller/agentruntime_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jordigilh/kubernaut-operator/internal/resources"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const agentRuntimeCRDName = "agentruntimes.agent.kagenti.dev"
+
+func agentRuntimeGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "agent.kagenti.dev",
+		Version: "v1alpha1",
+		Kind:    "AgentRuntime",
+	}
+}
+
+func newAgentRuntimeCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: agentRuntimeCRDName},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "agent.kagenti.dev",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "AgentRuntime",
+				Plural:   "agentruntimes",
+				Singular: "agentruntime",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1alpha1", Served: true, Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:                   "object",
+							XPreserveUnknownFields: boolPtr(true),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func newReconcilerWithCRD(objs ...runtime.Object) *KubernautReconciler {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = apiextensionsv1.AddToScheme(s)
+
+	builder := fake.NewClientBuilder().WithScheme(s)
+	for _, o := range objs {
+		builder = builder.WithRuntimeObjects(o)
+	}
+	return &KubernautReconciler{
+		Client:   builder.Build(),
+		Scheme:   s,
+		Recorder: events.NewFakeRecorder(100),
+	}
+}
+
+func getAgentRuntime(ctx context.Context, c client.Client, ns, name string) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(agentRuntimeGVK())
+	return obj, c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, obj)
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: ensureAgentRuntimeCR
+// ---------------------------------------------------------------------------
+
+func TestEnsureAgentRuntimeCR_CreatesWhenSidecarActive(t *testing.T) {
+	crd := newAgentRuntimeCRD()
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newReconcilerWithCRD(crd, ns)
+
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarAuthbridge); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ar, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend))
+	if err != nil {
+		t.Fatalf("AgentRuntime should exist: %v", err)
+	}
+
+	spec, ok := ar.Object["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatal("AgentRuntime spec should be a map")
+	}
+	if spec["type"] != "agent" {
+		t.Errorf("expected type=agent, got %v", spec["type"])
+	}
+	targetRef, ok := spec["targetRef"].(map[string]interface{})
+	if !ok {
+		t.Fatal("targetRef should be a map")
+	}
+	if targetRef["kind"] != "Deployment" {
+		t.Errorf("expected targetRef.kind=Deployment, got %v", targetRef["kind"])
+	}
+	if targetRef["name"] != string(resources.ComponentAPIFrontend) {
+		t.Errorf("expected targetRef.name=%s, got %v", resources.ComponentAPIFrontend, targetRef["name"])
+	}
+
+	labels := ar.GetLabels()
+	if labels["app.kubernetes.io/managed-by"] != "kubernaut-operator" {
+		t.Errorf("expected managed-by=kubernaut-operator, got %q", labels["app.kubernetes.io/managed-by"])
+	}
+}
+
+func TestEnsureAgentRuntimeCR_NoopWhenAlreadyExists(t *testing.T) {
+	crd := newAgentRuntimeCRD()
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newReconcilerWithCRD(crd, ns)
+
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarAuthbridge); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Second call should be a no-op.
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarAuthbridge); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if _, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend)); err != nil {
+		t.Fatalf("AgentRuntime should still exist: %v", err)
+	}
+}
+
+func TestEnsureAgentRuntimeCR_DeletesWhenSidecarDisabled(t *testing.T) {
+	crd := newAgentRuntimeCRD()
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newReconcilerWithCRD(crd, ns)
+
+	// Pre-create
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarAuthbridge); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Disable sidecar
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarNone); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	_, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend))
+	if err == nil {
+		t.Fatal("AgentRuntime should be deleted when sidecar is disabled")
+	}
+}
+
+func TestEnsureAgentRuntimeCR_NoopWhenSidecarDisabledAndNoCR(t *testing.T) {
+	crd := newAgentRuntimeCRD()
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, false)
+	r := newReconcilerWithCRD(crd, ns)
+
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarNone); err != nil {
+		t.Fatalf("should be no-op: %v", err)
+	}
+}
+
+func TestEnsureAgentRuntimeCR_SkipsWhenCRDNotInstalled(t *testing.T) {
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newFakeReconciler(ns) // no CRD registered
+
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarAuthbridge); err != nil {
+		t.Fatalf("should skip gracefully: %v", err)
+	}
+}
+
+func TestEnsureAgentRuntimeCR_WorksWithEnvoySidecarMode(t *testing.T) {
+	crd := newAgentRuntimeCRD()
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newReconcilerWithCRD(crd, ns)
+
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarEnvoy); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend)); err != nil {
+		t.Fatalf("AgentRuntime should exist for envoy mode: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: deleteAgentRuntimeCR
+// ---------------------------------------------------------------------------
+
+func TestDeleteAgentRuntimeCR_DeletesExisting(t *testing.T) {
+	crd := newAgentRuntimeCRD()
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newReconcilerWithCRD(crd, ns)
+
+	// Pre-create
+	if err := r.ensureAgentRuntimeCR(context.Background(), kn, resources.KagentiSidecarAuthbridge); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	errs := r.deleteAgentRuntimeCR(context.Background(), kn)
+	if len(errs) > 0 {
+		t.Fatalf("delete errors: %v", errs)
+	}
+
+	_, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend))
+	if err == nil {
+		t.Fatal("AgentRuntime should be deleted")
+	}
+}
+
+func TestDeleteAgentRuntimeCR_NoopWhenNotExists(t *testing.T) {
+	crd := newAgentRuntimeCRD()
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newReconcilerWithCRD(crd, ns)
+
+	errs := r.deleteAgentRuntimeCR(context.Background(), kn)
+	if len(errs) > 0 {
+		t.Fatalf("should not error: %v", errs)
+	}
+}
+
+func TestDeleteAgentRuntimeCR_SkipsWhenCRDNotInstalled(t *testing.T) {
+	ns := newTestNamespace(nil)
+	kn := testKubernautCR(true, true)
+	r := newFakeReconciler(ns)
+
+	errs := r.deleteAgentRuntimeCR(context.Background(), kn)
+	if len(errs) > 0 {
+		t.Fatalf("should skip when CRD absent: %v", errs)
+	}
+}

--- a/internal/controller/agentruntime_test.go
+++ b/internal/controller/agentruntime_test.go
@@ -86,10 +86,10 @@ func newReconcilerWithCRD(objs ...runtime.Object) *KubernautReconciler {
 	}
 }
 
-func getAgentRuntime(ctx context.Context, c client.Client, ns, name string) (*unstructured.Unstructured, error) {
+func getAgentRuntime(ctx context.Context, c client.Client, ns string) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(agentRuntimeGVK())
-	return obj, c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, obj)
+	return obj, c.Get(ctx, types.NamespacedName{Namespace: ns, Name: string(resources.ComponentAPIFrontend)}, obj)
 }
 
 // ---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ func TestEnsureAgentRuntimeCR_CreatesWhenSidecarActive(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ar, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend))
+	ar, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace)
 	if err != nil {
 		t.Fatalf("AgentRuntime should exist: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestEnsureAgentRuntimeCR_NoopWhenAlreadyExists(t *testing.T) {
 		t.Fatalf("second call: %v", err)
 	}
 
-	if _, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend)); err != nil {
+	if _, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace); err != nil {
 		t.Fatalf("AgentRuntime should still exist: %v", err)
 	}
 }
@@ -171,7 +171,7 @@ func TestEnsureAgentRuntimeCR_DeletesWhenSidecarDisabled(t *testing.T) {
 		t.Fatalf("delete: %v", err)
 	}
 
-	_, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend))
+	_, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace)
 	if err == nil {
 		t.Fatal("AgentRuntime should be deleted when sidecar is disabled")
 	}
@@ -208,7 +208,7 @@ func TestEnsureAgentRuntimeCR_WorksWithEnvoySidecarMode(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend)); err != nil {
+	if _, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace); err != nil {
 		t.Fatalf("AgentRuntime should exist for envoy mode: %v", err)
 	}
 }
@@ -233,7 +233,7 @@ func TestDeleteAgentRuntimeCR_DeletesExisting(t *testing.T) {
 		t.Fatalf("delete errors: %v", errs)
 	}
 
-	_, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace, string(resources.ComponentAPIFrontend))
+	_, err := getAgentRuntime(context.Background(), r.Client, kn.Namespace)
 	if err == nil {
 		t.Fatal("AgentRuntime should be deleted")
 	}

--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -446,6 +446,9 @@ func (r *KubernautReconciler) phaseDeploy(ctx context.Context, kn *kubernautv1al
 	if err := r.ensureKagentiNamespaceLabel(ctx, kn); err != nil {
 		return err
 	}
+	if err := r.ensureAgentRuntimeCR(ctx, kn, sidecar); err != nil {
+		return err
+	}
 	hasRoute, err := r.deployWorkloads(ctx, kn, cmHashes, sidecar)
 	if err != nil {
 		return err
@@ -1288,6 +1291,77 @@ func (r *KubernautReconciler) ensureKagentiNamespaceLabel(ctx context.Context, k
 	return r.Update(ctx, ns)
 }
 
+// agentRuntimeGVR is the GroupVersionResource for kagenti AgentRuntime CRs.
+var agentRuntimeGVR = schema.GroupVersionResource{
+	Group:    "agent.kagenti.dev",
+	Version:  "v1alpha1",
+	Resource: "agentruntimes",
+}
+
+// ensureAgentRuntimeCR creates or deletes the kagenti AgentRuntime CR for
+// apifrontend. When kagenti sidecar injection is active, the CR tells the
+// kagenti operator to provision authbridge ConfigMaps, SCC RoleBindings,
+// and discovery labels in the kubernaut-system namespace. When sidecar
+// injection is disabled, any existing CR is cleaned up.
+func (r *KubernautReconciler) ensureAgentRuntimeCR(ctx context.Context, kn *kubernautv1alpha1.Kubernaut, sidecar resources.KagentiSidecarMode) error {
+	log := logf.FromContext(ctx)
+
+	if !r.hasCRD(ctx, "agentruntimes.agent.kagenti.dev") {
+		return nil
+	}
+
+	name := string(resources.ComponentAPIFrontend)
+	want := sidecar != resources.KagentiSidecarNone
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: agentRuntimeGVR.Group, Version: agentRuntimeGVR.Version, Kind: "AgentRuntime",
+	})
+	err := r.Get(ctx, client.ObjectKey{Namespace: kn.Namespace, Name: name}, existing)
+
+	if !want {
+		if err == nil {
+			log.Info("deleting AgentRuntime CR (kagenti sidecar disabled)", "name", name)
+			return client.IgnoreNotFound(r.Delete(ctx, existing))
+		}
+		return nil
+	}
+
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": agentRuntimeGVR.Group + "/" + agentRuntimeGVR.Version,
+			"kind":       "AgentRuntime",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": kn.Namespace,
+				"labels": map[string]interface{}{
+					"app.kubernetes.io/managed-by": "kubernaut-operator",
+					"app.kubernetes.io/part-of":    "kubernaut",
+					"app.kubernetes.io/instance":   kn.Name,
+				},
+			},
+			"spec": map[string]interface{}{
+				"type": "agent",
+				"targetRef": map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"name":       name,
+				},
+			},
+		},
+	}
+
+	if apierrors.IsNotFound(err) {
+		log.Info("creating AgentRuntime CR for apifrontend", "name", name)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return fmt.Errorf("checking AgentRuntime CR: %w", err)
+	}
+
+	return nil
+}
+
 func (r *KubernautReconciler) deployAPIFrontendExtras(ctx context.Context, kn *kubernautv1alpha1.Kubernaut) error {
 	afHPA := resources.APIFrontendHPA(kn)
 	if err := r.ensureNamespaced(ctx, kn, afHPA); err != nil {
@@ -1448,6 +1522,7 @@ func (r *KubernautReconciler) deleteClusterScopedResources(ctx context.Context, 
 	errs = append(errs, r.deleteWebhookResources(ctx, kn)...)
 	errs = append(errs, r.deleteWorkflowResources(ctx, kn)...)
 	errs = append(errs, r.deleteSPIREResources(ctx, kn)...)
+	errs = append(errs, r.deleteAgentRuntimeCR(ctx, kn)...)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("cluster-scoped cleanup: %w", errors.Join(errs...))
@@ -1467,6 +1542,22 @@ func (r *KubernautReconciler) deleteSPIREResources(ctx context.Context, kn *kube
 	}
 	if err := r.deleteIfExists(ctx, spiffeID); err != nil {
 		return []error{fmt.Errorf("deleting ClusterSPIFFEID %s: %w", spiffeID.GetName(), err)}
+	}
+	return nil
+}
+
+func (r *KubernautReconciler) deleteAgentRuntimeCR(ctx context.Context, kn *kubernautv1alpha1.Kubernaut) []error {
+	if !r.hasCRD(ctx, "agentruntimes.agent.kagenti.dev") {
+		return nil
+	}
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: agentRuntimeGVR.Group, Version: agentRuntimeGVR.Version, Kind: "AgentRuntime",
+	})
+	obj.SetName(string(resources.ComponentAPIFrontend))
+	obj.SetNamespace(kn.Namespace)
+	if err := r.deleteIfExists(ctx, obj); err != nil {
+		return []error{fmt.Errorf("deleting AgentRuntime %s: %w", obj.GetName(), err)}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Create a kagenti `AgentRuntime` CR for `apifrontend` when kagenti sidecar injection is active, aligning with kagenti's intended integration API
- Delete the `AgentRuntime` CR when kagenti integration is disabled or on Kubernaut CR deletion
- No-op when the `agentruntimes.agent.kagenti.dev` CRD is not installed

## Problem

The operator previously set `kagenti.io/type=agent` directly on the apifrontend Deployment's pod template. This triggers the kagenti mutating webhook to inject authbridge sidecars, but does **not** trigger kagenti's `AgentRuntimeReconciler` to provision the required namespace resources (ConfigMaps, SCC RoleBindings). Without these resources, the injected sidecars fail to start.

The kagenti platform uses the `AgentRuntime` CR as the integration contract for enrolling workloads. When an agent is deployed via the kagenti UI/API, the backend creates an `AgentRuntime` CR, which triggers the `AgentRuntimeReconciler` to:
1. Copy template ConfigMaps from `kagenti-system` (`authbridge-config`, `authbridge-runtime-config`, `envoy-config`, `spiffe-helper-config`)
2. Create the `agent-authbridge-scc` RoleBinding on OpenShift
3. Apply `kagenti.io/type` labels to the workload

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/controller/... -count=1` passes (76s, all green)
- [ ] Deploy on dev cluster and verify apifrontend starts with kagenti sidecars

Closes #164

Made with [Cursor](https://cursor.com)