### PR TITLE
chore: bump kubernaut deps to latest main for pre-release validation

### DIFF
--- a/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
@@ -348,31 +348,31 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_GATEWAY
-                  value: quay.io/kubernaut-ai/gateway@sha256:0d341f1f63483db87ef5ec1d89e06563d9e36d24c252e7e0d971ce83d5ab639e
+                  value: ghcr.io/jordigilh/kubernaut/gateway@sha256:99a772299bd81ada825551bc39b116386aa49017b4554e93068b5c2c03e941ab
                 - name: RELATED_IMAGE_DATA_STORAGE
-                  value: quay.io/kubernaut-ai/datastorage@sha256:42bb2d59c08bf052a39ce425038c25ea219fc711a2b4fb53f5cf267ef9ae151c
+                  value: ghcr.io/jordigilh/kubernaut/datastorage@sha256:e892cdfea25f505c6acc7c8ea75aa135a9c1dd4a9c82468fc4c217e209d7c0f4
                 - name: RELATED_IMAGE_AIANALYSIS
-                  value: quay.io/kubernaut-ai/aianalysis@sha256:8e73a2287838034301c04705766bbe9a5610e2f349c49f7e2ab1cbbd9494e8e9
+                  value: ghcr.io/jordigilh/kubernaut/aianalysis@sha256:057bcaab0b8e972e31422886e468573697a77c43552f422f18b233336a1ca530
                 - name: RELATED_IMAGE_SIGNALPROCESSING
-                  value: quay.io/kubernaut-ai/signalprocessing@sha256:8ac56fd7233221664b7310df972489626ff3079cf5ee6947a2ccbfb36229f823
+                  value: ghcr.io/jordigilh/kubernaut/signalprocessing@sha256:d47d96857ddf1d4a1f86e694e7244c4e50a26e0b2e176813be20681f44252e52
                 - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-                  value: quay.io/kubernaut-ai/remediationorchestrator@sha256:536579c1ad43475b9cc0414aa867a2f3f194286db4d81bc10f2a4a8c2a4be9bf
+                  value: ghcr.io/jordigilh/kubernaut/remediationorchestrator@sha256:4ea778fbd4c996a484c72301a00c94a4f89e11c61dde84f0615cc4ebc817cf1b
                 - name: RELATED_IMAGE_WORKFLOWEXECUTION
-                  value: quay.io/kubernaut-ai/workflowexecution@sha256:d7a56c9012a9ce638cbf181a24c62cc701b36f9c4286355cca1515f693fc5d2a
+                  value: ghcr.io/jordigilh/kubernaut/workflowexecution@sha256:00df372e18f7773da00f6e9f5461aee4ce5af64e20964254e679116cfac270ac
                 - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-                  value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:dd117c24570596eaabd36916c89e8a9386285c6402a16485d9b692b18ea00f79
+                  value: ghcr.io/jordigilh/kubernaut/effectivenessmonitor@sha256:3632f234b059f0eae0b105bcd255257692c3b3c1ba8f8955bb093a9a847bb0f2
                 - name: RELATED_IMAGE_NOTIFICATION
-                  value: quay.io/kubernaut-ai/notification@sha256:575a53e48090a6b2b285cbfbc0fcc220502ec1acb272a34067889afe33e7ed0a
+                  value: ghcr.io/jordigilh/kubernaut/notification@sha256:ef67d0e42b2347497c20e47d85e358c6190c931c20f6118eebee24d7cd708c1d
                 - name: RELATED_IMAGE_KUBERNAUT_AGENT
-                  value: quay.io/kubernaut-ai/kubernautagent@sha256:ca5104891143c4b1ba681b5f007a3b70f83e58cdead922a8b5ec67c6126b0040
+                  value: ghcr.io/jordigilh/kubernaut/kubernautagent@sha256:fdd41d72872b98221b2eb435be144d86d05e0d030274c8f5724749a8a9718c6c
                 - name: RELATED_IMAGE_AUTHWEBHOOK
