### PR TITLE
fix: use quay.io/kubernaut-ai/ for all operand image references

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,6 +83,8 @@ spec:
           value: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
         - name: RELATED_IMAGE_CONSOLE
           value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+        - name: RELATED_IMAGE_OAUTH2_PROXY
+          value: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
         - name: RELATED_IMAGE_INIT_POSTGRES
           value: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
         - name: RELATED_IMAGE_INIT_UBI_MINIMAL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,31 +58,31 @@ spec:
         name: manager
         env:
         - name: RELATED_IMAGE_GATEWAY
-          value: ghcr.io/jordigilh/kubernaut/gateway@sha256:e8d8a12bd830bf5edf0edf816d46c385e90041108779f04f3a175838b864cf5f
+          value: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
         - name: RELATED_IMAGE_DATA_STORAGE
-          value: ghcr.io/jordigilh/kubernaut/datastorage@sha256:89e021bd8ee8bdc4572d008e44667c4a115d81b4494dc7324f40f7188108f76c
+          value: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
         - name: RELATED_IMAGE_AIANALYSIS
-          value: ghcr.io/jordigilh/kubernaut/aianalysis@sha256:ce96ef1b51710c334ca050edf6c769fea966abe5956bd7e9bf5d78035c32f092
+          value: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
         - name: RELATED_IMAGE_SIGNALPROCESSING
-          value: ghcr.io/jordigilh/kubernaut/signalprocessing@sha256:ac55be6bed09816f086dc0ef10f9437bd10bde61d3864b7000d38eed0f8e58f8
+          value: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
         - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-          value: ghcr.io/jordigilh/kubernaut/remediationorchestrator@sha256:ede16524ff492f4f6ba56f6f453d0d5ca9293e25aed2b52b7eb6762b1b538972
+          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
         - name: RELATED_IMAGE_WORKFLOWEXECUTION
-          value: ghcr.io/jordigilh/kubernaut/workflowexecution@sha256:5efe581af2119db0a54f8e17afb00aeb48fe953a05ce3149eef9c9469f0f7106
+          value: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
         - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-          value: ghcr.io/jordigilh/kubernaut/effectivenessmonitor@sha256:c26b70dc069b9cbdeb062bd02cff23c61a96717bb28d8c308fba53ef576457fa
+          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
         - name: RELATED_IMAGE_NOTIFICATION
-          value: ghcr.io/jordigilh/kubernaut/notification@sha256:697d7b02a2bdfa9f601a29899fa0138324e57b8c518532eb4c1e515e8783fd5b
+          value: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
         - name: RELATED_IMAGE_KUBERNAUT_AGENT
-          value: ghcr.io/jordigilh/kubernaut/kubernautagent@sha256:e9aa02d8e710feb139031ac02fccfa22c903d1235312c900634a738a9bfdd907
+          value: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
         - name: RELATED_IMAGE_AUTHWEBHOOK
-          value: ghcr.io/jordigilh/kubernaut/authwebhook@sha256:ee465e54614b45738cb5074d448e209ccc69d2d8f95c013a1718035f87c88582
+          value: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
         - name: RELATED_IMAGE_API_FRONTEND
-          value: ghcr.io/jordigilh/kubernaut/apifrontend@sha256:ee53550cd41cfe77d2b17c390f221529cf2e4e031750c48051bad6650db97463
+          value: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
         - name: RELATED_IMAGE_DB_MIGRATE
-          value: ghcr.io/jordigilh/kubernaut/db-migrate@sha256:4ed88bd1a417b86f47caef9d353e5f09a427450971a289865a82be5e13a6db8c
+          value: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
         - name: RELATED_IMAGE_CONSOLE
