### PR TITLE
chore: update air-gap manifests and image digests for v1.5.2

### DIFF
--- a/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
@@ -4,16 +4,51 @@ metadata:
   annotations:
     alm-examples: "[\n  {\n    \"apiVersion\": \"kubernaut.ai/v1alpha1\",\n    \"kind\": \"Kubernaut\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\"\
       ,\n        \"app.kubernetes.io/name\": \"kubernaut-operator\"\n      },\n      \"name\": \"kubernaut\",\n      \"namespace\": \"kubernaut-system\"\n    },\n    \"spec\": {\n      \"aiAnalysis\": {\n\
-      \        \"policy\": {\n          \"configMapName\": \"aianalysis-policies\"\n        }\n      },\n      \"gateway\": {\n        \"route\": {\n          \"enabled\": true\n        }\n      },\n  \
-      \    \"kubernautAgent\": {\n        \"llm\": {\n          \"credentialsSecretName\": \"llm-credentials\",\n          \"model\": \"claude-sonnet-4-6\",\n          \"provider\": \"vertex_ai\"\n    \
-      \    }\n      },\n      \"monitoring\": {\n        \"enabled\": true\n      },\n      \"postgresql\": {\n        \"host\": \"postgresql.kubernaut-system.svc.cluster.local\",\n        \"port\": 5432,\n\
-      \        \"secretName\": \"postgresql-secret\"\n      },\n      \"signalProcessing\": {\n        \"policy\": {\n          \"configMapName\": \"signalprocessing-policy\"\n        }\n      },\n    \
-      \  \"valkey\": {\n        \"host\": \"valkey.kubernaut-system.svc.cluster.local\",\n        \"port\": 6379,\n        \"secretName\": \"valkey-secret\"\n      }\n    }\n  }\n]"
+      \        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"policy\": {\n          \"configMapName\": \"aianalysis-policies\"\n        }\n      },\n      \"ansible\": {\n       \
+      \ \"enabled\": false\n      },\n      \"apiFrontend\": {\n        \"auth\": {\n          \"allowInsecureIssuers\": true,\n          \"audience\": \"https://keycloak-keycloak.apps.dev.redhat-internal.com/realms/kagenti\"\
+      ,\n          \"issuerURL\": \"https://keycloak-keycloak.apps.dev.redhat-internal.com/realms/kagenti\",\n          \"jwksURL\": \"http://keycloak-service.keycloak:8080/realms/kagenti/protocol/openid-connect/certs\"\
+      \n        },\n        \"enabled\": true,\n        \"logging\": {\n          \"level\": \"debug\"\n        },\n        \"rateLimit\": {\n          \"ipRequestsPerSec\": 50,\n          \"maxConcurrentSessions\"\
+      : 100,\n          \"toolCallsPerMinute\": 60,\n          \"userRequestsPerSec\": 20\n        },\n        \"rbac\": {\n          \"roleBindings\": [\n            {\n              \"groups\": [\n  \
+      \              \"platform-engineering\"\n              ],\n              \"role\": \"sre\"\n            },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n \
+      \             ],\n              \"role\": \"ai-orchestrator\"\n            },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n              ],\n            \
+      \  \"role\": \"cicd\"\n            },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n              ],\n              \"role\": \"observability\"\n         \
+      \   },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n              ],\n              \"role\": \"l3-audit\"\n            },\n            {\n              \"\
+      groups\": [\n                \"platform-engineering\"\n              ],\n              \"role\": \"remediation-approver\"\n            }\n          ],\n          \"sarCacheTTL\": \"30s\"\n       \
+      \ },\n        \"route\": {\n          \"enabled\": false\n        },\n        \"shutdown\": {\n          \"drainSeconds\": 15\n        },\n        \"spire\": {\n          \"className\": \"zero-trust-workload-identity-manager-spire\"\
+      ,\n          \"enabled\": true\n        }\n      },\n      \"authWebhook\": {\n        \"logging\": {\n          \"level\": \"info\"\n        }\n      },\n      \"console\": {\n        \"auth\": {\n\
+      \          \"secretName\": \"kubernaut-console-oidc\"\n        },\n        \"enabled\": true,\n        \"route\": {\n          \"enabled\": true\n        }\n      },\n      \"dataStorage\": {\n  \
+      \      \"endpointPropagationDelay\": \"10s\",\n        \"logging\": {\n          \"level\": \"info\"\n        }\n      },\n      \"effectivenessMonitor\": {\n        \"assessment\": {\n          \"\
+      stabilizationWindow\": \"30s\",\n          \"validityWindow\": \"300s\"\n        },\n        \"logging\": {\n          \"level\": \"info\"\n        }\n      },\n      \"gateway\": {\n        \"config\"\
+      : {\n          \"cors\": {\n            \"allowCredentials\": false,\n            \"maxAge\": 300\n          },\n          \"deduplicationCooldown\": \"5m\",\n          \"k8sRequestTimeout\": \"15s\"\
+      \n        },\n        \"enabled\": false,\n        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"route\": {\n          \"enabled\": false\n        }\n      },\n      \"image\"\
+      : {\n        \"pullPolicy\": \"IfNotPresent\"\n      },\n      \"kubernautAgent\": {\n        \"alignmentCheck\": {\n          \"enabled\": false,\n          \"maxStepTokens\": 500,\n          \"\
+      timeout\": \"10s\"\n        },\n        \"audit\": {\n          \"enabled\": true\n        },\n        \"interactive\": {\n          \"enabled\": true,\n          \"inactivityTimeout\": \"10m\",\n\
+      \          \"maxConcurrentSessions\": 10,\n          \"rateLimitPerUser\": 10,\n          \"sessionTTL\": \"30m\"\n        },\n        \"llm\": {\n          \"credentialsSecretName\": \"llm-credentials\"\
+      ,\n          \"maxRetries\": 3,\n          \"model\": \"claude-sonnet-4-6\",\n          \"phaseModels\": {\n            \"workflow_discovery\": {\n              \"model\": \"claude-haiku-4-5\"\n \
+      \           }\n          },\n          \"provider\": \"vertex_ai\",\n          \"timeoutSeconds\": 120,\n          \"vertexLocation\": \"global\",\n          \"vertexProject\": \"itpc-gcp-eco-eng-claude\"\
+      \n        },\n        \"logging\": {\n          \"level\": \"debug\"\n        },\n        \"maxTurns\": 40,\n        \"safety\": {\n          \"anomaly\": {\n            \"maxRepeatedFailures\": 3,\n\
+      \            \"maxToolCallsPerTool\": 10,\n            \"maxTotalToolCalls\": 40\n          },\n          \"sanitization\": {\n            \"credentialScrubEnabled\": true,\n            \"injectionPatternsEnabled\"\
+      : true\n          }\n        },\n        \"serverRateLimit\": {\n          \"burst\": 100,\n          \"requestsPerSecond\": 50\n        },\n        \"session\": {\n          \"ttl\": \"30m\"\n  \
+      \      },\n        \"shutdown\": {\n          \"drainSeconds\": 15\n        },\n        \"summarizer\": {\n          \"maxToolOutputSize\": 100000,\n          \"threshold\": 8000\n        }\n    \
+      \  },\n      \"monitoring\": {\n        \"enabled\": true\n      },\n      \"networkPolicies\": {\n        \"enabled\": false\n      },\n      \"notification\": {\n        \"logging\": {\n       \
+      \   \"level\": \"info\"\n        },\n        \"slack\": {\n          \"channel\": \"#kubernaut-alerts\",\n          \"secretName\": \"slack-webhook\"\n        }\n      },\n      \"postgresql\": {\n\
+      \        \"host\": \"postgresql.kubernaut-system.svc.cluster.local\",\n        \"port\": 5432,\n        \"secretName\": \"postgresql-secret\",\n        \"sslMode\": \"require\"\n      },\n      \"\
+      remediationOrchestrator\": {\n        \"asyncPropagation\": {\n          \"gitOpsSyncDelay\": \"10s\",\n          \"operatorReconcileDelay\": \"1m\",\n          \"proactiveAlertDelay\": \"5m\"\n \
+      \       },\n        \"dryRun\": false,\n        \"dryRunHoldPeriod\": \"1h\",\n        \"effectivenessAssessment\": {\n          \"stabilizationWindow\": \"2m20s\"\n        },\n        \"logging\"\
+      : {\n          \"level\": \"info\"\n        },\n        \"notifications\": {\n          \"notifySelfResolved\": false\n        },\n        \"retention\": {\n          \"period\": \"24h\"\n       \
+      \ },\n        \"routing\": {\n          \"consecutiveFailureCooldown\": \"1h\",\n          \"consecutiveFailureThreshold\": 3,\n          \"exponentialBackoffBase\": \"1m\",\n          \"exponentialBackoffMax\"\
+      : \"10m\",\n          \"exponentialBackoffMaxExponent\": 4,\n          \"ineffectiveChainThreshold\": 3,\n          \"ineffectiveTimeWindow\": \"4h\",\n          \"noActionRequiredDelayHours\": 24,\n\
+      \          \"recentlyRemediatedCooldown\": \"5m\",\n          \"recurrenceCountThreshold\": 5,\n          \"scopeBackoffBase\": \"5s\",\n          \"scopeBackoffMax\": \"5m\"\n        },\n       \
+      \ \"timeouts\": {\n          \"analyzing\": \"10m\",\n          \"awaitingApproval\": \"15m\",\n          \"executing\": \"30m\",\n          \"global\": \"1h\",\n          \"processing\": \"5m\",\n\
+      \          \"verifying\": \"30m\"\n        }\n      },\n      \"signalProcessing\": {\n        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"policy\": {\n          \"configMapName\"\
+      : \"signalprocessing-policy\"\n        }\n      },\n      \"valkey\": {\n        \"host\": \"valkey.kubernaut-system.svc.cluster.local\",\n        \"port\": 6379,\n        \"secretName\": \"valkey-secret\"\
+      \n      },\n      \"workflowExecution\": {\n        \"cooldownPeriod\": \"1m\",\n        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"workflowNamespace\": \"kubernaut-workflows\"\
+      \n      }\n    }\n  }\n]"
     capabilities: Full Lifecycle
     categories: AI/Machine Learning,Monitoring
     com.redhat.openshift.versions: v4.18
