### PR TITLE
chore: add workspace-level MCP config for project isolation

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "hindsight-docs": {
+      "type": "http",
+      "url": "http://localhost:8888/mcp/kubernaut-docs/"
+    },
+    "hindsight-issues": {
+      "type": "http",
+      "url": "http://localhost:8888/mcp/kubernaut-issues/"
+    },
+    "cocoindex-code": {
+      "command": "/Users/jgil/.hindsight/venv/bin/python3",
+      "args": ["/Users/jgil/.hindsight/cocoindex-search.py"],
+      "type": "stdio",
+      "env": {
+        "COCOINDEX_PG_URL": "postgresql://hindsight:hindsight@localhost:5432/hindsight"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.cursor/mcp.json` with kubernaut-specific MCP servers for workspace-level isolation
- Enables project-specific MCP scoping so other Engram-enabled projects get their own banks

## Test plan

- [ ] Verify MCP servers connect correctly when opening this workspace

Made with [Cursor](https://cursor.com)