### PR TITLE
Add nodes/proxy RBAC permission and Alertmanager config for KA investigator

### DIFF
--- a/internal/resources/configmaps.go
+++ b/internal/resources/configmaps.go
@@ -587,10 +587,16 @@ type kaIntegrationsDataStorageYAML struct {
 }
 
 type kaIntegrationsToolsYAML struct {
-	Prometheus kaIntegrationsPrometheusYAML `json:"prometheus" yaml:"prometheus"`
+	Prometheus   kaIntegrationsPrometheusYAML    `json:"prometheus" yaml:"prometheus"`
+	Alertmanager *kaIntegrationsAlertmanagerYAML `json:"alertmanager,omitempty" yaml:"alertmanager,omitempty"`
 }
 
 type kaIntegrationsPrometheusYAML struct {
+	URL       string `json:"url" yaml:"url"`
+	TLSCaFile string `json:"tlsCaFile,omitempty" yaml:"tlsCaFile,omitempty"`
+}
+
+type kaIntegrationsAlertmanagerYAML struct {
 	URL       string `json:"url" yaml:"url"`
 	TLSCaFile string `json:"tlsCaFile,omitempty" yaml:"tlsCaFile,omitempty"`
 }
@@ -1367,6 +1373,13 @@ func KubernautAgentConfigMap(kn *kubernautv1alpha1.Kubernaut, opts ...ConfigMapO
 		cfg.Integrations.Tools = &kaIntegrationsToolsYAML{
 			Prometheus: kaIntegrationsPrometheusYAML{
 				URL:       OCPPrometheusURL,
+				TLSCaFile: "/etc/ssl/ka/service-ca.crt",
+			},
+			// Alertmanager tools (get_alerts, get_silences) added upstream in
+			// kubernaut#1508 (#205). Follows the same SA-bearer-auth-via-service-CA
+			// pattern as Prometheus.
+			Alertmanager: &kaIntegrationsAlertmanagerYAML{
+				URL:       OCPAlertManagerURL,
 				TLSCaFile: "/etc/ssl/ka/service-ca.crt",
 			},
 		}

--- a/internal/resources/configmaps_test.go
+++ b/internal/resources/configmaps_test.go
@@ -587,9 +587,11 @@ var _ = Describe("ConfigMaps", func() {
 			Expect(data).To(ContainSubstring("dataStorage:"), "KA config should contain dataStorage section, got:\n%s", data)
 			Expect(data).To(ContainSubstring("url: https://data-storage-service.kubernaut-system.svc.cluster.local:8443"), "KA config should contain HTTPS dataStorage.url, got:\n%s", data)
 			Expect(strings.Contains(data, "tools:") && strings.Contains(data, "prometheus:")).To(BeTrue(), "KA config should contain upstream tools.prometheus section when monitoring enabled, got:\n%s", data)
+			Expect(data).To(ContainSubstring("alertmanager:"), "KA config should contain upstream tools.alertmanager section when monitoring enabled (#205), got:\n%s", data)
+			Expect(data).To(ContainSubstring(OCPAlertManagerURL), "KA config should contain AlertManager URL when monitoring enabled (#205), got:\n%s", data)
 		})
 
-		It("omits Prometheus tools when monitoring is disabled", func() {
+		It("omits Prometheus and Alertmanager tools when monitoring is disabled", func() {
 			kn := testKubernaut()
 			disabled := false
 			kn.Spec.Monitoring.Enabled = &disabled
@@ -598,6 +600,7 @@ var _ = Describe("ConfigMaps", func() {
 			data := cm.Data["config.yaml"]
 
 			Expect(strings.Contains(data, "prometheusUrl") || strings.Contains(data, "tools:")).To(BeFalse(), "KA config should not contain Prometheus tools section when monitoring is disabled, got:\n%s", data)
+			Expect(data).NotTo(ContainSubstring("alertmanager:"), "KA config should not contain alertmanager section when monitoring is disabled (#205), got:\n%s", data)
 		})
 
 		It("matches expected v1.4 structure and defaults", func() {
@@ -634,6 +637,10 @@ var _ = Describe("ConfigMaps", func() {
 							URL       string `yaml:"url"`
 							TLSCaFile string `yaml:"tlsCaFile"`
 						} `yaml:"prometheus"`
+						Alertmanager *struct {
+							URL       string `yaml:"url"`
+							TLSCaFile string `yaml:"tlsCaFile"`
+						} `yaml:"alertmanager,omitempty"`
 					} `yaml:"tools,omitempty"`
 				} `yaml:"integrations"`
 			}
@@ -649,6 +656,9 @@ var _ = Describe("ConfigMaps", func() {
 			Expect(root.Integrations.Tools).NotTo(BeNil(), "integrations.tools should be present when monitoring is enabled by default")
 			Expect(root.Integrations.Tools.Prometheus.URL).To(Equal(OCPPrometheusURL), "integrations.tools.prometheus.url = %q, want %q", root.Integrations.Tools.Prometheus.URL, OCPPrometheusURL)
 			Expect(root.Integrations.Tools.Prometheus.TLSCaFile).To(Equal("/etc/ssl/ka/service-ca.crt"), "integrations.tools.prometheus.tlsCaFile = %q, want /etc/ssl/ka/service-ca.crt", root.Integrations.Tools.Prometheus.TLSCaFile)
+			Expect(root.Integrations.Tools.Alertmanager).NotTo(BeNil(), "integrations.tools.alertmanager should be present when monitoring is enabled by default (#205)")
+			Expect(root.Integrations.Tools.Alertmanager.URL).To(Equal(OCPAlertManagerURL), "integrations.tools.alertmanager.url = %q, want %q", root.Integrations.Tools.Alertmanager.URL, OCPAlertManagerURL)
+			Expect(root.Integrations.Tools.Alertmanager.TLSCaFile).To(Equal("/etc/ssl/ka/service-ca.crt"), "integrations.tools.alertmanager.tlsCaFile = %q, want /etc/ssl/ka/service-ca.crt", root.Integrations.Tools.Alertmanager.TLSCaFile)
 		})
 
 		It("renders logging format as JSON", func() {

--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -728,6 +728,8 @@ func kubernautAgentClientClusterRole(kn *kubernautv1alpha1.Kubernaut, labels map
 func kubernautAgentInvestigatorClusterRole(kn *kubernautv1alpha1.Kubernaut, labels map[string]string) *rbacv1.ClusterRole {
 	rules := []rbacv1.PolicyRule{
 		{APIGroups: []string{""}, Resources: []string{"pods", "pods/log", "services", "endpoints", "configmaps", "secrets", "nodes", "namespaces", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes", "resourcequotas", "serviceaccounts"}, Verbs: []string{"get", "list", "watch"}},
+		// Kubelet proxy API access for nodes_log and nodes_stats_summary tools (#205).
+		{APIGroups: []string{""}, Resources: []string{"nodes/proxy"}, Verbs: []string{"get"}},
 		{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"get", "list", "watch", "create", "patch"}},
 		{APIGroups: []string{"apps"}, Resources: []string{"deployments", "replicasets", "statefulsets", "daemonsets"}, Verbs: []string{"get", "list", "watch"}},
 		{APIGroups: []string{"storage.k8s.io"}, Resources: []string{"storageclasses", "csidrivers", "volumeattachments", "csinodes"}, Verbs: []string{"get", "list", "watch"}},

--- a/internal/resources/rbac_test.go
+++ b/internal/resources/rbac_test.go
@@ -268,6 +268,32 @@ var _ = Describe("ClusterRoles", func() {
 			}
 			Expect(found).To(BeTrue(), "kubernaut-agent-investigator should have events with create/patch verbs")
 		})
+
+		It("has get permission on nodes/proxy for kubelet proxy API access", func() {
+			kn := testKubernaut()
+			roles := ClusterRoles(kn)
+			var investigator *rbacv1.ClusterRole
+			for _, r := range roles {
+				if r.Name == kn.Namespace+"-kubernaut-agent-investigator" {
+					investigator = r
+					break
+				}
+			}
+			Expect(investigator).NotTo(BeNil())
+
+			found := false
+			for _, rule := range investigator.Rules {
+				if len(rule.APIGroups) > 0 && rule.APIGroups[0] == "" {
+					for _, res := range rule.Resources {
+						if res == "nodes/proxy" {
+							Expect(rule.Verbs).To(ContainElement("get"))
+							found = true
+						}
+					}
+				}
+			}
+			Expect(found).To(BeTrue(), "kubernaut-agent-investigator should have get permission on nodes/proxy for nodes_log and nodes_stats_summary tools (#205)")
+		})
 	})
 
 	Describe("Workflow runner", func() {


### PR DESCRIPTION
## Summary

Implements the two infrastructure changes required by the KA investigator for new tools added in [kubernaut#1508](https://github.com/jordigilh/kubernaut/pull/1508):

- Adds `get` permission on `nodes/proxy` to the KA investigator ClusterRole, needed by the `nodes_log` and `nodes_stats_summary` tools to reach the kubelet proxy API. Without this, those tools return `403 Forbidden`.
- Renders `integrations.tools.alertmanager` in the `kubernaut-agent-config` ConfigMap when `monitoring.enabled` is true, needed by the `get_alerts` and `get_silences` tools. Follows the exact same pattern already used for Prometheus (OCP-derived URL constant + service-CA TLS file), gated on the same `monitoring.enabled` flag. No CRD changes required.

## Test plan

- [x] RED: added failing unit tests for `nodes/proxy` RBAC rule and Alertmanager ConfigMap rendering
- [x] GREEN: implemented production code, all 584 specs in `internal/resources` pass
- [x] Full `internal/controller` envtest suite passes (generic reconcile wiring for ClusterRoles/ConfigMaps already covers these builder functions)
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` all clean

Closes #205

Made with [Cursor](https://cursor.com)