-          value: ghcr.io/jordigilh/kubernaut-console:latest
+          value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
         - name: RELATED_IMAGE_INIT_POSTGRES
           value: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
         - name: RELATED_IMAGE_INIT_UBI_MINIMAL

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -77,6 +77,7 @@ var _ = BeforeSuite(func() {
 		"RELATED_IMAGE_CONSOLE":                 "quay.io/kubernaut-ai/console:test",
 		"RELATED_IMAGE_DB_MIGRATE":              "quay.io/kubernaut-ai/db-migrate:test",
 		"RELATED_IMAGE_INIT_UBI_MINIMAL":        "registry.access.redhat.com/ubi10/ubi-minimal:latest",
+		"RELATED_IMAGE_OAUTH2_PROXY":            "quay.io/oauth2-proxy/oauth2-proxy:v7.9.0",
 	} {
 		Expect(os.Setenv(k, v)).To(Succeed())
 	}

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -290,6 +290,7 @@ var componentEnvSuffix = map[string]string{
 	"db-migrate":              "DB_MIGRATE",
 	"init-ubi-minimal":        "INIT_UBI_MINIMAL",
 	"console":                 "CONSOLE",
+	"oauth2-proxy":            "OAUTH2_PROXY",
 }
 
 // ResolveImage returns the fully-qualified container image for a component.

--- a/internal/resources/console.go
+++ b/internal/resources/console.go
@@ -31,9 +31,8 @@ import (
 )
 
 const (
-	consoleOAuth2ProxyImage = "quay.io/oauth2-proxy/oauth2-proxy:v7.9.0"
-	consoleProxyPort        = int32(4180)
-	consoleStaticPort       = int32(8080)
+	consoleProxyPort  = int32(4180)
+	consoleStaticPort = int32(8080)
 )
 
 // ConsoleDeployment builds the Deployment for the standalone web console.
@@ -41,6 +40,10 @@ const (
 // used to derive the oauth2-proxy redirect URL when console.route.host is empty.
 func ConsoleDeployment(kn *kubernautv1alpha1.Kubernaut, ingressDomain string) (*appsv1.Deployment, error) {
 	consoleImage, err := ResolveImage(kn, "console")
+	if err != nil {
+		return nil, err
+	}
+	oauth2ProxyImage, err := ResolveImage(kn, "oauth2-proxy")
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +100,7 @@ func ConsoleDeployment(kn *kubernautv1alpha1.Kubernaut, ingressDomain string) (*
 					Containers: []corev1.Container{
 						{
 							Name:  "oauth2-proxy",
-							Image: consoleOAuth2ProxyImage,
+							Image: oauth2ProxyImage,
 							Args:  oauthArgs,
 							Env: []corev1.EnvVar{
 								{Name: "OAUTH2_PROXY_CLIENT_ID", ValueFrom: &corev1.EnvVarSource{

--- a/internal/resources/console_test.go
+++ b/internal/resources/console_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Console Resources", func() {
 
 			oauth2 := spec.Containers[0]
 			Expect(oauth2.Name).To(Equal("oauth2-proxy"))
-			Expect(oauth2.Image).To(Equal(consoleOAuth2ProxyImage))
+			Expect(oauth2.Image).To(Equal("quay.io/oauth2-proxy/oauth2-proxy:v7.9.0"))
 			Expect(*oauth2.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
 			Expect(*oauth2.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
 			Expect(oauth2.Ports).To(HaveLen(1))

--- a/internal/resources/suite_test.go
+++ b/internal/resources/suite_test.go
@@ -45,6 +45,7 @@ var _ = BeforeSuite(func() {
 		"RELATED_IMAGE_CONSOLE":                 "quay.io/kubernaut-ai/console:v1.3.0",
 		"RELATED_IMAGE_DB_MIGRATE":              "quay.io/kubernaut-ai/db-migrate:v1.3.0",
 		"RELATED_IMAGE_INIT_UBI_MINIMAL":        "registry.access.redhat.com/ubi10/ubi-minimal:latest",
+		"RELATED_IMAGE_OAUTH2_PROXY":            "quay.io/oauth2-proxy/oauth2-proxy:v7.9.0",
 	} {
 		Expect(os.Setenv(k, v)).To(Succeed())
 	}
@@ -66,6 +67,7 @@ var _ = AfterSuite(func() {
 		"RELATED_IMAGE_CONSOLE",
 		"RELATED_IMAGE_DB_MIGRATE",
 		"RELATED_IMAGE_INIT_UBI_MINIMAL",
+		"RELATED_IMAGE_OAUTH2_PROXY",
 	} {
 		Expect(os.Unsetenv(k)).To(Succeed())
 	}


### PR DESCRIPTION
## Summary

- Restores all `RELATED_IMAGE_*` env vars in `config/manager/manager.yaml` to use the production registry `quay.io/kubernaut-ai/` instead of `ghcr.io/jordigilh/kubernaut/`
- Pins `RELATED_IMAGE_CONSOLE` to `quay.io/kubernaut-ai/kubernaut-console@sha256:...` by digest (was previously `ghcr.io/jordigilh/kubernaut-console:latest`)
- The v1.5.2 release was deleted and will be re-cut from `main` after this PR merges

## Test plan

- [ ] Verify all `RELATED_IMAGE_*` values reference `quay.io/kubernaut-ai/`
- [ ] Verify no `ghcr.io` references remain in `manager.yaml`
- [ ] After merge, re-tag v1.5.2 and confirm release workflow succeeds


Made with [Cursor](https://cursor.com)