-                  value: quay.io/kubernaut-ai/authwebhook@sha256:de70733e73713deab87638a31f55ce5ff9638648e134c699cac784129d424c50
+                  value: ghcr.io/jordigilh/kubernaut/authwebhook@sha256:d8e09bac3c6516211f9158b8a2d9d9681c169337b44681418b418f0fd3a27faf
                 - name: RELATED_IMAGE_API_FRONTEND
-                  value: quay.io/kubernaut-ai/apifrontend@sha256:0b929c154fa9c43c2fb9adfeb2197e1c9007dfc22d75fe4f194822c830efdf31
+                  value: ghcr.io/jordigilh/kubernaut/apifrontend@sha256:fb8d1751b19392e4d8970bec7082247a8503168b5358bd4e6c86f3729e9ee1f0
                 - name: RELATED_IMAGE_DB_MIGRATE
-                  value: quay.io/kubernaut-ai/db-migrate@sha256:7bd94ae3eb1f614608104fa71b1c390c44f0a63207371381f1b5001e0778bf58
+                  value: ghcr.io/jordigilh/kubernaut/db-migrate@sha256:0be348b17e417ff5757a17bb65c4558c3827478e7e8b04a39fc329d0757e577e
                 - name: RELATED_IMAGE_CONSOLE
-                  value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+                  value: ghcr.io/jordigilh/kubernaut-console@sha256:fa0e6401deadb0423eb255f507a6231ff7c4681f23e16266ac162201a7cb1f88
                 - name: RELATED_IMAGE_OAUTH2_PROXY
                   value: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
                 - name: RELATED_IMAGE_INIT_POSTGRES
@@ -481,31 +481,31 @@ spec:
     name: Kubernaut AI
     url: https://github.com/jordigilh/kubernaut
   relatedImages:
-  - image: quay.io/kubernaut-ai/gateway@sha256:0d341f1f63483db87ef5ec1d89e06563d9e36d24c252e7e0d971ce83d5ab639e
+  - image: ghcr.io/jordigilh/kubernaut/gateway@sha256:99a772299bd81ada825551bc39b116386aa49017b4554e93068b5c2c03e941ab
     name: gateway
-  - image: quay.io/kubernaut-ai/datastorage@sha256:42bb2d59c08bf052a39ce425038c25ea219fc711a2b4fb53f5cf267ef9ae151c
+  - image: ghcr.io/jordigilh/kubernaut/datastorage@sha256:e892cdfea25f505c6acc7c8ea75aa135a9c1dd4a9c82468fc4c217e209d7c0f4
     name: data-storage
-  - image: quay.io/kubernaut-ai/aianalysis@sha256:8e73a2287838034301c04705766bbe9a5610e2f349c49f7e2ab1cbbd9494e8e9
+  - image: ghcr.io/jordigilh/kubernaut/aianalysis@sha256:057bcaab0b8e972e31422886e468573697a77c43552f422f18b233336a1ca530
     name: aianalysis
-  - image: quay.io/kubernaut-ai/signalprocessing@sha256:8ac56fd7233221664b7310df972489626ff3079cf5ee6947a2ccbfb36229f823
+  - image: ghcr.io/jordigilh/kubernaut/signalprocessing@sha256:d47d96857ddf1d4a1f86e694e7244c4e50a26e0b2e176813be20681f44252e52
     name: signalprocessing
-  - image: quay.io/kubernaut-ai/remediationorchestrator@sha256:536579c1ad43475b9cc0414aa867a2f3f194286db4d81bc10f2a4a8c2a4be9bf
+  - image: ghcr.io/jordigilh/kubernaut/remediationorchestrator@sha256:4ea778fbd4c996a484c72301a00c94a4f89e11c61dde84f0615cc4ebc817cf1b
     name: remediationorchestrator
-  - image: quay.io/kubernaut-ai/workflowexecution@sha256:d7a56c9012a9ce638cbf181a24c62cc701b36f9c4286355cca1515f693fc5d2a
+  - image: ghcr.io/jordigilh/kubernaut/workflowexecution@sha256:00df372e18f7773da00f6e9f5461aee4ce5af64e20964254e679116cfac270ac
     name: workflowexecution
