### PR TITLE
chore: pin operator/bundle digests for v1.5.5

### DIFF
--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2812,7 +2812,7 @@ spec:
           value: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
         - name: RELATED_IMAGE_INIT_UBI_MINIMAL
           value: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
-        image: quay.io/kubernaut-ai/kubernaut-operator:1.5.5
+        image: quay.io/kubernaut-ai/kubernaut-operator@sha256:46735c9f7320edf6ca5705cc846cc93d75e301e2f026e7764901c7d9e57f3d9c
         livenessProbe:
           httpGet:
             path: /healthz

--- a/hack/airgap/imageset-config.yaml
+++ b/hack/airgap/imageset-config.yaml
@@ -14,9 +14,9 @@ apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   additionalImages:
     # Operator
-    - name: quay.io/kubernaut-ai/kubernaut-operator:1.5.5
+    - name: quay.io/kubernaut-ai/kubernaut-operator@sha256:46735c9f7320edf6ca5705cc846cc93d75e301e2f026e7764901c7d9e57f3d9c
     # Operator bundle
-    - name: quay.io/kubernaut-ai/kubernaut-operator-bundle:v1.5.5
+    - name: quay.io/kubernaut-ai/kubernaut-operator-bundle@sha256:d1c5275d11844799b13b98589076df5a4db8c43d4720d3140f4054a5283afb35
     # Operand and infrastructure images
     - name: quay.io/kubernaut-ai/aianalysis@sha256:ca6ccf69586f38915da7e340e714e2657171db93a9149cafeeebf4ca27e6a657
     - name: quay.io/kubernaut-ai/apifrontend@sha256:4e60d1e5e88717f991c20739fee408cfc985e5ba072c3273d91dc9f805600e1b
@@ -31,9 +31,8 @@ mirror:
     - name: quay.io/kubernaut-ai/remediationorchestrator@sha256:179b0d6829bc9d843df22b51386ed0528aff4194cfe13db2f0ff5ed62e2e31c7
     - name: quay.io/kubernaut-ai/signalprocessing@sha256:4e770e3010529974a95653eabdf3a77c6e9c08ff7559e852ff3838d1279f4035
     - name: quay.io/kubernaut-ai/workflowexecution@sha256:e9d8292719139cf845b26bfa5d8d4911af197aba853b7e69538061175063c3e0
-    # Console oauth2-proxy sidecar
     - name: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
-    # Infrastructure dependencies (PostgreSQL, Valkey)
     - name: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
     - name: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
+    # Infrastructure dependencies (PostgreSQL, Valkey)
     - name: registry.redhat.io/rhel10/valkey-8@sha256:7b478930b2d186a61c3af408c3228f3da5104c759b8bd52d62c683e33bdb9ee2


### PR DESCRIPTION
## Summary
- Resolves the `kubernaut-operator` (`v1.5.5`) and `kubernaut-operator-bundle` (`v1.5.5`) manifest-list digests now that the [release pipeline](https://github.com/jordigilh/kubernaut-operator/actions/runs/28990466860) has published them.
- Pins the operator's own image in `dist/install.yaml` from `quay.io/kubernaut-ai/kubernaut-operator:1.5.5` to a digest reference.
- Regenerates `hack/airgap/imageset-config.yaml` via `hack/airgap/generate-imageset.sh 1.5.5` to pin the operator and bundle self-images by digest for air-gapped mirroring.

Follows up on `b23f3a8` (release: bump to v1.5.5 with upstream kubernaut v1.5.3 image digests), mirroring the same two-phase pattern used for v1.5.4 (`859f35b` then `d3aa568`/`0c5bf58`).

## Test plan
- [x] `git diff` reviewed: only `dist/install.yaml` (operator image line) and `hack/airgap/imageset-config.yaml` (operator + bundle lines) changed.
- [x] Digests verified via `skopeo inspect --raw` against the published `quay.io/kubernaut-ai/kubernaut-operator:1.5.5` and `quay.io/kubernaut-ai/kubernaut-operator-bundle:v1.5.5` manifest lists.

Made with [Cursor](https://cursor.com)