### PR TITLE
feat: support AF OpenAI provider translation (#196)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,22 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# Unit-test packages that do NOT need envtest (fast, no API server).
+UT_PKGS := ./internal/resources/... ./internal/webhook/...
+
+.PHONY: test-unit
+test-unit: fmt vet ## Run unit tests (no envtest, no API server).
+	go test $(UT_PKGS) -coverprofile cover-unit.out
+
+# Integration-test packages that DO need envtest (controller reconciler).
+IT_PKGS := ./internal/controller/...
+
+.PHONY: test-integration
+test-integration: manifests generate fmt vet setup-envtest ## Run integration tests (envtest API server).
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(IT_PKGS) -coverprofile cover-integration.out
+
 .PHONY: test
-test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+test: test-unit test-integration ## Run all tests (unit + integration).
 
 # E2E tests run against a live OCP cluster. Ensure you are logged in (oc login)
 # and IMG points to a registry reachable from the cluster.

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ test-integration: manifests generate fmt vet setup-envtest ## Run integration te
 
 .PHONY: test
 test: test-unit test-integration ## Run all tests (unit + integration).
+	@echo "mode: set" > cover.out
+	@tail -n +2 cover-unit.out >> cover.out 2>/dev/null || true
+	@tail -n +2 cover-integration.out >> cover.out 2>/dev/null || true
 
 # E2E tests run against a live OCP cluster. Ensure you are logged in (oc login)
 # and IMG points to a registry reachable from the cluster.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2781,29 +2781,29 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_GATEWAY
-          value: quay.io/kubernaut-ai/gateway@sha256:5a034c54881b93c94707099bb35fc85df4f15dd5847653399688747ce12095ab
+          value: quay.io/kubernaut-ai/gateway@sha256:b715e35f730302daad388c6291def24877a0b7c9209ac32e0b8975eb8655bff7
         - name: RELATED_IMAGE_DATA_STORAGE
-          value: quay.io/kubernaut-ai/datastorage@sha256:2b784714a594375dee310acdc7c34df09d1e7f625bbc6d439898fe4b8d04e26d
+          value: quay.io/kubernaut-ai/datastorage@sha256:805ed123ad0e51267d131267a23fa80751482eda76da38cda36b8b93c14c9754
         - name: RELATED_IMAGE_AIANALYSIS
-          value: quay.io/kubernaut-ai/aianalysis@sha256:11e60b614c956b2b31b644c8c280aacf317c4d4592d67e2da47612fc29d69aa1
+          value: quay.io/kubernaut-ai/aianalysis@sha256:490d21d616f88e5ae0b725e8d6d85824e810ca715fff7f3776b43e7eb0d2019f
         - name: RELATED_IMAGE_SIGNALPROCESSING
-          value: quay.io/kubernaut-ai/signalprocessing@sha256:5895a2c66a35afffd6b470474d910bc4d39b6e0801af44e8eb47e2629d5a203c
+          value: quay.io/kubernaut-ai/signalprocessing@sha256:a9a5f9c804057b3d60791e4d25ff4d38af32c7958a084e9e162135f0c294d4fc
         - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:8637fa8681284ee306eedf9ee67ee5480a1248a9292adfa6e16332eeeb6bb193
+          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:a70d71f671bead375c0803a87552822ce215037689ee199c0d226c72c73cdb30
         - name: RELATED_IMAGE_WORKFLOWEXECUTION
-          value: quay.io/kubernaut-ai/workflowexecution@sha256:e621977c7bd64c34ddad4bd94861af75ee7981d1d75d1574fba5748b887cfd39
+          value: quay.io/kubernaut-ai/workflowexecution@sha256:39927b0a0e6da94ecc57b8fc130e49529913a0c24f5a0e3049e0eb9ae62b61d0
         - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:d04437a3e5694db80bc5a225958a9402be01b9832f2d59c1413cf81c52174d16
+          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:0549eed75b8a2d4980747da4ed4e0357a1898dbbd370779de46dc0a1d5b3341a
         - name: RELATED_IMAGE_NOTIFICATION
-          value: quay.io/kubernaut-ai/notification@sha256:9857c2384aa9c7866730bbf0160b68ecf6c7d4444355ef0d78ea368f6e291e8a
+          value: quay.io/kubernaut-ai/notification@sha256:1fd90dfa8d4df693a6ae0dd2c3933878ea8b17c0f25bf309d8748490d154e5a6
         - name: RELATED_IMAGE_KUBERNAUT_AGENT
-          value: quay.io/kubernaut-ai/kubernautagent@sha256:6487b59e9b955bdaa0fb47fef18c5012c81e41415bf1f954a81abfbacbed55dc
+          value: quay.io/kubernaut-ai/kubernautagent@sha256:34415766c18ef0b951f0ecbe820891e1136e9f04a4999bf651134e827899c187
         - name: RELATED_IMAGE_AUTHWEBHOOK
-          value: quay.io/kubernaut-ai/authwebhook@sha256:63c619adfc80d8e433635377b0c3af732055dc83f61e0274615964b1bc9aa31a
+          value: quay.io/kubernaut-ai/authwebhook@sha256:abfd68819361bb8a0f2fcbb2f1847a2539c02a290cd81eac8e0df79abbdb5eb3
         - name: RELATED_IMAGE_API_FRONTEND
-          value: quay.io/kubernaut-ai/apifrontend@sha256:2aee7ef17f7632d8dd2d426036aceb19d04a5cafd9a6f0f499215216314ef0fa
+          value: quay.io/kubernaut-ai/apifrontend@sha256:8acd17df3447c9bad44807e6061378a49c6321fe0647d38e9706422e26c8fbd0
         - name: RELATED_IMAGE_DB_MIGRATE
-          value: quay.io/kubernaut-ai/db-migrate@sha256:4a25f7165fd86ad70437c7fdb3c5268630e3069095cf66c329972a99cfa7cf80
+          value: quay.io/kubernaut-ai/db-migrate@sha256:a1b7f151ff58964267b2d7814f55cafdf2b0e1ea2da32cfdcd6a35fab51933a1
         - name: RELATED_IMAGE_CONSOLE
           value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
         - name: RELATED_IMAGE_OAUTH2_PROXY

--- a/docs/tests/196/TEST_PLAN.md
+++ b/docs/tests/196/TEST_PLAN.md
@@ -1,0 +1,72 @@
+# Test Plan: OpenAI Provider Support (Issue #196)
+
+| Field              | Value                                                    |
+|--------------------|----------------------------------------------------------|
+| **Test Plan ID**   | TP-196                                                   |
+| **Feature**        | OpenAI/OpenAI-compatible LLM provider support for AF     |
+| **Issue**          | https://github.com/jordigilh/kubernaut-operator/issues/196 |
+| **Upstream**       | kubernaut PR #1487, kubernaut #1488 (normalization)      |
+| **Author**         | kubernaut-operator team                                  |
+| **Date**           | 2026-06-24                                               |
+
+## 1. Introduction
+
+The upstream Kubernaut v1.5.2 release adds an OpenAI-compatible LLM adapter
+to the API Frontend (AF). AF distinguishes `openai` (first-party API) from
+`openai_compatible` (third-party endpoints like vLLM, LiteLLM, Ollama), while
+KA uses `openai` for both via LangChain. AF also expects the endpoint to
+include the `/v1` suffix, while KA appends it internally.
+
+The operator must translate `provider: openai` from the CR into the correct
+format for each component without changing the CR schema.
+
+## 2. Scope
+
+### In scope
+
+- AF ConfigMap provider name translation (`openai` -> `openai_compatible`)
+- AF endpoint `/v1` suffix normalization
+- KA ConfigMap passthrough (no translation)
+- Validation: require `endpoint` when `provider == "openai"`
+- AF `apiKeyFile` wiring for OpenAI provider
+
+### Out of scope
+
+- CR schema changes (deferred to kubernaut#1488 normalization)
+- KA ConfigMap generation changes
+- New provider additions beyond `openai`/`openai_compatible`
+
+## 3. Test Strategy
+
+Unit tests using Ginkgo/Gomega, following existing patterns in the operator
+codebase. Tests verify the operator's internal config generation logic.
+
+## 4. Test Scenarios
+
+### 4.1 ConfigMap Generation (AF)
+
+| ID | Description | FedRAMP | Acceptance Criteria |
+|----|-------------|---------|---------------------|
+| UT-CM-196-001 | AF receives `openai_compatible` when CR specifies `openai` | SI-10 | `agent.llm.provider` in AF ConfigMap equals `"openai_compatible"` |
+| UT-CM-196-002 | AF endpoint gets `/v1` suffix appended | CM-6 | Endpoint `http://gw:8080` becomes `http://gw:8080/v1` in AF config |
+| UT-CM-196-003 | AF endpoint not doubled when `/v1` already present | CM-6 | Endpoint `http://gw:8080/v1` stays `http://gw:8080/v1` |
+| UT-CM-196-004 | AF endpoint trailing slash handled before `/v1` append | CM-6 | Endpoint `http://gw:8080/` becomes `http://gw:8080/v1` |
+| UT-CM-196-005 | KA receives raw `openai` provider, no endpoint mutation | CM-6 | KA llm-runtime.yaml has `provider: openai` and raw endpoint without `/v1` |
+| UT-CM-196-006 | Non-OpenAI providers pass through untranslated | CM-6 | `vertex_ai` in CR produces `vertex_ai` in AF config |
+| UT-CM-196-007 | AF `apiKeyFile` set for OpenAI provider | SC-7 | `agent.llm.apiKeyFile` is `/etc/apifrontend/llm-credentials/api_key` |
+
+### 4.2 Validation
+
+| ID | Description | FedRAMP | Acceptance Criteria |
+|----|-------------|---------|---------------------|
+| UT-VL-196-001 | `provider: openai` without endpoint fails validation | SI-10 | Validation returns error mentioning `endpoint` |
+| UT-VL-196-002 | `provider: openai` with endpoint passes validation | SI-10 | No validation error for endpoint |
+
+## 5. Acceptance Criteria
+
+- All 9 test scenarios pass
+- `go build ./...` clean
+- `golangci-lint` clean
+- No regressions in existing provider paths (`vertex_ai`, `gemini`, `anthropic`)
+- KA ConfigMap generation unchanged
+- CR schema unchanged (no `kubernaut_types.go` modifications)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/jordigilh/kubernaut-operator
 go 1.26
 
 require (
-	github.com/jordigilh/kubernaut v1.5.1-0.20260619031653-592335431baa
-	github.com/onsi/ginkgo/v2 v2.31.0
+	github.com/jordigilh/kubernaut v1.5.2
+	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.0
 	github.com/openshift/api v0.0.0-20260327162646-993e604705e3
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.91.0

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jordigilh/kubernaut v1.5.1-0.20260619031653-592335431baa h1:yP0ZpHziOZp4xVPimYkRQqUBBDP5vER3ez2CEOuYGIs=
-github.com/jordigilh/kubernaut v1.5.1-0.20260619031653-592335431baa/go.mod h1:irH7+BI6emS3zYqdO6Ki08oFkAz0xlb8n1YlmWKeXJ0=
+github.com/jordigilh/kubernaut v1.5.2 h1:lubTcP91H6DFD10FY3ILFPVkxcceLk7I7b+XLM+uIFw=
+github.com/jordigilh/kubernaut v1.5.2/go.mod h1:AiKZgS0Ro3HRHZjZIJyEGi7yVI6fIgnTgdU5rMciCa0=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -127,8 +127,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.31.0 h1:GtuJos5DFUV9EerYJo8RhYxosYNGvOdDE5haKq6Grfs=
-github.com/onsi/ginkgo/v2 v2.31.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/ginkgo/v2 v2.32.0 h1:Hw7s2pVrQo/8Yz5N77qdnpHaoc+c6cC9WIV1Jce+J6E=
+github.com/onsi/ginkgo/v2 v2.32.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.42.0 h1:CJby8u36xb7v34W78F8WKvqTQP7PCMIPB78IVDB73l4=
 github.com/onsi/gomega v1.42.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/openshift/api v0.0.0-20260327162646-993e604705e3 h1:qSEX/RqR/SM9L4hUoCzOIH1TtINpINRW9BNH89OUprQ=

--- a/internal/controller/kubernaut_controller_test.go
+++ b/internal/controller/kubernaut_controller_test.go
@@ -74,6 +74,7 @@ func newMinimalCR() *kubernautv1alpha1.Kubernaut {
 				LLM: kubernautv1alpha1.LLMSpec{
 					Provider:              "openai",
 					Model:                 "gpt-4o",
+					Endpoint:              "http://llm-gateway:8080",
 					CredentialsSecretName: llmSecretName,
 				},
 			},

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -145,6 +145,16 @@ const PDBMaxUnavailable = 1
 // Application Default Credentials (ADC) instead of a flat API key file.
 const LLMProviderVertexAI = "vertex_ai"
 
+// LLMProviderOpenAI is the canonical provider name users set in the CR.
+// KA consumes this as-is; the operator translates it for AF.
+const LLMProviderOpenAI = "openai"
+
+// LLMProviderOpenAICompatible is what AF expects for OpenAI-compatible
+// endpoints (kubernaut#1487). The operator emits this to AF when the CR
+// specifies "openai". This translation will be removed when upstream
+// normalizes the config (kubernaut#1488).
+const LLMProviderOpenAICompatible = "openai_compatible"
+
 // Kagenti discovery labels for A2A agent auto-discovery.
 const (
 	KagentiAgentTypeLabel                = "kagenti.io/type"

--- a/internal/resources/common_test.go
+++ b/internal/resources/common_test.go
@@ -66,6 +66,7 @@ func testKubernaut() *kubernautv1alpha1.Kubernaut {
 				LLM: kubernautv1alpha1.LLMSpec{
 					Provider:              "openai",
 					Model:                 "gpt-4o",
+					Endpoint:              "http://llm-gateway:8080",
 					CredentialsSecretName: "llm-creds",
 				},
 			},

--- a/internal/resources/configmaps.go
+++ b/internal/resources/configmaps.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
@@ -1860,6 +1861,12 @@ func afSeverityTriageConfig(kn *kubernautv1alpha1.Kubernaut) afSeverityTriageYAM
 
 // afAgentLLMConfig builds the nested agent.llm config section for the AF,
 // matching the schema introduced in kubernaut#1252 / PR#1255.
+//
+// AF and KA have divergent OpenAI config formats (kubernaut#1487/#1488):
+//   - CR "openai" -> AF receives "openai_compatible" (superset that works with/without API key)
+//   - AF expects the endpoint to include "/v1"; KA appends it internally
+//
+// This translation will be removed when upstream normalizes (kubernaut#1488).
 func afAgentLLMConfig(kn *kubernautv1alpha1.Kubernaut) afAgentLLMYAML {
 	llm := kn.Spec.KubernautAgent.LLM
 	provider := llm.Provider
@@ -1867,10 +1874,21 @@ func afAgentLLMConfig(kn *kubernautv1alpha1.Kubernaut) afAgentLLMYAML {
 		provider = LLMProviderVertexAI
 	}
 
+	afProvider := provider
+	if provider == LLMProviderOpenAI {
+		afProvider = LLMProviderOpenAICompatible
+	}
+
+	endpoint := llm.Endpoint
+	if afProvider == LLMProviderOpenAICompatible &&
+		endpoint != "" && !strings.HasSuffix(endpoint, "/v1") {
+		endpoint = strings.TrimRight(endpoint, "/") + "/v1"
+	}
+
 	cfg := afAgentLLMYAML{
-		Provider:       provider,
+		Provider:       afProvider,
 		Model:          llm.Model,
-		Endpoint:       llm.Endpoint,
+		Endpoint:       endpoint,
 		VertexProject:  llm.VertexProject,
 		VertexLocation: llm.VertexLocation,
 		TLSCaFile:      llm.TLSCaFile,
@@ -1878,7 +1896,7 @@ func afAgentLLMConfig(kn *kubernautv1alpha1.Kubernaut) afAgentLLMYAML {
 		TLSKeyFile:     llm.TLSKeyFile,
 	}
 
-	if llm.CredentialsSecretName != "" && provider != LLMProviderVertexAI {
+	if llm.CredentialsSecretName != "" && afProvider != LLMProviderVertexAI {
 		cfg.APIKeyFile = "/etc/apifrontend/llm-credentials/api_key"
 	}
 

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -1275,7 +1275,7 @@ var _ = Describe("APIFrontendConfigMap", func() {
 		}
 		err = yaml.Unmarshal([]byte(data), &root)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(root.Agent.LLM.Provider).To(Equal("openai"), "agent.llm.provider = %q, want openai", root.Agent.LLM.Provider)
+		Expect(root.Agent.LLM.Provider).To(Equal("openai_compatible"), "agent.llm.provider = %q, want openai_compatible (kubernaut#1487)", root.Agent.LLM.Provider)
 		Expect(root.Agent.LLM.Model).To(Equal("gpt-4o"), "agent.llm.model = %q, want gpt-4o", root.Agent.LLM.Model)
 		Expect(root.Agent.LLM.APIKeyFile).To(Equal("/etc/apifrontend/llm-credentials/api_key"),
 			"agent.llm.apiKeyFile should point to mounted secret")

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -30,6 +30,8 @@ import (
 
 const injectCABundleAnnotationValue = "true"
 
+const testOpenAIEndpoint = "http://llm-gateway:8080"
+
 var _ = Describe("ConfigMaps", func() {
 	Describe("Gateway ConfigMap", func() {
 		It("contains DataStorage URL and expected keys", func() {
@@ -640,7 +642,7 @@ var _ = Describe("ConfigMaps", func() {
 			Expect(root.Runtime.Logging.Level).To(Equal("info"), "runtime.logging.level = %q, want info", root.Runtime.Logging.Level)
 			Expect(root.Runtime.Server.Port == 8443 && root.Runtime.Server.Address == "0.0.0.0").To(BeTrue(), "runtime.server = %#v, want address 0.0.0.0 port 8443", root.Runtime.Server)
 			Expect(root.Runtime.Audit.BufferSize).To(Equal(10000), "runtime.audit.bufferSize = %d, want 10000", root.Runtime.Audit.BufferSize)
-			Expect(root.AI.LLM.Provider).To(Equal("openai"), "ai.llm.provider = %q, want openai", root.AI.LLM.Provider)
+			Expect(root.AI.LLM.Provider).To(Equal(LLMProviderOpenAI), "ai.llm.provider = %q, want openai", root.AI.LLM.Provider)
 			Expect(root.AI.Investigation.MaxTurns).To(Equal(40), "ai.investigation.maxTurns = %d, want 40", root.AI.Investigation.MaxTurns)
 			wantDS := DataStorageURL(kn.Namespace)
 			Expect(root.Integrations.DataStorage.URL).To(Equal(wantDS), "integrations.dataStorage.url = %q, want %q", root.Integrations.DataStorage.URL, wantDS)
@@ -703,7 +705,7 @@ var _ = Describe("ConfigMaps", func() {
 			kn.Spec.KubernautAgent.AlignmentCheck.Timeout = "20s"
 			kn.Spec.KubernautAgent.AlignmentCheck.MaxStepTokens = 1024
 			kn.Spec.KubernautAgent.AlignmentCheck.LLM = &kubernautv1alpha1.AlignmentCheckLLMSpec{
-				Provider: "openai",
+				Provider: LLMProviderOpenAI,
 				Model:    "gpt-4o-mini",
 				Endpoint: "https://align.example/v1",
 			}
@@ -1323,8 +1325,8 @@ var _ = Describe("APIFrontendConfigMap", func() {
 
 	It("UT-CM-196-001 [SI-10]: AF receives openai_compatible when CR specifies openai", func() {
 		kn := testKubernautWithAF()
-		kn.Spec.KubernautAgent.LLM.Provider = "openai"
-		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		kn.Spec.KubernautAgent.LLM.Provider = LLMProviderOpenAI
+		kn.Spec.KubernautAgent.LLM.Endpoint = testOpenAIEndpoint
 		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
 		Expect(err).NotTo(HaveOccurred())
 		var root struct {
@@ -1341,8 +1343,8 @@ var _ = Describe("APIFrontendConfigMap", func() {
 
 	It("UT-CM-196-002 [CM-6]: AF endpoint gets /v1 suffix appended", func() {
 		kn := testKubernautWithAF()
-		kn.Spec.KubernautAgent.LLM.Provider = "openai"
-		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		kn.Spec.KubernautAgent.LLM.Provider = LLMProviderOpenAI
+		kn.Spec.KubernautAgent.LLM.Endpoint = testOpenAIEndpoint
 		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
 		Expect(err).NotTo(HaveOccurred())
 		var root struct {
@@ -1353,14 +1355,14 @@ var _ = Describe("APIFrontendConfigMap", func() {
 			} `yaml:"agent"`
 		}
 		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
-		Expect(root.Agent.LLM.Endpoint).To(Equal("http://llm-gateway:8080/v1"),
+		Expect(root.Agent.LLM.Endpoint).To(Equal(testOpenAIEndpoint+"/v1"),
 			"AF OpenAI adapter requires /v1 suffix on endpoint")
 	})
 
 	It("UT-CM-196-003 [CM-6]: AF endpoint not doubled when /v1 already present", func() {
 		kn := testKubernautWithAF()
-		kn.Spec.KubernautAgent.LLM.Provider = "openai"
-		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080/v1"
+		kn.Spec.KubernautAgent.LLM.Provider = LLMProviderOpenAI
+		kn.Spec.KubernautAgent.LLM.Endpoint = testOpenAIEndpoint + "/v1"
 		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
 		Expect(err).NotTo(HaveOccurred())
 		var root struct {
@@ -1371,14 +1373,14 @@ var _ = Describe("APIFrontendConfigMap", func() {
 			} `yaml:"agent"`
 		}
 		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
-		Expect(root.Agent.LLM.Endpoint).To(Equal("http://llm-gateway:8080/v1"),
+		Expect(root.Agent.LLM.Endpoint).To(Equal(testOpenAIEndpoint+"/v1"),
 			"/v1 suffix must not be doubled")
 	})
 
 	It("UT-CM-196-004 [CM-6]: AF endpoint trailing slash handled before /v1 append", func() {
 		kn := testKubernautWithAF()
-		kn.Spec.KubernautAgent.LLM.Provider = "openai"
-		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080/"
+		kn.Spec.KubernautAgent.LLM.Provider = LLMProviderOpenAI
+		kn.Spec.KubernautAgent.LLM.Endpoint = testOpenAIEndpoint + "/"
 		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
 		Expect(err).NotTo(HaveOccurred())
 		var root struct {
@@ -1389,14 +1391,14 @@ var _ = Describe("APIFrontendConfigMap", func() {
 			} `yaml:"agent"`
 		}
 		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
-		Expect(root.Agent.LLM.Endpoint).To(Equal("http://llm-gateway:8080/v1"),
+		Expect(root.Agent.LLM.Endpoint).To(Equal(testOpenAIEndpoint+"/v1"),
 			"trailing slash must be normalized before appending /v1")
 	})
 
 	It("UT-CM-196-005 [CM-6]: KA gets raw openai provider, no endpoint mutation", func() {
 		kn := testKubernaut()
-		kn.Spec.KubernautAgent.LLM.Provider = "openai"
-		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		kn.Spec.KubernautAgent.LLM.Provider = LLMProviderOpenAI
+		kn.Spec.KubernautAgent.LLM.Endpoint = testOpenAIEndpoint
 		cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
 		Expect(err).NotTo(HaveOccurred())
 		var root struct {
@@ -1404,9 +1406,9 @@ var _ = Describe("APIFrontendConfigMap", func() {
 			Endpoint string `yaml:"endpoint"`
 		}
 		Expect(yaml.Unmarshal([]byte(cm.Data["llm-runtime.yaml"]), &root)).To(Succeed())
-		Expect(root.Provider).To(Equal("openai"),
+		Expect(root.Provider).To(Equal(LLMProviderOpenAI),
 			"KA must receive raw openai provider (KA handles translation internally)")
-		Expect(root.Endpoint).To(Equal("http://llm-gateway:8080"),
+		Expect(root.Endpoint).To(Equal(testOpenAIEndpoint),
 			"KA endpoint must not be mutated (KA appends /v1 internally)")
 	})
 
@@ -1431,8 +1433,8 @@ var _ = Describe("APIFrontendConfigMap", func() {
 
 	It("UT-CM-196-007 [SC-7]: AF apiKeyFile set for OpenAI provider", func() {
 		kn := testKubernautWithAF()
-		kn.Spec.KubernautAgent.LLM.Provider = "openai"
-		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		kn.Spec.KubernautAgent.LLM.Provider = LLMProviderOpenAI
+		kn.Spec.KubernautAgent.LLM.Endpoint = testOpenAIEndpoint
 		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
 		Expect(err).NotTo(HaveOccurred())
 		var root struct {

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -1321,6 +1321,132 @@ var _ = Describe("APIFrontendConfigMap", func() {
 			"vertex_ai should use GOOGLE_APPLICATION_CREDENTIALS (ADC), not apiKeyFile")
 	})
 
+	It("UT-CM-196-001 [SI-10]: AF receives openai_compatible when CR specifies openai", func() {
+		kn := testKubernautWithAF()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
+		Expect(err).NotTo(HaveOccurred())
+		var root struct {
+			Agent struct {
+				LLM struct {
+					Provider string `yaml:"provider"`
+				} `yaml:"llm"`
+			} `yaml:"agent"`
+		}
+		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
+		Expect(root.Agent.LLM.Provider).To(Equal("openai_compatible"),
+			"AF must receive openai_compatible for openai provider (kubernaut#1487)")
+	})
+
+	It("UT-CM-196-002 [CM-6]: AF endpoint gets /v1 suffix appended", func() {
+		kn := testKubernautWithAF()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
+		Expect(err).NotTo(HaveOccurred())
+		var root struct {
+			Agent struct {
+				LLM struct {
+					Endpoint string `yaml:"endpoint"`
+				} `yaml:"llm"`
+			} `yaml:"agent"`
+		}
+		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
+		Expect(root.Agent.LLM.Endpoint).To(Equal("http://llm-gateway:8080/v1"),
+			"AF OpenAI adapter requires /v1 suffix on endpoint")
+	})
+
+	It("UT-CM-196-003 [CM-6]: AF endpoint not doubled when /v1 already present", func() {
+		kn := testKubernautWithAF()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080/v1"
+		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
+		Expect(err).NotTo(HaveOccurred())
+		var root struct {
+			Agent struct {
+				LLM struct {
+					Endpoint string `yaml:"endpoint"`
+				} `yaml:"llm"`
+			} `yaml:"agent"`
+		}
+		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
+		Expect(root.Agent.LLM.Endpoint).To(Equal("http://llm-gateway:8080/v1"),
+			"/v1 suffix must not be doubled")
+	})
+
+	It("UT-CM-196-004 [CM-6]: AF endpoint trailing slash handled before /v1 append", func() {
+		kn := testKubernautWithAF()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080/"
+		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
+		Expect(err).NotTo(HaveOccurred())
+		var root struct {
+			Agent struct {
+				LLM struct {
+					Endpoint string `yaml:"endpoint"`
+				} `yaml:"llm"`
+			} `yaml:"agent"`
+		}
+		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
+		Expect(root.Agent.LLM.Endpoint).To(Equal("http://llm-gateway:8080/v1"),
+			"trailing slash must be normalized before appending /v1")
+	})
+
+	It("UT-CM-196-005 [CM-6]: KA gets raw openai provider, no endpoint mutation", func() {
+		kn := testKubernaut()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		cm, err := KubernautAgentLLMRuntimeConfigMap(kn)
+		Expect(err).NotTo(HaveOccurred())
+		var root struct {
+			Provider string `yaml:"provider"`
+			Endpoint string `yaml:"endpoint"`
+		}
+		Expect(yaml.Unmarshal([]byte(cm.Data["llm-runtime.yaml"]), &root)).To(Succeed())
+		Expect(root.Provider).To(Equal("openai"),
+			"KA must receive raw openai provider (KA handles translation internally)")
+		Expect(root.Endpoint).To(Equal("http://llm-gateway:8080"),
+			"KA endpoint must not be mutated (KA appends /v1 internally)")
+	})
+
+	It("UT-CM-196-006 [CM-6]: non-OpenAI providers are not translated", func() {
+		kn := testKubernautWithAF()
+		kn.Spec.KubernautAgent.LLM.Provider = LLMProviderVertexAI
+		kn.Spec.KubernautAgent.LLM.VertexProject = "my-project"
+		kn.Spec.KubernautAgent.LLM.VertexLocation = "us-central1"
+		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
+		Expect(err).NotTo(HaveOccurred())
+		var root struct {
+			Agent struct {
+				LLM struct {
+					Provider string `yaml:"provider"`
+				} `yaml:"llm"`
+			} `yaml:"agent"`
+		}
+		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
+		Expect(root.Agent.LLM.Provider).To(Equal(LLMProviderVertexAI),
+			"non-OpenAI providers must pass through untranslated")
+	})
+
+	It("UT-CM-196-007 [SC-7]: AF apiKeyFile set for OpenAI provider", func() {
+		kn := testKubernautWithAF()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		cm, err := APIFrontendConfigMap(kn, KagentiSidecarNone, nil)
+		Expect(err).NotTo(HaveOccurred())
+		var root struct {
+			Agent struct {
+				LLM struct {
+					APIKeyFile string `yaml:"apiKeyFile"`
+				} `yaml:"llm"`
+			} `yaml:"agent"`
+		}
+		Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &root)).To(Succeed())
+		Expect(root.Agent.LLM.APIKeyFile).To(Equal("/etc/apifrontend/llm-credentials/api_key"),
+			"apiKeyFile must be set for OpenAI provider (secret always mounted)")
+	})
+
 	It("renders OAuth2 block in agent.llm when enabled", func() {
 		kn := testKubernautWithAF()
 		kn.Spec.KubernautAgent.LLM.OAuth2.Enabled = true

--- a/internal/resources/validation.go
+++ b/internal/resources/validation.go
@@ -69,6 +69,9 @@ func validateLLMPrerequisites(kn *kubernautv1alpha1.Kubernaut) []error {
 	if llm.CredentialsSecretName == "" {
 		errs = append(errs, fmt.Errorf("%s.credentialsSecretName: required — provide a Secret with LLM API credentials", base))
 	}
+	if llm.Provider == LLMProviderOpenAI && llm.Endpoint == "" {
+		errs = append(errs, fmt.Errorf("%s.endpoint: required when provider is %q — both KA and AF need an explicit endpoint for OpenAI", base, LLMProviderOpenAI))
+	}
 	certSet := llm.TLSCertFile != "" || llm.TLSKeyFile != ""
 	if certSet && (llm.TLSCertFile == "" || llm.TLSKeyFile == "") {
 		errs = append(errs, fmt.Errorf("%s.tlsCertFile and %s.tlsKeyFile must both be set or both empty for mTLS", base, base))

--- a/internal/resources/validation_test.go
+++ b/internal/resources/validation_test.go
@@ -817,4 +817,28 @@ var _ = Describe("LLM Prerequisite Validation", func() {
 		errs := ValidateKubernaut(kn, KagentiSidecarNone)
 		Expect(errs).To(BeEmpty())
 	})
+
+	It("UT-VL-196-001 [SI-10]: provider openai without endpoint fails validation", func() {
+		kn := testKubernaut()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = ""
+		errs := ValidateKubernaut(kn, KagentiSidecarNone)
+		endpointErr := false
+		for _, e := range errs {
+			if strings.Contains(e.Error(), "endpoint") {
+				endpointErr = true
+			}
+		}
+		Expect(endpointErr).To(BeTrue(),
+			"provider openai must require endpoint (both KA and AF need it)")
+	})
+
+	It("UT-VL-196-002 [SI-10]: provider openai with endpoint passes validation", func() {
+		kn := testKubernaut()
+		kn.Spec.KubernautAgent.LLM.Provider = "openai"
+		kn.Spec.KubernautAgent.LLM.Endpoint = "http://llm-gateway:8080"
+		errs := ValidateKubernaut(kn, KagentiSidecarNone)
+		Expect(errs).To(BeEmpty(),
+			"provider openai with endpoint and credentials should pass validation")
+	})
 })


### PR DESCRIPTION
## Summary

- Translates CR `provider: openai` to `openai_compatible` for AF config, and appends `/v1` to the endpoint (kubernaut#1487). KA config passes through unchanged.
- Adds validation requiring `endpoint` when `provider` is `openai`.
- Splits `make test` into `test-unit` (fast, no envtest) and `test-integration` (envtest-backed controller tests).

Closes #196

## Test plan

- [x] IEEE 829 test plan in `docs/tests/196/TEST_PLAN.md`
- [x] 9 unit tests (UT-CM-196-001..007, UT-VL-196-001..002) — all pass
- [x] Full `make test-unit` suite (577 specs) — 0 failures
- [ ] `make test-integration` (controller reconciler)
- [ ] `make test-e2e` on live cluster


Made with [Cursor](https://cursor.com)