-  - image: quay.io/kubernaut-ai/effectivenessmonitor@sha256:dd117c24570596eaabd36916c89e8a9386285c6402a16485d9b692b18ea00f79
+  - image: ghcr.io/jordigilh/kubernaut/effectivenessmonitor@sha256:3632f234b059f0eae0b105bcd255257692c3b3c1ba8f8955bb093a9a847bb0f2
     name: effectivenessmonitor
-  - image: quay.io/kubernaut-ai/notification@sha256:575a53e48090a6b2b285cbfbc0fcc220502ec1acb272a34067889afe33e7ed0a
+  - image: ghcr.io/jordigilh/kubernaut/notification@sha256:ef67d0e42b2347497c20e47d85e358c6190c931c20f6118eebee24d7cd708c1d
     name: notification
-  - image: quay.io/kubernaut-ai/kubernautagent@sha256:ca5104891143c4b1ba681b5f007a3b70f83e58cdead922a8b5ec67c6126b0040
+  - image: ghcr.io/jordigilh/kubernaut/kubernautagent@sha256:fdd41d72872b98221b2eb435be144d86d05e0d030274c8f5724749a8a9718c6c
     name: kubernaut-agent
-  - image: quay.io/kubernaut-ai/authwebhook@sha256:de70733e73713deab87638a31f55ce5ff9638648e134c699cac784129d424c50
+  - image: ghcr.io/jordigilh/kubernaut/authwebhook@sha256:d8e09bac3c6516211f9158b8a2d9d9681c169337b44681418b418f0fd3a27faf
     name: authwebhook
-  - image: quay.io/kubernaut-ai/apifrontend@sha256:0b929c154fa9c43c2fb9adfeb2197e1c9007dfc22d75fe4f194822c830efdf31
+  - image: ghcr.io/jordigilh/kubernaut/apifrontend@sha256:fb8d1751b19392e4d8970bec7082247a8503168b5358bd4e6c86f3729e9ee1f0
     name: api-frontend
-  - image: quay.io/kubernaut-ai/db-migrate@sha256:7bd94ae3eb1f614608104fa71b1c390c44f0a63207371381f1b5001e0778bf58
+  - image: ghcr.io/jordigilh/kubernaut/db-migrate@sha256:0be348b17e417ff5757a17bb65c4558c3827478e7e8b04a39fc329d0757e577e
     name: db-migrate
-  - image: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+  - image: ghcr.io/jordigilh/kubernaut-console@sha256:fa0e6401deadb0423eb255f507a6231ff7c4681f23e16266ac162201a7cb1f88
     name: console
   - image: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
     name: oauth2-proxy

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,31 +58,31 @@ spec:
         name: manager
         env:
         - name: RELATED_IMAGE_GATEWAY
-          value: quay.io/kubernaut-ai/gateway@sha256:0d341f1f63483db87ef5ec1d89e06563d9e36d24c252e7e0d971ce83d5ab639e
+          value: ghcr.io/jordigilh/kubernaut/gateway@sha256:99a772299bd81ada825551bc39b116386aa49017b4554e93068b5c2c03e941ab
         - name: RELATED_IMAGE_DATA_STORAGE
-          value: quay.io/kubernaut-ai/datastorage@sha256:42bb2d59c08bf052a39ce425038c25ea219fc711a2b4fb53f5cf267ef9ae151c
+          value: ghcr.io/jordigilh/kubernaut/datastorage@sha256:e892cdfea25f505c6acc7c8ea75aa135a9c1dd4a9c82468fc4c217e209d7c0f4
         - name: RELATED_IMAGE_AIANALYSIS
-          value: quay.io/kubernaut-ai/aianalysis@sha256:8e73a2287838034301c04705766bbe9a5610e2f349c49f7e2ab1cbbd9494e8e9
+          value: ghcr.io/jordigilh/kubernaut/aianalysis@sha256:057bcaab0b8e972e31422886e468573697a77c43552f422f18b233336a1ca530
         - name: RELATED_IMAGE_SIGNALPROCESSING
-          value: quay.io/kubernaut-ai/signalprocessing@sha256:8ac56fd7233221664b7310df972489626ff3079cf5ee6947a2ccbfb36229f823
+          value: ghcr.io/jordigilh/kubernaut/signalprocessing@sha256:d47d96857ddf1d4a1f86e694e7244c4e50a26e0b2e176813be20681f44252e52
         - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:536579c1ad43475b9cc0414aa867a2f3f194286db4d81bc10f2a4a8c2a4be9bf