-    containerImage: quay.io/kubernaut-ai/kubernaut-operator:1.5.0
-    createdAt: '2026-06-10T17:54:24Z'
+    containerImage: quay.io/kubernaut-ai/kubernaut-operator@sha256:6e3f88fd84b2dbc14d7e8e9cf2ab7bbe20286f94268255c0094bd41356e20ce9
+    createdAt: '2026-06-21T14:24:35Z'
     description: "Automated Kubernetes remediation powered by AI \u2014 detects issues, analyzes root causes, and executes verified fixes."
     documentation: https://jordigilh.github.io/kubernaut-docs/latest/
     features.operators.openshift.io/cnf: 'false'
@@ -31,7 +66,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/jordigilh/kubernaut-operator
     support: jgil@redhat.com
-  name: kubernaut-operator.v1.5.0
+  name: kubernaut-operator.v1.5.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -61,6 +96,18 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - agent.kagenti.dev
+          resources:
+          - agentruntimes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - ''
           resources:
           - configmaps
@@ -89,18 +136,6 @@ spec:
           resources:
           - mutatingwebhookconfigurations
           - validatingwebhookconfigurations
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - agent.kagenti.dev
-          resources:
-          - agentruntimes
           verbs:
           - create
           - delete
@@ -160,6 +195,7 @@ spec:
           - config.openshift.io
           resources:
           - apiservers
