### PR TITLE
fix: add --ping-path to oauth2-proxy so health probes pass

### DIFF
--- a/internal/resources/console.go
+++ b/internal/resources/console.go
@@ -76,6 +76,7 @@ func ConsoleDeployment(kn *kubernautv1alpha1.Kubernaut, ingressDomain string) (*
 		"--skip-jwt-bearer-tokens=true",
 		"--cookie-refresh=25m",
 		"--ssl-insecure-skip-verify=true",
+		"--ping-path=/oauth2/ping",
 	}
 
 	replicas := int32(1)


### PR DESCRIPTION
## Summary

- Add `--ping-path=/oauth2/ping` to the console oauth2-proxy container args so the readiness/liveness probes get a 200 instead of a 302 redirect

Without this flag, oauth2-proxy v7.9.0 only serves health checks at `/ping` (the default). The operator configures probes at `/oauth2/ping`, which the proxy treats as an unauthenticated request and redirects to login, causing repeated restarts.

Fixes #190

## Test plan

- [ ] Deploy operator and verify console pod reaches Ready without restarts
- [ ] `oc exec` into a console pod and confirm `curl localhost:4180/oauth2/ping` returns 200


Made with [Cursor](https://cursor.com)