+          value: ghcr.io/jordigilh/kubernaut/remediationorchestrator@sha256:4ea778fbd4c996a484c72301a00c94a4f89e11c61dde84f0615cc4ebc817cf1b
         - name: RELATED_IMAGE_WORKFLOWEXECUTION
-          value: quay.io/kubernaut-ai/workflowexecution@sha256:d7a56c9012a9ce638cbf181a24c62cc701b36f9c4286355cca1515f693fc5d2a
+          value: ghcr.io/jordigilh/kubernaut/workflowexecution@sha256:00df372e18f7773da00f6e9f5461aee4ce5af64e20964254e679116cfac270ac
         - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:dd117c24570596eaabd36916c89e8a9386285c6402a16485d9b692b18ea00f79
+          value: ghcr.io/jordigilh/kubernaut/effectivenessmonitor@sha256:3632f234b059f0eae0b105bcd255257692c3b3c1ba8f8955bb093a9a847bb0f2
         - name: RELATED_IMAGE_NOTIFICATION
-          value: quay.io/kubernaut-ai/notification@sha256:575a53e48090a6b2b285cbfbc0fcc220502ec1acb272a34067889afe33e7ed0a
+          value: ghcr.io/jordigilh/kubernaut/notification@sha256:ef67d0e42b2347497c20e47d85e358c6190c931c20f6118eebee24d7cd708c1d
         - name: RELATED_IMAGE_KUBERNAUT_AGENT
-          value: quay.io/kubernaut-ai/kubernautagent@sha256:ca5104891143c4b1ba681b5f007a3b70f83e58cdead922a8b5ec67c6126b0040
+          value: ghcr.io/jordigilh/kubernaut/kubernautagent@sha256:fdd41d72872b98221b2eb435be144d86d05e0d030274c8f5724749a8a9718c6c
         - name: RELATED_IMAGE_AUTHWEBHOOK
-          value: quay.io/kubernaut-ai/authwebhook@sha256:de70733e73713deab87638a31f55ce5ff9638648e134c699cac784129d424c50
+          value: ghcr.io/jordigilh/kubernaut/authwebhook@sha256:d8e09bac3c6516211f9158b8a2d9d9681c169337b44681418b418f0fd3a27faf
         - name: RELATED_IMAGE_API_FRONTEND
-          value: quay.io/kubernaut-ai/apifrontend@sha256:0b929c154fa9c43c2fb9adfeb2197e1c9007dfc22d75fe4f194822c830efdf31
+          value: ghcr.io/jordigilh/kubernaut/apifrontend@sha256:fb8d1751b19392e4d8970bec7082247a8503168b5358bd4e6c86f3729e9ee1f0
         - name: RELATED_IMAGE_DB_MIGRATE
-          value: quay.io/kubernaut-ai/db-migrate@sha256:7bd94ae3eb1f614608104fa71b1c390c44f0a63207371381f1b5001e0778bf58
+          value: ghcr.io/jordigilh/kubernaut/db-migrate@sha256:0be348b17e417ff5757a17bb65c4558c3827478e7e8b04a39fc329d0757e577e
         - name: RELATED_IMAGE_CONSOLE
-          value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+          value: ghcr.io/jordigilh/kubernaut-console@sha256:fa0e6401deadb0423eb255f507a6231ff7c4681f23e16266ac162201a7cb1f88
         - name: RELATED_IMAGE_OAUTH2_PROXY
           value: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
         - name: RELATED_IMAGE_INIT_POSTGRES

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2781,31 +2781,31 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_GATEWAY
-          value: quay.io/kubernaut-ai/gateway@sha256:0d341f1f63483db87ef5ec1d89e06563d9e36d24c252e7e0d971ce83d5ab639e
+          value: ghcr.io/jordigilh/kubernaut/gateway@sha256:99a772299bd81ada825551bc39b116386aa49017b4554e93068b5c2c03e941ab
         - name: RELATED_IMAGE_DATA_STORAGE
