### PR TITLE
fix: correct stale containerImage annotation in bundle CSV for v1.5.5

### DIFF
--- a/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernaut-operator.clusterserviceversion.yaml
@@ -47,8 +47,8 @@ metadata:
     capabilities: Full Lifecycle
     categories: AI/Machine Learning,Monitoring
     com.redhat.openshift.versions: v4.18
-    containerImage: quay.io/kubernaut-ai/kubernaut-operator:1.5.4
-    createdAt: '2026-07-09T02:44:05Z'
+    containerImage: quay.io/kubernaut-ai/kubernaut-operator:1.5.5
+    createdAt: '2026-07-09T03:01:12Z'
     description: "Automated Kubernetes remediation powered by AI \u2014 detects issues, analyzes root causes, and executes verified fixes."
     documentation: https://jordigilh.github.io/kubernaut-docs/latest/
     features.operators.openshift.io/cnf: 'false'


### PR DESCRIPTION
## Summary
- `config/manifests/bases/kubernaut-operator.clusterserviceversion.yaml`'s `containerImage` annotation was bumped to `1.5.5` after `make bundle` had already run in #212's predecessor commit, so the generated `bundle/manifests/kubernaut-operator.clusterserviceversion.yaml` still showed `1.5.4`.
- Re-ran `make bundle` to regenerate the CSV with the corrected annotation.

## Test plan
- [x] `git diff` reviewed: only the `containerImage` annotation and `createdAt` timestamp changed.

Made with [Cursor](https://cursor.com)