+          - ingresses
           verbs:
           - get
           - list
@@ -312,34 +348,38 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_GATEWAY
-                  value: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
+                  value: quay.io/kubernaut-ai/gateway@sha256:5a034c54881b93c94707099bb35fc85df4f15dd5847653399688747ce12095ab
                 - name: RELATED_IMAGE_DATA_STORAGE
-                  value: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
+                  value: quay.io/kubernaut-ai/datastorage@sha256:2b784714a594375dee310acdc7c34df09d1e7f625bbc6d439898fe4b8d04e26d
                 - name: RELATED_IMAGE_AIANALYSIS
-                  value: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
+                  value: quay.io/kubernaut-ai/aianalysis@sha256:11e60b614c956b2b31b644c8c280aacf317c4d4592d67e2da47612fc29d69aa1
                 - name: RELATED_IMAGE_SIGNALPROCESSING
-                  value: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
+                  value: quay.io/kubernaut-ai/signalprocessing@sha256:5895a2c66a35afffd6b470474d910bc4d39b6e0801af44e8eb47e2629d5a203c
                 - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-                  value: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
+                  value: quay.io/kubernaut-ai/remediationorchestrator@sha256:8637fa8681284ee306eedf9ee67ee5480a1248a9292adfa6e16332eeeb6bb193
                 - name: RELATED_IMAGE_WORKFLOWEXECUTION
