### PR TITLE
fix: create inter-service-ca ConfigMap before migration job

### DIFF
--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -294,7 +294,21 @@ func (r *KubernautReconciler) ensureMigrationPrereqs(ctx context.Context, kn *ku
 	if err != nil {
 		return fmt.Errorf("building migration configmap: %w", err)
 	}
-	return r.ensureNamespaced(ctx, kn, migrationCM)
+	if err := r.ensureNamespaced(ctx, kn, migrationCM); err != nil {
+		return fmt.Errorf("ensuring migration configmap: %w", err)
+	}
+
+	sslMode := kn.Spec.PostgreSQL.SSLMode
+	if sslMode == "" {
+		sslMode = "verify-full"
+	}
+	if sslMode == "verify-full" {
+		caCM := resources.InterServiceCAConfigMap(kn)
+		if err := r.ensureNamespaced(ctx, kn, caCM); err != nil {
+			return fmt.Errorf("ensuring inter-service-ca configmap: %w", err)
+		}
+	}
+	return nil
 }
 
 // ensureMigrationJob creates the migration Job if absent, then checks its


### PR DESCRIPTION
## Summary

- Moves creation of the `inter-service-ca` ConfigMap from `phaseDeploy` (after migration) to `ensureMigrationPrereqs` (before migration)
- On fresh deployments, the migration job connects to PostgreSQL with `sslmode=verify-full` (default) and mounts `inter-service-ca` as an optional volume. The pod starts but the job fails because the CA cert file doesn't exist yet
- By creating the ConfigMap in the pre-migration step, the OCP service-ca operator injects the CA bundle before the migration job runs

## Test plan

- [x] Unit tests pass
- [x] Lint passes
- [ ] Deploy on dev cluster from a clean state and verify migration succeeds without manual intervention

Made with [Cursor](https://cursor.com)