### PR TITLE
chore: update airgap manifests for v1.5.1 release

### DIFF
--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2527,7 +2527,7 @@ spec:
           value: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
         - name: RELATED_IMAGE_INIT_UBI_MINIMAL
           value: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
-        image: quay.io/kubernaut-ai/kubernaut-operator:1.5.0-rc9
+        image: quay.io/kubernaut-ai/kubernaut-operator@sha256:586e5344ec3897fa2e80bab5207f1eca1611fdc4c6db80113247a1539c7941b7
         livenessProbe:
           httpGet:
             path: /healthz

--- a/hack/airgap/generate-imageset.sh
+++ b/hack/airgap/generate-imageset.sh
@@ -13,6 +13,27 @@ VERSION="${1:-$(grep '^VERSION' Makefile | head -1 | awk '{print $NF}')}"
 MANAGER="config/manager/manager.yaml"
 OUT="hack/airgap/imageset-config.yaml"
 
+resolve_digest() {
+  local ref="$1"
+  skopeo inspect "docker://${ref}" 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["Digest"])' 2>/dev/null
+}
+
+OP_TAG="quay.io/kubernaut-ai/kubernaut-operator:${VERSION}"
+BUNDLE_TAG="quay.io/kubernaut-ai/kubernaut-operator-bundle:v${VERSION}"
+
+echo "Resolving operator digest for ${OP_TAG}..."
+OP_DIGEST=$(resolve_digest "$OP_TAG")
+if [[ -z "$OP_DIGEST" ]]; then
+  echo "ERROR: could not resolve digest for ${OP_TAG}" >&2; exit 1
+fi
+
+echo "Resolving bundle digest for ${BUNDLE_TAG}..."
+BUNDLE_DIGEST=$(resolve_digest "$BUNDLE_TAG")
+if [[ -z "$BUNDLE_DIGEST" ]]; then
+  echo "ERROR: could not resolve digest for ${BUNDLE_TAG}" >&2; exit 1
+fi
+
 images=()
 while IFS= read -r img; do
   images+=("$img")
@@ -34,10 +55,10 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   additionalImages:
-    # Operator (quay.io tag omits the v prefix)
-    - name: quay.io/kubernaut-ai/kubernaut-operator:${VERSION}
-    # Operator bundle (quay.io tag keeps the v prefix)
-    - name: quay.io/kubernaut-ai/kubernaut-operator-bundle:v${VERSION}
+    # Operator
+    - name: quay.io/kubernaut-ai/kubernaut-operator@${OP_DIGEST}
+    # Operator bundle
+    - name: quay.io/kubernaut-ai/kubernaut-operator-bundle@${BUNDLE_DIGEST}
     # Operand and infrastructure images
 HEADER
 

--- a/hack/airgap/imageset-config.yaml
+++ b/hack/airgap/imageset-config.yaml
@@ -8,15 +8,15 @@
 #   oc-mirror --config hack/airgap/imageset-config.yaml \
 #     docker://<mirror-registry>
 #
-# Version: v1.5.0
+# Version: v1.5.1
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   additionalImages:
-    # Operator (quay.io tag omits the v prefix)
-    - name: quay.io/kubernaut-ai/kubernaut-operator:1.5.0
-    # Operator bundle (quay.io tag keeps the v prefix)
-    - name: quay.io/kubernaut-ai/kubernaut-operator-bundle:v1.5.0
+    # Operator
+    - name: quay.io/kubernaut-ai/kubernaut-operator@sha256:586e5344ec3897fa2e80bab5207f1eca1611fdc4c6db80113247a1539c7941b7
+    # Operator bundle
+    - name: quay.io/kubernaut-ai/kubernaut-operator-bundle@sha256:7e26ed41d96b94483bb0d4d971e2f93a541c586ebc56c3902a077f3849943119
     # Operand and infrastructure images
     - name: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
     - name: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946


### PR DESCRIPTION
## Summary
- Pins the operator image in `dist/install.yaml` to the v1.5.1 release digest (`sha256:586e5344ec...`)
- Regenerates `hack/airgap/imageset-config.yaml` with v1.5.1 operator and bundle image references

## Test plan
- [x] `dist/install.yaml` references the correct v1.5.1 digest
- [x] `hack/airgap/imageset-config.yaml` generated via `generate-imageset.sh` with VERSION=1.5.1


Made with [Cursor](https://cursor.com)