### PR TITLE
fix: set PSA enforce=privileged on namespace when SPIRE is enabled

### DIFF
--- a/internal/controller/kubernaut_controller.go
+++ b/internal/controller/kubernaut_controller.go
@@ -1347,6 +1347,8 @@ func (r *KubernautReconciler) resolveKagentiOIDCDefaults(ctx context.Context, kn
 // ensureKagentiNamespaceLabel adds or removes the "kagenti-enabled" label on
 // the kubernaut-system namespace. The kagenti mutating webhook requires this
 // label in its namespaceSelector to inject the authbridge sidecar into AF pods.
+// Additionally, when SPIRE is enabled the authbridge sidecar uses a SPIFFE CSI
+// inline volume that requires pod-security.kubernetes.io/enforce=privileged.
 func (r *KubernautReconciler) ensureKagentiNamespaceLabel(ctx context.Context, kn *kubernautv1alpha1.Kubernaut) error {
 	log := logf.FromContext(ctx)
 
@@ -1358,22 +1360,53 @@ func (r *KubernautReconciler) ensureKagentiNamespaceLabel(ctx context.Context, k
 	want := kn.Spec.APIFrontendEnabled() && kn.Spec.APIFrontend.SPIRE.SPIREEnabled()
 	have := ns.Labels["kagenti-enabled"] == resources.LabelValueTrue
 
-	if want == have {
-		return nil
-	}
+	needsUpdate := want != have
 
 	if ns.Labels == nil {
 		ns.Labels = make(map[string]string)
 	}
+
 	if want {
-		log.Info("labeling namespace for kagenti authbridge injection", "namespace", kn.Namespace)
-		ns.Labels["kagenti-enabled"] = resources.LabelValueTrue
+		if !have {
+			log.Info("labeling namespace for kagenti authbridge injection", "namespace", kn.Namespace)
+			ns.Labels["kagenti-enabled"] = resources.LabelValueTrue
+		}
+		if ensurePSALabels(ns.Labels) {
+			log.Info("setting pod security labels for SPIFFE CSI volume", "namespace", kn.Namespace)
+			needsUpdate = true
+		}
 	} else {
-		log.Info("removing kagenti-enabled label from namespace", "namespace", kn.Namespace)
-		delete(ns.Labels, "kagenti-enabled")
+		if have {
+			log.Info("removing kagenti-enabled label from namespace", "namespace", kn.Namespace)
+			delete(ns.Labels, "kagenti-enabled")
+		}
 	}
 
+	if !needsUpdate {
+		return nil
+	}
 	return r.Update(ctx, ns)
+}
+
+// ensurePSALabels sets the Pod Security Admission labels required for the
+// SPIFFE CSI inline volume. Returns true if any label was added or changed.
+func ensurePSALabels(labels map[string]string) bool {
+	changed := false
+	psaLabels := map[string]string{
+		"pod-security.kubernetes.io/enforce":         "privileged",
+		"pod-security.kubernetes.io/enforce-version": "latest",
+		"pod-security.kubernetes.io/audit":           "privileged",
+		"pod-security.kubernetes.io/audit-version":   "latest",
+		"pod-security.kubernetes.io/warn":            "privileged",
+		"pod-security.kubernetes.io/warn-version":    "latest",
+	}
+	for k, v := range psaLabels {
+		if labels[k] != v {
+			labels[k] = v
+			changed = true
+		}
+	}
+	return changed
 }
 
 // agentRuntimeGVR is the GroupVersionResource for kagenti AgentRuntime CRs.

--- a/internal/controller/kubernaut_lifecycle_test.go
+++ b/internal/controller/kubernaut_lifecycle_test.go
@@ -2937,6 +2937,12 @@ var _ = Describe("Kubernaut Lifecycle", func() {
 			updated := &corev1.Namespace{}
 			Expect(r.Get(ctx, types.NamespacedName{Name: testNamespace}, updated)).To(Succeed())
 			Expect(updated.Labels).To(HaveKeyWithValue("kagenti-enabled", "true"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/enforce-version", "latest"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/audit", "privileged"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/audit-version", "latest"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/warn", "privileged"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/warn-version", "latest"))
 		})
 
 		It("UT-KL-02 [AC-4, CC6.1]: removes label when SPIRE is disabled", func() {
@@ -2962,7 +2968,16 @@ var _ = Describe("Kubernaut Lifecycle", func() {
 		})
 
 		It("UT-KL-04 [CM-6, CC8.1]: no mutation when label already matches desired state", func() {
-			ns := unitTestNamespace(map[string]string{"kagenti-enabled": "true", "other": "label"})
+			ns := unitTestNamespace(map[string]string{
+				"kagenti-enabled":                    "true",
+				"other":                              "label",
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"pod-security.kubernetes.io/enforce-version": "latest",
+				"pod-security.kubernetes.io/audit":           "privileged",
+				"pod-security.kubernetes.io/audit-version":   "latest",
+				"pod-security.kubernetes.io/warn":            "privileged",
+				"pod-security.kubernetes.io/warn-version":    "latest",
+			})
 			kn := unitTestKubernautCR(true, true)
 			r := newFakeUnitReconciler(ns)
 			Expect(r.ensureKagentiNamespaceLabel(ctx, kn)).To(Succeed())
@@ -2983,6 +2998,36 @@ var _ = Describe("Kubernaut Lifecycle", func() {
 			Expect(r.Get(ctx, types.NamespacedName{Name: testNamespace}, updated)).To(Succeed())
 			Expect(updated.Labels).NotTo(HaveKey("kagenti-enabled"))
 			Expect(updated.Labels).To(HaveKeyWithValue("other", "label"))
+		})
+
+		It("UT-KL-06 [AC-4]: adds PSA labels when kagenti-enabled already present but PSA missing", func() {
+			ns := unitTestNamespace(map[string]string{"kagenti-enabled": "true"})
+			kn := unitTestKubernautCR(true, true)
+			r := newFakeUnitReconciler(ns)
+			Expect(r.ensureKagentiNamespaceLabel(ctx, kn)).To(Succeed())
+
+			updated := &corev1.Namespace{}
+			Expect(r.Get(ctx, types.NamespacedName{Name: testNamespace}, updated)).To(Succeed())
+			Expect(updated.Labels).To(HaveKeyWithValue("kagenti-enabled", "true"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/enforce-version", "latest"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/audit", "privileged"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/warn", "privileged"))
+		})
+
+		It("UT-KL-07 [CM-6]: does not remove PSA labels when SPIRE is disabled", func() {
+			ns := unitTestNamespace(map[string]string{
+				"kagenti-enabled":                    "true",
+				"pod-security.kubernetes.io/enforce": "privileged",
+			})
+			kn := unitTestKubernautCR(true, false)
+			r := newFakeUnitReconciler(ns)
+			Expect(r.ensureKagentiNamespaceLabel(ctx, kn)).To(Succeed())
+
+			updated := &corev1.Namespace{}
+			Expect(r.Get(ctx, types.NamespacedName{Name: testNamespace}, updated)).To(Succeed())
+			Expect(updated.Labels).NotTo(HaveKey("kagenti-enabled"))
+			Expect(updated.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"))
 		})
 	})
 


### PR DESCRIPTION
## Summary
- Extends `ensureKagentiNamespaceLabel` to reconcile all six Pod Security Admission labels (`enforce`, `audit`, `warn` + version variants) on the kubernaut-system namespace when SPIRE is enabled
- PSA labels are not removed when SPIRE is disabled (safe default to avoid breaking other workloads)
- Adds two new unit tests (UT-KL-06, UT-KL-07) covering PSA label addition and retention

Closes #193

## Test plan
- [x] All 7 UT-KL tests pass (`go test --ginkgo.focus="UT-KL"`)
- [ ] Deploy operator to OCP 4.18 cluster with SPIRE enabled and confirm AF pod starts without PSA rejection

Made with [Cursor](https://cursor.com)