-                  value: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
+                  value: quay.io/kubernaut-ai/workflowexecution@sha256:e621977c7bd64c34ddad4bd94861af75ee7981d1d75d1574fba5748b887cfd39
                 - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-                  value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
+                  value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:d04437a3e5694db80bc5a225958a9402be01b9832f2d59c1413cf81c52174d16
                 - name: RELATED_IMAGE_NOTIFICATION
-                  value: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
+                  value: quay.io/kubernaut-ai/notification@sha256:9857c2384aa9c7866730bbf0160b68ecf6c7d4444355ef0d78ea368f6e291e8a
                 - name: RELATED_IMAGE_KUBERNAUT_AGENT
-                  value: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
+                  value: quay.io/kubernaut-ai/kubernautagent@sha256:6487b59e9b955bdaa0fb47fef18c5012c81e41415bf1f954a81abfbacbed55dc
                 - name: RELATED_IMAGE_AUTHWEBHOOK
-                  value: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
+                  value: quay.io/kubernaut-ai/authwebhook@sha256:63c619adfc80d8e433635377b0c3af732055dc83f61e0274615964b1bc9aa31a
                 - name: RELATED_IMAGE_API_FRONTEND
-                  value: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
+                  value: quay.io/kubernaut-ai/apifrontend@sha256:2aee7ef17f7632d8dd2d426036aceb19d04a5cafd9a6f0f499215216314ef0fa
                 - name: RELATED_IMAGE_DB_MIGRATE
-                  value: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
+                  value: quay.io/kubernaut-ai/db-migrate@sha256:4a25f7165fd86ad70437c7fdb3c5268630e3069095cf66c329972a99cfa7cf80
+                - name: RELATED_IMAGE_CONSOLE
+                  value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+                - name: RELATED_IMAGE_OAUTH2_PROXY
+                  value: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
                 - name: RELATED_IMAGE_INIT_POSTGRES
                   value: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
                 - name: RELATED_IMAGE_INIT_UBI_MINIMAL
                   value: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
-                image: quay.io/kubernaut-ai/kubernaut-operator:1.5.0
+                image: quay.io/kubernaut-ai/kubernaut-operator@sha256:6e3f88fd84b2dbc14d7e8e9cf2ab7bbe20286f94268255c0094bd41356e20ce9
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -441,35 +481,39 @@ spec:
     name: Kubernaut AI
     url: https://github.com/jordigilh/kubernaut
   relatedImages:
-  - image: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
+  - image: quay.io/kubernaut-ai/gateway@sha256:5a034c54881b93c94707099bb35fc85df4f15dd5847653399688747ce12095ab
     name: gateway
-  - image: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
+  - image: quay.io/kubernaut-ai/datastorage@sha256:2b784714a594375dee310acdc7c34df09d1e7f625bbc6d439898fe4b8d04e26d
     name: data-storage
-  - image: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
+  - image: quay.io/kubernaut-ai/aianalysis@sha256:11e60b614c956b2b31b644c8c280aacf317c4d4592d67e2da47612fc29d69aa1
     name: aianalysis
-  - image: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
+  - image: quay.io/kubernaut-ai/signalprocessing@sha256:5895a2c66a35afffd6b470474d910bc4d39b6e0801af44e8eb47e2629d5a203c
     name: signalprocessing
-  - image: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
+  - image: quay.io/kubernaut-ai/remediationorchestrator@sha256:8637fa8681284ee306eedf9ee67ee5480a1248a9292adfa6e16332eeeb6bb193
     name: remediationorchestrator
-  - image: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
+  - image: quay.io/kubernaut-ai/workflowexecution@sha256:e621977c7bd64c34ddad4bd94861af75ee7981d1d75d1574fba5748b887cfd39
     name: workflowexecution