-          value: quay.io/kubernaut-ai/datastorage@sha256:42bb2d59c08bf052a39ce425038c25ea219fc711a2b4fb53f5cf267ef9ae151c
+          value: ghcr.io/jordigilh/kubernaut/datastorage@sha256:e892cdfea25f505c6acc7c8ea75aa135a9c1dd4a9c82468fc4c217e209d7c0f4
         - name: RELATED_IMAGE_AIANALYSIS
-          value: quay.io/kubernaut-ai/aianalysis@sha256:8e73a2287838034301c04705766bbe9a5610e2f349c49f7e2ab1cbbd9494e8e9
+          value: ghcr.io/jordigilh/kubernaut/aianalysis@sha256:057bcaab0b8e972e31422886e468573697a77c43552f422f18b233336a1ca530
         - name: RELATED_IMAGE_SIGNALPROCESSING
-          value: quay.io/kubernaut-ai/signalprocessing@sha256:8ac56fd7233221664b7310df972489626ff3079cf5ee6947a2ccbfb36229f823
+          value: ghcr.io/jordigilh/kubernaut/signalprocessing@sha256:d47d96857ddf1d4a1f86e694e7244c4e50a26e0b2e176813be20681f44252e52
         - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
-          value: quay.io/kubernaut-ai/remediationorchestrator@sha256:536579c1ad43475b9cc0414aa867a2f3f194286db4d81bc10f2a4a8c2a4be9bf
+          value: ghcr.io/jordigilh/kubernaut/remediationorchestrator@sha256:4ea778fbd4c996a484c72301a00c94a4f89e11c61dde84f0615cc4ebc817cf1b
         - name: RELATED_IMAGE_WORKFLOWEXECUTION
-          value: quay.io/kubernaut-ai/workflowexecution@sha256:d7a56c9012a9ce638cbf181a24c62cc701b36f9c4286355cca1515f693fc5d2a
+          value: ghcr.io/jordigilh/kubernaut/workflowexecution@sha256:00df372e18f7773da00f6e9f5461aee4ce5af64e20964254e679116cfac270ac
         - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
-          value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:dd117c24570596eaabd36916c89e8a9386285c6402a16485d9b692b18ea00f79
+          value: ghcr.io/jordigilh/kubernaut/effectivenessmonitor@sha256:3632f234b059f0eae0b105bcd255257692c3b3c1ba8f8955bb093a9a847bb0f2
         - name: RELATED_IMAGE_NOTIFICATION
-          value: quay.io/kubernaut-ai/notification@sha256:575a53e48090a6b2b285cbfbc0fcc220502ec1acb272a34067889afe33e7ed0a
+          value: ghcr.io/jordigilh/kubernaut/notification@sha256:ef67d0e42b2347497c20e47d85e358c6190c931c20f6118eebee24d7cd708c1d
         - name: RELATED_IMAGE_KUBERNAUT_AGENT
-          value: quay.io/kubernaut-ai/kubernautagent@sha256:ca5104891143c4b1ba681b5f007a3b70f83e58cdead922a8b5ec67c6126b0040
+          value: ghcr.io/jordigilh/kubernaut/kubernautagent@sha256:fdd41d72872b98221b2eb435be144d86d05e0d030274c8f5724749a8a9718c6c
         - name: RELATED_IMAGE_AUTHWEBHOOK
-          value: quay.io/kubernaut-ai/authwebhook@sha256:de70733e73713deab87638a31f55ce5ff9638648e134c699cac784129d424c50
+          value: ghcr.io/jordigilh/kubernaut/authwebhook@sha256:d8e09bac3c6516211f9158b8a2d9d9681c169337b44681418b418f0fd3a27faf
         - name: RELATED_IMAGE_API_FRONTEND
-          value: quay.io/kubernaut-ai/apifrontend@sha256:0b929c154fa9c43c2fb9adfeb2197e1c9007dfc22d75fe4f194822c830efdf31
+          value: ghcr.io/jordigilh/kubernaut/apifrontend@sha256:fb8d1751b19392e4d8970bec7082247a8503168b5358bd4e6c86f3729e9ee1f0
         - name: RELATED_IMAGE_DB_MIGRATE
