### PR TITLE
Remove hardcoded RunAsUser UIDs from console deployment

### DIFF
--- a/internal/resources/console.go
+++ b/internal/resources/console.go
@@ -129,7 +129,6 @@ func ConsoleDeployment(kn *kubernautv1alpha1.Kubernaut, ingressDomain string) (*
 								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 								ReadOnlyRootFilesystem:   ptr.To(true),
-								RunAsUser:                ptr.To(int64(65534)),
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{
@@ -164,7 +163,6 @@ func ConsoleDeployment(kn *kubernautv1alpha1.Kubernaut, ingressDomain string) (*
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-								RunAsUser:                ptr.To(int64(1001)),
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{

--- a/internal/resources/console_test.go
+++ b/internal/resources/console_test.go
@@ -101,6 +101,7 @@ var _ = Describe("Console Resources", func() {
 			Expect(oauth2.Image).To(Equal("quay.io/oauth2-proxy/oauth2-proxy:v7.9.0"))
 			Expect(*oauth2.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
 			Expect(*oauth2.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(oauth2.SecurityContext.RunAsUser).To(BeNil(), "hardcoded RunAsUser breaks OCP restricted SCC")
 			Expect(oauth2.Ports).To(HaveLen(1))
 			Expect(oauth2.Ports[0].ContainerPort).To(Equal(consoleProxyPort))
 			Expect(oauth2.Env).To(HaveLen(3))
@@ -115,6 +116,7 @@ var _ = Describe("Console Resources", func() {
 			Expect(console.Image).To(Equal("quay.io/kubernaut-ai/console:v1.3.0"))
 			Expect(console.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 			Expect(*console.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(console.SecurityContext.RunAsUser).To(BeNil(), "hardcoded RunAsUser breaks OCP restricted SCC")
 			Expect(console.VolumeMounts).To(HaveLen(3))
 
 			Expect(spec.Volumes).To(HaveLen(2))


### PR DESCRIPTION
## Summary

- Removes hardcoded `RunAsUser: 65534` from the oauth2-proxy container and `RunAsUser: 1001` from the console/nginx container in `ConsoleDeployment()`.
- Lets OpenShift assign UIDs from the namespace-allocated range, making the console compatible with the `restricted` and `restricted-v2` SCCs on OCP 4.18.

Fixes #188

## Test plan

- [x] `go build ./...` passes
- [x] All 20 console Ginkgo tests pass (`go test ./internal/resources/ --ginkgo.focus="Console"`)
- [ ] Deploy on OCP 4.18 cluster and verify console pods schedule without SCC violations

Made with [Cursor](https://cursor.com)