### PR TITLE
fix: use HTTPS for console nginx proxy_pass to AF (#198)

### DIFF
--- a/docs/tests/198/TEST_PLAN.md
+++ b/docs/tests/198/TEST_PLAN.md
@@ -1,0 +1,36 @@
+# IEEE 829 Test Plan — Issue #198: Console nginx proxy_pass TLS
+
+| Field              | Value                                              |
+|--------------------|----------------------------------------------------|
+| **Test Plan ID**   | TP-198                                             |
+| **Issue**          | #198 — Console nginx proxy_pass uses http:// but AF serves TLS on 8443 |
+| **Author**         | kubernaut-operator agent                           |
+| **Created**        | 2026-06-24                                         |
+| **Scope**          | `internal/resources/console.go` — nginx ConfigMap and Deployment |
+
+## 1. Objective
+
+Verify the console nginx reverse proxy connects to AF over HTTPS with
+proper TLS verification using the OCP service-ca trust bundle.
+
+## 2. Test Strategy
+
+Unit tests only (no envtest). All tests exercise the `ConsoleNginxConfigMap`
+and `ConsoleDeployment` resource builders.
+
+## 3. Test Scenarios
+
+| ID            | FedRAMP | Description                                                         |
+|---------------|---------|---------------------------------------------------------------------|
+| UT-CN-198-001 | SC-8    | proxy_pass uses https:// scheme for AF upstream                     |
+| UT-CN-198-002 | SC-8    | server.conf includes proxy_ssl_trusted_certificate directive        |
+| UT-CN-198-003 | SC-8    | server.conf includes proxy_ssl_verify on                            |
+| UT-CD-198-001 | SC-8    | console container mounts tls-ca volume at /etc/tls-ca               |
+| UT-CD-198-002 | CM-6    | tls-ca volume sources from inter-service-ca ConfigMap               |
+| UT-CN-198-004 | SC-8    | proxy_pass does NOT use http:// (negative check)                    |
+
+## 4. Acceptance Criteria
+
+- All 6 scenarios pass (`make test-unit`)
+- No regressions in existing console tests (UT-CD-*, UT-CN-*, UT-CS-*, UT-CR-*)
+- `make build` succeeds

--- a/internal/resources/console.go
+++ b/internal/resources/console.go
@@ -178,21 +178,21 @@ func ConsoleDeployment(kn *kubernautv1alpha1.Kubernaut, ingressDomain string) (*
 								InitialDelaySeconds: 5, PeriodSeconds: 10,
 							},
 							Resources: consoleContainerResources(kn),
-						VolumeMounts: []corev1.VolumeMount{
-							{Name: "nginx-tmp", MountPath: "/tmp"},
-							{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.d/kubernaut-http.conf", SubPath: "http.conf", ReadOnly: true},
-							{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.default.d/kubernaut-server.conf", SubPath: "server.conf", ReadOnly: true},
-							{Name: "tls-ca", MountPath: "/etc/tls-ca", ReadOnly: true},
-						},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "nginx-tmp", MountPath: "/tmp"},
+								{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.d/kubernaut-http.conf", SubPath: "http.conf", ReadOnly: true},
+								{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.default.d/kubernaut-server.conf", SubPath: "server.conf", ReadOnly: true},
+								{Name: "tls-ca", MountPath: "/etc/tls-ca", ReadOnly: true},
+							},
 						},
 					},
-				Volumes: []corev1.Volume{
-					{Name: "nginx-tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-					{Name: "nginx-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: ComponentConsole + "-nginx"},
-					}}},
-					configMapVolume("tls-ca", InterServiceCAConfigMapName),
-				},
+					Volumes: []corev1.Volume{
+						{Name: "nginx-tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "nginx-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: ComponentConsole + "-nginx"},
+						}}},
+						configMapVolume("tls-ca", InterServiceCAConfigMapName),
+					},
 				},
 			},
 		},

--- a/internal/resources/console.go
+++ b/internal/resources/console.go
@@ -178,19 +178,21 @@ func ConsoleDeployment(kn *kubernautv1alpha1.Kubernaut, ingressDomain string) (*
 								InitialDelaySeconds: 5, PeriodSeconds: 10,
 							},
 							Resources: consoleContainerResources(kn),
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "nginx-tmp", MountPath: "/tmp"},
-								{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.d/kubernaut-http.conf", SubPath: "http.conf", ReadOnly: true},
-								{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.default.d/kubernaut-server.conf", SubPath: "server.conf", ReadOnly: true},
-							},
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "nginx-tmp", MountPath: "/tmp"},
+							{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.d/kubernaut-http.conf", SubPath: "http.conf", ReadOnly: true},
+							{Name: "nginx-config", MountPath: "/opt/app-root/etc/nginx.default.d/kubernaut-server.conf", SubPath: "server.conf", ReadOnly: true},
+							{Name: "tls-ca", MountPath: "/etc/tls-ca", ReadOnly: true},
+						},
 						},
 					},