-  - image: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
+  - image: quay.io/kubernaut-ai/effectivenessmonitor@sha256:d04437a3e5694db80bc5a225958a9402be01b9832f2d59c1413cf81c52174d16
     name: effectivenessmonitor
-  - image: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
+  - image: quay.io/kubernaut-ai/notification@sha256:9857c2384aa9c7866730bbf0160b68ecf6c7d4444355ef0d78ea368f6e291e8a
     name: notification
-  - image: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
+  - image: quay.io/kubernaut-ai/kubernautagent@sha256:6487b59e9b955bdaa0fb47fef18c5012c81e41415bf1f954a81abfbacbed55dc
     name: kubernaut-agent
-  - image: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
+  - image: quay.io/kubernaut-ai/authwebhook@sha256:63c619adfc80d8e433635377b0c3af732055dc83f61e0274615964b1bc9aa31a
     name: authwebhook
-  - image: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
+  - image: quay.io/kubernaut-ai/apifrontend@sha256:2aee7ef17f7632d8dd2d426036aceb19d04a5cafd9a6f0f499215216314ef0fa
     name: api-frontend
-  - image: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
+  - image: quay.io/kubernaut-ai/db-migrate@sha256:4a25f7165fd86ad70437c7fdb3c5268630e3069095cf66c329972a99cfa7cf80
     name: db-migrate
+  - image: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+    name: console
+  - image: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+    name: oauth2-proxy
   - image: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
     name: init-postgres
   - image: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
     name: init-ubi-minimal
-  version: 1.5.0
+  version: 1.5.2
   webhookdefinitions:
   - type: ValidatingAdmissionWebhook
     admissionReviewVersions:

--- a/bundle/manifests/kubernaut.ai_kubernauts.yaml
+++ b/bundle/manifests/kubernaut.ai_kubernauts.yaml
@@ -225,7 +225,10 @@ spec:
                           session authenticity).'
                         type: string
                       issuerURL:
-                        description: OIDC issuer URL (e.g. "https://login.kubernaut.ai/realms/kubernaut").
+                        description: |-
+                          OIDC issuer URL (e.g. "https://login.kubernaut.ai/realms/kubernaut").
+                          Used for single-provider auth or kagenti auto-detection fallback.
+                          When jwtProviders is non-empty, multi-provider config takes precedence.
                         type: string
                       jwksURL:
                         description: |-
@@ -233,6 +236,60 @@ spec:
                           (FedRAMP IA-5: authenticator management). When empty, derived from
                           issuerURL + "/protocol/openid-connect/certs".
                         type: string
+                      jwtProviders:
+                        description: |-
+                          Multi-provider JWT configuration (FedRAMP IA-2: multi-source auth).
+                          When non-empty, the AF validates tokens against all configured
+                          providers concurrently. Takes precedence over the single-provider
+                          issuerURL/audience/jwksURL fields above.
+                        items:
+                          description: |-
+                            JWTProviderSpec configures a single OIDC JWT provider for multi-issuer
+                            authentication. Shared by KA interactive and API Frontend auth.
+                          properties:
+                            audiences:
+                              description: Expected audience claim values for session
+                                authenticity (FedRAMP SC-23).
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            claimMappings:
+                              description: Claim mappings for username and group extraction
+                                (FedRAMP AC-6).
+                              properties:
+                                groups:
+                                  description: JWT claim name for group membership
+                                    extraction.
+                                  type: string
+                                username:
+                                  description: JWT claim name for username extraction.
+                                  type: string
+                              type: object
+                            issuerURL:
+                              description: OIDC issuer URL for token validation.
+                              minLength: 1
+                              type: string
+                            jwksURL:
+                              description: |-
+                                JWKS endpoint URL for token signature verification. When empty,
+                                derived from IssuerURL. Must use HTTPS unless the parent's
+                                allowInsecureJWKS/allowInsecureIssuers flag is true.
+                              maxLength: 2048
+                              type: string
+                            name:
+                              description: Human-readable name for this provider (e.g.
+                                "rhbk", "spire").
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                          required:
+                          - audiences
+                          - issuerURL
+                          - name
+                          type: object
+                        maxItems: 8
+                        type: array
                       oidcCaFile:
                         description: |-
                           Path to CA bundle for OIDC/JWKS TLS trust (FedRAMP IA-5). When set,
