### PR TITLE
fix: add RBAC rules for AgentRuntime CR management

### DIFF
--- a/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
@@ -98,6 +98,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - agent.kagenti.dev
+          resources:
+          - agentruntimes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - agent.kagenti.dev
+  resources:
+  - agentruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2215,6 +2215,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - agent.kagenti.dev
+  resources:
+  - agentruntimes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -134,6 +134,7 @@ type KubernautReconciler struct {
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules;alertmanagerconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=spire.spiffe.io,resources=clusterspiffeids,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=agent.kagenti.dev,resources=agentruntimes,verbs=get;list;watch;create;update;patch;delete
 func (r *KubernautReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 


### PR DESCRIPTION
## Summary

- Adds `agent.kagenti.dev/agentruntimes` RBAC rules (get/list/watch/create/update/patch/delete) to the operator's ClusterRole
- The operator needs these permissions to manage the `AgentRuntime` CR introduced in #165
- Without these rules the reconciler fails with `403 Forbidden` when checking or creating the CR
- Updates `config/rbac/role.yaml`, the OLM CSV, `dist/install.yaml`, and the kubebuilder RBAC marker

Discovered during dev cluster validation of the AgentRuntime feature.

## Test plan

- [x] Unit tests pass (no new tests needed — RBAC-only change)
- [x] Lint passes
- [x] Validated on dev cluster: after granting equivalent permissions manually, the operator successfully created the `AgentRuntime` CR and kagenti reconciled it to `Active` phase

Made with [Cursor](https://cursor.com)