-					Volumes: []corev1.Volume{
-						{Name: "nginx-tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-						{Name: "nginx-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: ComponentConsole + "-nginx"},
-						}}},
-					},
+				Volumes: []corev1.Volume{
+					{Name: "nginx-tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					{Name: "nginx-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: ComponentConsole + "-nginx"},
+					}}},
+					configMapVolume("tls-ca", InterServiceCAConfigMapName),
+				},
 				},
 			},
 		},
@@ -214,7 +216,7 @@ func ConsoleService(kn *kubernautv1alpha1.Kubernaut) *corev1.Service {
 
 // ConsoleNginxConfigMap builds the nginx configuration ConfigMap for the console.
 func ConsoleNginxConfigMap(kn *kubernautv1alpha1.Kubernaut) *corev1.ConfigMap {
-	afURL := fmt.Sprintf("http://%s.%s.svc:%d", ComponentAPIFrontend, kn.Namespace, PortHTTPS)
+	afURL := fmt.Sprintf("https://%s.%s.svc:%d", ComponentAPIFrontend, kn.Namespace, PortHTTPS)
 
 	httpConf := `limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
 limit_req_zone $binary_remote_addr zone=mcp:10m rate=10r/s;
@@ -231,6 +233,10 @@ add_header X-Frame-Options "DENY" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+proxy_ssl_trusted_certificate /etc/tls-ca/service-ca.crt;
+proxy_ssl_verify on;
+proxy_ssl_server_name on;
 
 location /a2a/ {
   limit_req zone=api burst=50 nodelay;

--- a/internal/resources/console_test.go
+++ b/internal/resources/console_test.go
@@ -117,12 +117,13 @@ var _ = Describe("Console Resources", func() {
 			Expect(console.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 			Expect(*console.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
 			Expect(console.SecurityContext.RunAsUser).To(BeNil(), "hardcoded RunAsUser breaks OCP restricted SCC")
-			Expect(console.VolumeMounts).To(HaveLen(3))
+			Expect(console.VolumeMounts).To(HaveLen(4))
 
-			Expect(spec.Volumes).To(HaveLen(2))
+			Expect(spec.Volumes).To(HaveLen(3))
 			Expect(spec.Volumes[0].Name).To(Equal("nginx-tmp"))
 			Expect(spec.Volumes[1].Name).To(Equal("nginx-config"))
 			Expect(spec.Volumes[1].ConfigMap.Name).To(Equal(ComponentConsole + "-nginx"))
+			Expect(spec.Volumes[2].Name).To(Equal("tls-ca"))
 		})
 	})
 
@@ -172,6 +173,75 @@ var _ = Describe("Console Resources", func() {
 			httpConf := cm.Data["http.conf"]
 			Expect(httpConf).To(ContainSubstring("limit_req_zone"))
 			Expect(httpConf).To(ContainSubstring("gzip on"))
+		})
+	})
+
+	Context("ConsoleNginxConfigMap TLS (#198)", func() {
+		It("UT-CN-198-001 [SC-8]: proxy_pass uses https:// scheme for AF upstream", func() {
+			kn := testKubernautWithConsole()
+			cm := ConsoleNginxConfigMap(kn)
+			serverConf := cm.Data["server.conf"]
+			Expect(serverConf).To(ContainSubstring("proxy_pass https://"),
+				"proxy_pass must use https:// to connect to AF over TLS")
+		})
+
+		It("UT-CN-198-002 [SC-8]: includes proxy_ssl_trusted_certificate directive", func() {
+			kn := testKubernautWithConsole()
+			cm := ConsoleNginxConfigMap(kn)
+			serverConf := cm.Data["server.conf"]
+			Expect(serverConf).To(ContainSubstring("proxy_ssl_trusted_certificate"),
+				"nginx must trust the service-ca bundle for upstream TLS verification")
+		})
+
+		It("UT-CN-198-003 [SC-8]: includes proxy_ssl_verify on", func() {
+			kn := testKubernautWithConsole()
+			cm := ConsoleNginxConfigMap(kn)
+			serverConf := cm.Data["server.conf"]
+			Expect(serverConf).To(ContainSubstring("proxy_ssl_verify on"),
+				"nginx must verify the AF upstream certificate")
+		})
+
+		It("UT-CN-198-004 [SC-8]: proxy_pass does NOT use http:// (negative)", func() {
+			kn := testKubernautWithConsole()
+			cm := ConsoleNginxConfigMap(kn)
+			serverConf := cm.Data["server.conf"]
+			Expect(serverConf).NotTo(ContainSubstring("proxy_pass http://"),
+				"plaintext HTTP proxy_pass to AF must not appear")
+		})
+	})
+
+	Context("ConsoleDeployment TLS (#198)", func() {
+		It("UT-CD-198-001 [SC-8]: console container mounts tls-ca volume at /etc/tls-ca", func() {
+			kn := testKubernautWithConsole()
+			dep, err := ConsoleDeployment(kn, testIngressDomain)
+			Expect(err).NotTo(HaveOccurred())
+
+			console := dep.Spec.Template.Spec.Containers[1]
+			Expect(console.Name).To(Equal("console"))
+
+			found := false
+			for _, m := range console.VolumeMounts {
+				if m.Name == "tls-ca" && m.MountPath == "/etc/tls-ca" && m.ReadOnly {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(),
+				"console container must mount tls-ca at /etc/tls-ca for nginx proxy_ssl_trusted_certificate")
+		})
+
+		It("UT-CD-198-002 [CM-6]: tls-ca volume sources from inter-service-ca ConfigMap", func() {
+			kn := testKubernautWithConsole()
+			dep, err := ConsoleDeployment(kn, testIngressDomain)
+			Expect(err).NotTo(HaveOccurred())
+
+			found := false
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == "tls-ca" && v.ConfigMap != nil && v.ConfigMap.Name == InterServiceCAConfigMapName {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue(),
+				"tls-ca volume must source from the inter-service-ca ConfigMap")
 		})
 	})
 

--- a/internal/resources/console_test.go
+++ b/internal/resources/console_test.go
@@ -211,6 +211,8 @@ var _ = Describe("Console Resources", func() {
 	})
 
 	Context("ConsoleDeployment TLS (#198)", func() {
+		const tlsCAMountPath = "/etc/tls-ca"
+
 		It("UT-CD-198-001 [SC-8]: console container mounts tls-ca volume at /etc/tls-ca", func() {
 			kn := testKubernautWithConsole()
 			dep, err := ConsoleDeployment(kn, testIngressDomain)
@@ -221,12 +223,12 @@ var _ = Describe("Console Resources", func() {
 
 			found := false
 			for _, m := range console.VolumeMounts {
-				if m.Name == "tls-ca" && m.MountPath == "/etc/tls-ca" && m.ReadOnly {
+				if m.Name == testVolumeTLSCA && m.MountPath == tlsCAMountPath && m.ReadOnly {
 					found = true
 				}
 			}
 			Expect(found).To(BeTrue(),
-				"console container must mount tls-ca at /etc/tls-ca for nginx proxy_ssl_trusted_certificate")
+				"console container must mount tls-ca at %s for nginx proxy_ssl_trusted_certificate", tlsCAMountPath)
 		})
 
 		It("UT-CD-198-002 [CM-6]: tls-ca volume sources from inter-service-ca ConfigMap", func() {
@@ -236,7 +238,7 @@ var _ = Describe("Console Resources", func() {
 
 			found := false
 			for _, v := range dep.Spec.Template.Spec.Volumes {
-				if v.Name == "tls-ca" && v.ConfigMap != nil && v.ConfigMap.Name == InterServiceCAConfigMapName {
+				if v.Name == testVolumeTLSCA && v.ConfigMap != nil && v.ConfigMap.Name == InterServiceCAConfigMapName {
 					found = true
 				}
 			}


### PR DESCRIPTION
## Summary

- Fixes console→AF communication by switching nginx `proxy_pass` from `http://` to `https://` (AF always serves TLS on :8443 via OCP service-ca).
- Adds `proxy_ssl_trusted_certificate`, `proxy_ssl_verify on`, and `proxy_ssl_server_name on` to the nginx server config.
- Mounts the `inter-service-ca` ConfigMap as a volume in the console pod so nginx can verify AF's certificate.

Closes #198

## Test plan

- [x] IEEE 829 test plan in `docs/tests/198/TEST_PLAN.md`
- [x] 6 unit tests (UT-CN-198-001..004, UT-CD-198-001..002) — all pass
- [x] Full `internal/resources` suite (574 specs) — 0 failures, no regressions
- [ ] E2E validation on OCP cluster


Made with [Cursor](https://cursor.com)