### PR TITLE
fix: set sslRootCert in datastorage config for verify-full mode

### DIFF
--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -300,9 +300,9 @@ func (r *KubernautReconciler) ensureMigrationPrereqs(ctx context.Context, kn *ku
 
 	sslMode := kn.Spec.PostgreSQL.SSLMode
 	if sslMode == "" {
-		sslMode = "verify-full"
+		sslMode = resources.DefaultSSLMode
 	}
-	if sslMode == "verify-full" {
+	if sslMode == resources.DefaultSSLMode {
 		caCM := resources.InterServiceCAConfigMap(kn)
 		if err := r.ensureNamespaced(ctx, kn, caCM); err != nil {
 			return fmt.Errorf("ensuring inter-service-ca configmap: %w", err)

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -177,6 +177,10 @@ const InterServiceTLSCertDir = "/etc/tls"
 // the bundle under the key "service-ca.crt".
 const InterServiceTLSCAFile = "/etc/tls-ca/service-ca.crt"
 
+// DefaultSSLMode is the PostgreSQL connection SSL mode used when not
+// explicitly configured in the CR.
+const DefaultSSLMode = "verify-full"
+
 // OCP monitoring stack endpoints. These are always available on OCP clusters
 // and are hardcoded rather than discovered (OCP-only operator).
 // Thanos Querier federates both cluster Prometheus and User Workload

--- a/internal/resources/configmaps.go
+++ b/internal/resources/configmaps.go
@@ -128,6 +128,7 @@ type dataStorageDatabaseYAML struct {
 	Name            string `json:"name" yaml:"name"`
 	User            string `json:"user" yaml:"user"`
 	SSLMode         string `json:"sslMode" yaml:"sslMode"`
+	SSLRootCert     string `json:"sslRootCert,omitempty" yaml:"sslRootCert,omitempty"`
 	MaxOpenConns    int    `json:"maxOpenConns" yaml:"maxOpenConns"`
 	MaxIdleConns    int    `json:"maxIdleConns" yaml:"maxIdleConns"`
 	ConnMaxLifetime string `json:"connMaxLifetime" yaml:"connMaxLifetime"`
@@ -755,20 +756,27 @@ func DataStorageConfigMap(kn *kubernautv1alpha1.Kubernaut, dbName, dbUser string
 	cfg := dataStorageConfigYAML{
 		TLSProfile: o.tlsProfile,
 		Server:     dataStorageServerConfig(kn),
-		Database: dataStorageDatabaseYAML{
-			Host:            kn.Spec.PostgreSQL.Host,
-			Port:            pgPort,
-			Name:            dbName,
-			User:            dbUser,
-			SSLMode:         withDefault(kn.Spec.PostgreSQL.SSLMode, "verify-full"),
-			MaxOpenConns:    100,
-			MaxIdleConns:    20,
-			ConnMaxLifetime: "1h",
-			ConnMaxIdleTime: "10m",
-			SecretsFile:     "/etc/datastorage/secrets/db-secrets.yaml",
-			UsernameKey:     "username",
-			PasswordKey:     "password",
-		},
+		Database: func() dataStorageDatabaseYAML {
+			sslMode := withDefault(kn.Spec.PostgreSQL.SSLMode, DefaultSSLMode)
+			db := dataStorageDatabaseYAML{
+				Host:            kn.Spec.PostgreSQL.Host,
+				Port:            pgPort,
+				Name:            dbName,
+				User:            dbUser,
+				SSLMode:         sslMode,
+				MaxOpenConns:    100,
+				MaxIdleConns:    20,
+				ConnMaxLifetime: "1h",
+				ConnMaxIdleTime: "10m",
+				SecretsFile:     "/etc/datastorage/secrets/db-secrets.yaml",
+				UsernameKey:     "username",
+				PasswordKey:     "password",
+			}
+			if sslMode == DefaultSSLMode {
+				db.SSLRootCert = InterServiceTLSCAFile
+			}
+			return db
+		}(),
 		Redis: dataStorageRedisConfig(kn),
 		Logging: dataStorageLoggingYAML{
 			Level:  withDefault(kn.Spec.DataStorage.Logging.Level, "info"),

--- a/internal/resources/migration.go
+++ b/internal/resources/migration.go
@@ -66,7 +66,7 @@ func MigrationJob(kn *kubernautv1alpha1.Kubernaut) (*batchv1.Job, error) {
 		return nil, err
 	}
 
-	sslMode := withDefault(kn.Spec.PostgreSQL.SSLMode, "verify-full")
+	sslMode := withDefault(kn.Spec.PostgreSQL.SSLMode, DefaultSSLMode)
 	dsn := fmt.Sprintf("host=%s port=%d dbname=$(POSTGRES_DB) user=$(POSTGRES_USER) password=$(POSTGRES_PASSWORD) sslmode=%s",
 		kn.Spec.PostgreSQL.Host, pgPort, sslMode)
 
@@ -79,7 +79,7 @@ func MigrationJob(kn *kubernautv1alpha1.Kubernaut) (*batchv1.Job, error) {
 		ReadOnly:  true,
 	}}
 
-	if sslMode == "verify-full" {
+	if sslMode == DefaultSSLMode {
 		dsn += " sslrootcert=" + InterServiceTLSCAFile
 		volumes = append(volumes, optionalConfigMapVolume("tls-ca", InterServiceCAConfigMapName))
 		mounts = append(mounts, corev1.VolumeMount{Name: "tls-ca", MountPath: "/etc/tls-ca", ReadOnly: true})

--- a/internal/resources/validation_test.go
+++ b/internal/resources/validation_test.go
@@ -114,7 +114,7 @@ var _ = Describe("PostgreSQL SSLMode Validation", func() {
 
 	It("accepts sslMode=verify-full", func() {
 		kn := testKubernaut()
-		kn.Spec.PostgreSQL.SSLMode = "verify-full"
+		kn.Spec.PostgreSQL.SSLMode = DefaultSSLMode
 		errs := ValidateKubernaut(kn, KagentiSidecarNone)
 		Expect(errs).To(BeEmpty())
 	})


### PR DESCRIPTION
## Summary

- Adds `sslRootCert` field to the datastorage database config YAML struct
- Sets it to `/etc/tls-ca/service-ca.crt` (the inter-service-ca mount) when `sslMode` is `verify-full`
- Without this, datastorage fails with `x509: certificate signed by unknown authority` because it doesn't know where to find the CA cert even though the volume is mounted
- Extracts `DefaultSSLMode` constant to fix goconst lint

## Test plan

- [x] Unit tests pass
- [x] Lint passes (0 issues)
- [ ] Deploy on dev cluster and verify datastorage connects to PostgreSQL successfully

Made with [Cursor](https://cursor.com)