@@ -317,9 +374,18 @@ spec:
                         description: RoleBindings maps persona-based tool roles to
                           OIDC groups.
                         items:
-                          description: ToolRoleBinding binds a persona-based tool
-                            role to one or more OIDC groups.
+                          description: |-
+                            ToolRoleBinding binds a tool role to one or more OIDC groups.
+                            Exactly one of Role or ClusterRoleName must be set.
                           properties:
+                            clusterRoleName:
+                              description: |-
+                                ClusterRoleName references a user-managed ClusterRole for custom tool authorization.
+                                The operator creates only the ClusterRoleBinding; the ClusterRole itself must be
+                                pre-created by the user with rules granting verb "use" on resource "tools" in
+                                apiGroup "kubernaut.ai".
+                                Mutually exclusive with Role.
+                              type: string
                             groups:
                               description: Groups are the OIDC group names to bind
                                 to this role.
@@ -329,8 +395,9 @@ spec:
                               type: array
                             role:
                               description: |-
-                                Role is the persona name. Must be one of: sre, ai-orchestrator, cicd,
+                                Role is a built-in persona name. Must be one of: sre, ai-orchestrator, cicd,
                                 observability, l3-audit, remediation-approver.
+                                Mutually exclusive with ClusterRoleName.
                               enum:
                               - sre
                               - ai-orchestrator
@@ -341,7 +408,6 @@ spec:
                               type: string
                           required:
                           - groups
-                          - role
                           type: object
                         type: array
                       sarCacheTTL:
@@ -553,6 +619,99 @@ spec:
                           otherwise to an implementation-defined value. Requests cannot exceed Limits.
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
+                    type: object
+                type: object
+              console:
+                description: Console configures the standalone web console (A2A chat
+                  UI).
+                properties:
+                  auth:
+                    description: OIDC authentication configuration for the console
+                      oauth2-proxy.
+                    properties:
+                      secretName:
+                        description: |-
+                          Name of the pre-existing Secret containing OIDC credentials.
+                          Required keys: client-id, client-secret, cookie-secret.
+                        minLength: 1
+                        type: string
+                    type: object
+                  enabled:
+                    default: false
+                    description: Whether the Console component is deployed. Defaults
+                      to false (opt-in).
+                    type: boolean
+                  resources:
+                    description: Resource requirements for the console container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  route:
+                    description: OCP Route configuration for external access.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Whether to create an OCP Route. Defaults to true
+                          on OpenShift.
+                        type: boolean
+                      host:
+                        description: Explicit hostname. Empty = auto-derived from
+                          namespace.
+                        type: string
                     type: object
                 type: object
               dataStorage:
@@ -1033,29 +1192,49 @@ spec:
                       jwtProviders:
                         description: JWT providers for OIDC-based identity delegation.
                         items:
-                          description: JWTProviderSpec configures a single OIDC JWT
-                            provider.
+                          description: |-
+                            JWTProviderSpec configures a single OIDC JWT provider for multi-issuer
+                            authentication. Shared by KA interactive and API Frontend auth.
                           properties:
-                            audience:
-                              description: Expected audience claim value.
-                              type: string
-                            issuer:
-                              description: Expected issuer claim value.
+                            audiences:
+                              description: Expected audience claim values for session
+                                authenticity (FedRAMP SC-23).
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            claimMappings:
+                              description: Claim mappings for username and group extraction
+                                (FedRAMP AC-6).
+                              properties:
+                                groups:
+                                  description: JWT claim name for group membership
+                                    extraction.
+                                  type: string
+                                username:
+                                  description: JWT claim name for username extraction.
+                                  type: string
+                              type: object
+                            issuerURL:
+                              description: OIDC issuer URL for token validation.
+                              minLength: 1
                               type: string
                             jwksURL:
-                              description: JWKS endpoint URL. Must use HTTPS unless
-                                allowInsecureJWKS is true.
+                              description: |-
+                                JWKS endpoint URL for token signature verification. When empty,
+                                derived from IssuerURL. Must use HTTPS unless the parent's
+                                allowInsecureJWKS/allowInsecureIssuers flag is true.
                               maxLength: 2048
