### PR TITLE
fix: set PGSSLROOTCERT env var on datastorage for verify-full mode

### DIFF
--- a/internal/resources/deployments.go
+++ b/internal/resources/deployments.go
@@ -156,12 +156,16 @@ func DataStorageDeployment(kn *kubernautv1alpha1.Kubernaut) (*appsv1.Deployment,
 		mounts = append(mounts, corev1.VolumeMount{Name: "signing-cert", MountPath: "/etc/certs", ReadOnly: true})
 	}
 
+	sslMode := withDefault(kn.Spec.PostgreSQL.SSLMode, DefaultSSLMode)
 	env := []corev1.EnvVar{
 		{Name: "CONFIG_PATH", Value: "/etc/datastorage/config.yaml"},
 		{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 		}},
 		{Name: "TLS_CA_FILE", Value: InterServiceTLSCAFile},
+	}
+	if sslMode == DefaultSSLMode {
+		env = append(env, corev1.EnvVar{Name: "PGSSLROOTCERT", Value: InterServiceTLSCAFile})
 	}
 
 	var gracePeriod int64 = 60


### PR DESCRIPTION
## Summary
- Sets the `PGSSLROOTCERT` environment variable on the `data-storage` deployment when `sslMode` is `verify-full`, pointing to the mounted service-CA cert at `/etc/tls-ca/service-ca.crt`
- The upstream datastorage binary uses `pgx`/`lib/pq` which respects this standard libpq env var for CA cert lookup. Without it, the driver falls back to system CA certs which don't include the OpenShift service-serving-signer CA, causing `x509: certificate signed by unknown authority` failures
- Complements PR #168 which added `sslRootCert` to the config YAML — this env var provides the fallback the driver actually uses at connection time

## Test plan
- [x] Unit tests pass
- [x] Linter passes (0 issues)
- [x] Validated on dev cluster: data-storage starts cleanly with 0 restarts, full deployment reaches `Running` status


Made with [Cursor](https://cursor.com)