-          value: quay.io/kubernaut-ai/db-migrate@sha256:7bd94ae3eb1f614608104fa71b1c390c44f0a63207371381f1b5001e0778bf58
+          value: ghcr.io/jordigilh/kubernaut/db-migrate@sha256:0be348b17e417ff5757a17bb65c4558c3827478e7e8b04a39fc329d0757e577e
         - name: RELATED_IMAGE_CONSOLE
-          value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+          value: ghcr.io/jordigilh/kubernaut-console@sha256:fa0e6401deadb0423eb255f507a6231ff7c4681f23e16266ac162201a7cb1f88
         - name: RELATED_IMAGE_OAUTH2_PROXY
           value: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
         - name: RELATED_IMAGE_INIT_POSTGRES

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jordigilh/kubernaut-operator
 go 1.26
 
 require (
-	github.com/jordigilh/kubernaut v1.5.2
+	github.com/jordigilh/kubernaut v1.5.3-0.20260626224623-b5fde54b9325
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.0
 	github.com/openshift/api v0.0.0-20260327162646-993e604705e3

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jordigilh/kubernaut v1.5.2 h1:lubTcP91H6DFD10FY3ILFPVkxcceLk7I7b+XLM+uIFw=
-github.com/jordigilh/kubernaut v1.5.2/go.mod h1:AiKZgS0Ro3HRHZjZIJyEGi7yVI6fIgnTgdU5rMciCa0=
+github.com/jordigilh/kubernaut v1.5.3-0.20260626224623-b5fde54b9325 h1:Ae5GVm8QjrTIjfSrMc4ZaI+Buc1KFMt5Y3y1AUVoKno=
+github.com/jordigilh/kubernaut v1.5.3-0.20260626224623-b5fde54b9325/go.mod h1:AiKZgS0Ro3HRHZjZIJyEGi7yVI6fIgnTgdU5rMciCa0=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/hack/airgap/imageset-config.yaml
+++ b/hack/airgap/imageset-config.yaml
@@ -18,19 +18,19 @@ mirror:
     # Operator bundle
     - name: quay.io/kubernaut-ai/kubernaut-operator-bundle@sha256:d272667c6a3bc6ab683db223e47fc2ca0bd69d6a4bb13cab676620a0176bba6b
     # Operand and infrastructure images
-    - name: quay.io/kubernaut-ai/aianalysis@sha256:8e73a2287838034301c04705766bbe9a5610e2f349c49f7e2ab1cbbd9494e8e9
-    - name: quay.io/kubernaut-ai/apifrontend@sha256:0b929c154fa9c43c2fb9adfeb2197e1c9007dfc22d75fe4f194822c830efdf31
-    - name: quay.io/kubernaut-ai/authwebhook@sha256:de70733e73713deab87638a31f55ce5ff9638648e134c699cac784129d424c50
-    - name: quay.io/kubernaut-ai/datastorage@sha256:42bb2d59c08bf052a39ce425038c25ea219fc711a2b4fb53f5cf267ef9ae151c
-    - name: quay.io/kubernaut-ai/db-migrate@sha256:7bd94ae3eb1f614608104fa71b1c390c44f0a63207371381f1b5001e0778bf58
-    - name: quay.io/kubernaut-ai/effectivenessmonitor@sha256:dd117c24570596eaabd36916c89e8a9386285c6402a16485d9b692b18ea00f79
-    - name: quay.io/kubernaut-ai/gateway@sha256:0d341f1f63483db87ef5ec1d89e06563d9e36d24c252e7e0d971ce83d5ab639e
-    - name: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
-    - name: quay.io/kubernaut-ai/kubernautagent@sha256:ca5104891143c4b1ba681b5f007a3b70f83e58cdead922a8b5ec67c6126b0040
-    - name: quay.io/kubernaut-ai/notification@sha256:575a53e48090a6b2b285cbfbc0fcc220502ec1acb272a34067889afe33e7ed0a
-    - name: quay.io/kubernaut-ai/remediationorchestrator@sha256:536579c1ad43475b9cc0414aa867a2f3f194286db4d81bc10f2a4a8c2a4be9bf
-    - name: quay.io/kubernaut-ai/signalprocessing@sha256:8ac56fd7233221664b7310df972489626ff3079cf5ee6947a2ccbfb36229f823
-    - name: quay.io/kubernaut-ai/workflowexecution@sha256:d7a56c9012a9ce638cbf181a24c62cc701b36f9c4286355cca1515f693fc5d2a
+    - name: ghcr.io/jordigilh/kubernaut/aianalysis@sha256:057bcaab0b8e972e31422886e468573697a77c43552f422f18b233336a1ca530
+    - name: ghcr.io/jordigilh/kubernaut/apifrontend@sha256:fb8d1751b19392e4d8970bec7082247a8503168b5358bd4e6c86f3729e9ee1f0
+    - name: ghcr.io/jordigilh/kubernaut/authwebhook@sha256:d8e09bac3c6516211f9158b8a2d9d9681c169337b44681418b418f0fd3a27faf
+    - name: ghcr.io/jordigilh/kubernaut/datastorage@sha256:e892cdfea25f505c6acc7c8ea75aa135a9c1dd4a9c82468fc4c217e209d7c0f4
+    - name: ghcr.io/jordigilh/kubernaut/db-migrate@sha256:0be348b17e417ff5757a17bb65c4558c3827478e7e8b04a39fc329d0757e577e
+    - name: ghcr.io/jordigilh/kubernaut/effectivenessmonitor@sha256:3632f234b059f0eae0b105bcd255257692c3b3c1ba8f8955bb093a9a847bb0f2
+    - name: ghcr.io/jordigilh/kubernaut/gateway@sha256:99a772299bd81ada825551bc39b116386aa49017b4554e93068b5c2c03e941ab
+    - name: ghcr.io/jordigilh/kubernaut-console@sha256:fa0e6401deadb0423eb255f507a6231ff7c4681f23e16266ac162201a7cb1f88
+    - name: ghcr.io/jordigilh/kubernaut/kubernautagent@sha256:fdd41d72872b98221b2eb435be144d86d05e0d030274c8f5724749a8a9718c6c
+    - name: ghcr.io/jordigilh/kubernaut/notification@sha256:ef67d0e42b2347497c20e47d85e358c6190c931c20f6118eebee24d7cd708c1d
+    - name: ghcr.io/jordigilh/kubernaut/remediationorchestrator@sha256:4ea778fbd4c996a484c72301a00c94a4f89e11c61dde84f0615cc4ebc817cf1b
+    - name: ghcr.io/jordigilh/kubernaut/signalprocessing@sha256:d47d96857ddf1d4a1f86e694e7244c4e50a26e0b2e176813be20681f44252e52
+    - name: ghcr.io/jordigilh/kubernaut/workflowexecution@sha256:00df372e18f7773da00f6e9f5461aee4ce5af64e20964254e679116cfac270ac
     # Console oauth2-proxy sidecar
     - name: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
     # Infrastructure dependencies (PostgreSQL, Valkey)


### PR DESCRIPTION
## Summary

- Bump `github.com/jordigilh/kubernaut` Go module from v1.5.2 to v1.5.3-0.20260626224623-b5fde54b9325 (latest main, commit b5fde54b9325)
- Update all 13 operand container images to latest multi-arch builds from kubernaut main CI run [#28269488264](https://github.com/jordigilh/kubernaut/actions/runs/28269488264), switching registry from `quay.io/kubernaut-ai` to `ghcr.io/jordigilh/kubernaut`
- Update console image to latest build from [#28211510511](https://github.com/jordigilh/kubernaut-console/actions/runs/28211510511) (commit 04299cb)

## Motivation

Validate that the latest code changes in both the operator and kubernaut upstream don't have regressions before cutting a new release. The CI/CD pipeline will build a new operator image from this branch for deployment in the dev environment.

## CRD Impact

No CRD changes required. Analysis of upstream changes (LLM config normalization #1488, KA shutdown drain #1329, logging format #1330, AF bug fixes) confirmed full backward compatibility with the current operator CRD.

## Test plan

- [ ] CI pipeline builds operator image successfully
- [ ] Deploy operator in dev environment
- [ ] Verify all operand pods start and reach Ready state
- [ ] Run smoke test against deployed platform

Made with [Cursor](https://cursor.com)