-                              minLength: 1
                               type: string
                             name:
                               description: Human-readable name for this provider (e.g.
-                                "rhbk", "auth0").
+                                "rhbk", "spire").
                               maxLength: 63
                               minLength: 1
                               type: string
                           required:
-                          - jwksURL
+                          - audiences
+                          - issuerURL
                           - name
                           type: object
                         maxItems: 8
@@ -1122,6 +1301,32 @@ spec:
                             description: Token endpoint URL.
                             type: string
                         type: object
+                      phaseModels:
+                        additionalProperties:
+                          description: |-
+                            LLMPhaseOverrideSpec allows a specific agent phase to use a different LLM.
+                            All fields are optional; non-zero fields override the corresponding base values.
+                          properties:
+                            apiKey:
+                              type: string
+                            endpoint:
+                              type: string
+                            model:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        description: |-
+                          Per-phase LLM model overrides. Keys are agent phase names
+                          (rca, workflow_discovery, validation). Each override can specify
+                          a different model (and optionally provider/endpoint) for that phase,
+                          allowing faster/cheaper models for structured tasks like workflow discovery.
+                          When absent, all phases use the default model above.
+                        type: object
+                        x-kubernetes-validations:
+                        - message: 'phaseModels keys must be one of: rca, workflow_discovery,
+                            validation'
+                          rule: self.all(k, k in ['rca','workflow_discovery','validation'])
                       provider:
                         description: LLM provider name (e.g. "openai", "vertexai",
                           "bedrock", "azure").
@@ -1289,6 +1494,21 @@ spec:
                             type: boolean
                         type: object
                     type: object
+                  serverRateLimit:
+                    description: Server-level rate limiting for the KA HTTP endpoint.
+                    properties:
+                      burst:
+                        default: 100
+                        description: Burst size (max concurrent requests above the
+                          steady-state rate).
+                        minimum: 1
+                        type: integer
+                      requestsPerSecond:
+                        default: 50
+                        description: Requests per second allowed.
+                        minimum: 1
+                        type: integer
+                    type: object
                   session:
                     description: Session configuration.
                     properties:
@@ -1339,43 +1559,14 @@ spec:
                   NetworkPolicies controls the creation of Kubernetes NetworkPolicy
                   resources that enforce a default-deny posture with explicit allow rules.
                 properties:
-                  apiServerCIDR:
-                    description: |-
-                      API server CIDR for egress rules (e.g. "10.0.0.0/16").
-                      When empty, API server egress rules are omitted.
-                    type: string
                   enabled:
                     default: false
                     description: |-
                       Whether the operator creates NetworkPolicy resources.
                       When true, a default-deny posture is applied with explicit allow rules
-                      matching the upstream Helm chart traffic matrix.
+                      matching the upstream Helm chart traffic matrix. Monitoring namespace,
+                      ingress namespaces, and API server egress are auto-detected.
                     type: boolean
-                  externalEgressCIDRs:
-                    description: |-
-                      ExternalEgressCIDRs lists CIDRs that AF is allowed to reach for external
-                      services (OIDC/Keycloak JWKS endpoints, etc.) on port 443.
-                      Example: ["10.128.0.0/14"] for cluster-internal Keycloak, or
-                      ["0.0.0.0/0"] to allow any external HTTPS destination.
-                    items:
-                      type: string
-                    type: array
-                  gatewayIngressNamespaces:
-                    description: Gateway ingress namespaces. Namespaces allowed to
-                      send traffic to the Gateway.
-                    items:
-                      type: string
-                    type: array
-                  ingressNamespace:
-                    description: |-
-                      IngressNamespace is the namespace where the OpenShift Router (or ingress
-                      controller) runs. AF needs ingress from this namespace for Route-based traffic.
-                      Typically "openshift-ingress" on OCP.
-                    type: string
-                  monitoringNamespace:
-                    description: Monitoring namespace for Prometheus scrape ingress
-                      (e.g. "openshift-monitoring").
-                    type: string
                 type: object
               notification:
                 description: Notification controller settings.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:97adc8fdf066bb862e0abd70129dd9bbed36b17e2e0d33da5b1e648a889587b2
+- digest: sha256:6e3f88fd84b2dbc14d7e8e9cf2ab7bbe20286f94268255c0094bd41356e20ce9
   name: controller
-  newName: ghcr.io/jordigilh/kubernaut-operator
+  newName: quay.io/kubernaut-ai/kubernaut-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,29 +58,29 @@ spec:
         name: manager
         env:
         - name: RELATED_IMAGE_GATEWAY
-          value: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
+          value: quay.io/kubernaut-ai/gateway@sha256:5a034c54881b93c94707099bb35fc85df4f15dd5847653399688747ce12095ab
         - name: RELATED_IMAGE_DATA_STORAGE
-          value: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
+          value: quay.io/kubernaut-ai/datastorage@sha256:2b784714a594375dee310acdc7c34df09d1e7f625bbc6d439898fe4b8d04e26d
         - name: RELATED_IMAGE_AIANALYSIS
-          value: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
+          value: quay.io/kubernaut-ai/aianalysis@sha256:11e60b614c956b2b31b644c8c280aacf317c4d4592d67e2da47612fc29d69aa1
         - name: RELATED_IMAGE_SIGNALPROCESSING
-          value: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
+          value: quay.io/kubernaut-ai/signalprocessing@sha256:5895a2c66a35afffd6b470474d910bc4d39b6e0801af44e8eb47e2629d5a203c
         - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
+          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:8637fa8681284ee306eedf9ee67ee5480a1248a9292adfa6e16332eeeb6bb193
         - name: RELATED_IMAGE_WORKFLOWEXECUTION
-          value: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
+          value: quay.io/kubernaut-ai/workflowexecution@sha256:e621977c7bd64c34ddad4bd94861af75ee7981d1d75d1574fba5748b887cfd39
         - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
+          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:d04437a3e5694db80bc5a225958a9402be01b9832f2d59c1413cf81c52174d16
         - name: RELATED_IMAGE_NOTIFICATION
-          value: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
+          value: quay.io/kubernaut-ai/notification@sha256:9857c2384aa9c7866730bbf0160b68ecf6c7d4444355ef0d78ea368f6e291e8a
         - name: RELATED_IMAGE_KUBERNAUT_AGENT
-          value: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
+          value: quay.io/kubernaut-ai/kubernautagent@sha256:6487b59e9b955bdaa0fb47fef18c5012c81e41415bf1f954a81abfbacbed55dc
         - name: RELATED_IMAGE_AUTHWEBHOOK
-          value: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
+          value: quay.io/kubernaut-ai/authwebhook@sha256:63c619adfc80d8e433635377b0c3af732055dc83f61e0274615964b1bc9aa31a
         - name: RELATED_IMAGE_API_FRONTEND
-          value: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
+          value: quay.io/kubernaut-ai/apifrontend@sha256:2aee7ef17f7632d8dd2d426036aceb19d04a5cafd9a6f0f499215216314ef0fa
         - name: RELATED_IMAGE_DB_MIGRATE
-          value: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
+          value: quay.io/kubernaut-ai/db-migrate@sha256:4a25f7165fd86ad70437c7fdb3c5268630e3069095cf66c329972a99cfa7cf80
         - name: RELATED_IMAGE_CONSOLE
           value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
         - name: RELATED_IMAGE_OAUTH2_PROXY


### PR DESCRIPTION
## Summary

- Update all operand image digests (`RELATED_IMAGE_*`) in `config/manager/` and bundle CSV to match the latest v1.5.2 releases published to `quay.io/kubernaut-ai/`
- Migrate operator image reference from `ghcr.io` to `quay.io/kubernaut-ai/kubernaut-operator`
- Update bundle CSV: version bump to 1.5.2, add console + oauth2-proxy to managed images, add RBAC for `agent.kagenti.dev` and `config.openshift.io/ingresses`, refresh alm-examples
- Update CRD schema with `jwtProviders` multi-issuer authentication support

## Test plan

- [ ] Verify `make bundle` produces no additional diff (bundle is already regenerated)
- [ ] Deploy operator in disconnected cluster using the ImageSetConfiguration from the air-gap guide and confirm all pods start with mirrored images
- [ ] Confirm OLM can install the bundle (CSV passes validation)


Made with [Cursor](https://cursor.com)